### PR TITLE
Add: Disk Usage Analysis

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -9,7 +9,9 @@ labels: enhancement
 
 ## Description
 
-Describe the feature.
+Analyze artifact size and disk usage.
+
+아티팩트 크기와 디스크 사용량을 분석.
 
 ## Expected Behavior
 
@@ -17,7 +19,7 @@ Describe how it should work.
 
 ## Additional Notes
 
-Optional.
+Optional. (Closes #)
 
 ## Checklist
 

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -18,3 +18,27 @@ Describe how it should work.
 ## Additional Notes
 
 Optional.
+
+## Checklist
+
+### Required
+
+- [ ] `cargo check` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
+- [ ] `cargo test` passes
+
+### Functional Validation
+
+- [ ] I verified the behavior locally
+- [ ] I added or updated tests when necessary
+
+### Documentation
+
+- [ ] README or docs were updated if needed
+- [ ] New configuration or behavior is documented
+
+### Safety
+
+- [ ] Cleanup behavior was reviewed for safety
+- [ ] No destructive behavior was introduced without confirmation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,16 +68,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -117,6 +161,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "dustfril-cli"
 version = "0.1.0"
 dependencies = [
@@ -128,6 +178,7 @@ dependencies = [
 name = "dustfril-core"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "tempfile",
 ]
 
@@ -154,10 +205,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -194,6 +275,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +327,18 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -254,6 +371,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +390,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prettyplease"
@@ -313,6 +445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +497,18 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strsim"
@@ -427,6 +577,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,10 +656,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/apps/dustfril-cli/src/commands/analyze.rs
+++ b/apps/dustfril-cli/src/commands/analyze.rs
@@ -79,13 +79,12 @@ pub fn execute() {
             analyzer::format_modified(artifact.last_modified)
         );
 
-        println!(
-            "  Age: {} days",
-            artifact
-                .age_days
-                .map(|d| d.to_string())
-                .unwrap_or_else(|| "Unknown".into())
-        );
+        let age_display = artifact
+            .age_days
+            .map(|d| format!("{d} days"))
+            .unwrap_or_else(|| "Unknown".to_string());
+
+        println!("  Age: {}", age_display);
 
         println!("  Recommendation: {}\n", artifact.recommendation);
     }

--- a/apps/dustfril-cli/src/commands/analyze.rs
+++ b/apps/dustfril-cli/src/commands/analyze.rs
@@ -1,3 +1,94 @@
+use std::path::Path;
+
+use dustfril_core::{analyzer, detector};
+
+use dustfril_core::models::{AnalysisResult, CleanupRecommendation};
+
+fn print_summary(analysis: &AnalysisResult) {
+    let mut keep = 0;
+    let mut review = 0;
+    let mut safe_to_clean = 0;
+    let mut review_size = 0_u64;
+    let mut safe_size = 0_u64;
+
+    for artifact in &analysis.artifacts {
+        match artifact.recommendation {
+            CleanupRecommendation::Keep => {
+                keep += 1;
+            }
+
+            CleanupRecommendation::Review => {
+                review += 1;
+                review_size += artifact.size_bytes;
+            }
+
+            CleanupRecommendation::SafeToClean => {
+                safe_to_clean += 1;
+                safe_size += artifact.size_bytes;
+            }
+        }
+    }
+
+    println!("----------------------------------------\n");
+
+    println!("DustFril Analysis Summary\n");
+
+    println!("Artifacts: {}", analysis.artifacts.len());
+
+    println!(
+        "Total Size: {}\n",
+        analyzer::format_size(analysis.total_size_bytes)
+    );
+
+    println!("Keep: {}", keep);
+    println!(
+        "Review: {}, Size: {}",
+        review,
+        analyzer::format_size(review_size)
+    );
+    println!(
+        "Safe To Clean: {}, Size: {}",
+        safe_to_clean,
+        analyzer::format_size(safe_size)
+    );
+
+    println!("\n----------------------------------------\n");
+}
+
 pub fn execute() {
-    println!("Analyze command is not implemented yet.");
+    let scan_result = detector::scan(Path::new("."));
+
+    let analysis_result = analyzer::analyze(scan_result);
+
+    if analysis_result.artifacts.is_empty() {
+        println!("No Rust artifacts found.");
+        return;
+    }
+
+    println!("Found {} artifact(s)\n", analysis_result.artifacts.len());
+
+    for artifact in &analysis_result.artifacts {
+        println!("[{}]", artifact.artifact.artifact_type);
+
+        println!("  Path: {}", artifact.artifact.path.display());
+
+        println!("  Size: {}", analyzer::format_size(artifact.size_bytes));
+
+        println!(
+            "  Modified: {}",
+            analyzer::format_modified(artifact.last_modified)
+        );
+
+        println!(
+            "  Age: {} days",
+            artifact
+                .age_days
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "Unknown".into())
+        );
+
+        println!("  Recommendation: {}\n", artifact.recommendation);
+    }
+
+    print_summary(&analysis_result);
 }

--- a/crates/dustfril-core/Cargo.toml
+++ b/crates/dustfril-core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+chrono = "0.4"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/dustfril-core/src/analyzer/age.rs
+++ b/crates/dustfril-core/src/analyzer/age.rs
@@ -1,4 +1,4 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 pub fn calculate_age_days(modified: Option<SystemTime>) -> Option<u64> {
     let modified = modified?;

--- a/crates/dustfril-core/src/analyzer/age.rs
+++ b/crates/dustfril-core/src/analyzer/age.rs
@@ -1,0 +1,11 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn calculate_age_days(modified: Option<SystemTime>) -> Option<u64> {
+    let modified = modified?;
+
+    let now = SystemTime::now();
+
+    let duration = now.duration_since(modified).ok()?;
+
+    Some(duration.as_secs() / 86_400)
+}

--- a/crates/dustfril-core/src/analyzer/analyze.rs
+++ b/crates/dustfril-core/src/analyzer/analyze.rs
@@ -1,6 +1,6 @@
 use crate::{
     analyzer::{
-        calculate_age_days, calculate_directory_size, get_latest_modified, recommend_cleanup,
+        calculate_age_days, calculate_directory_size, find_latest_modified, recommend_cleanup,
     },
     models::{AnalysisResult, ArtifactAnalysis, ScanResult},
 };
@@ -10,7 +10,7 @@ pub fn analyze(scan_result: ScanResult) -> AnalysisResult {
 
     for artifact in scan_result.artifacts {
         let size_bytes = calculate_directory_size(&artifact.path);
-        let last_modified = get_latest_modified(&artifact.path);
+        let last_modified = find_latest_modified(&artifact.path);
         let age_days = calculate_age_days(last_modified);
         let recommendation = recommend_cleanup(age_days);
 
@@ -27,7 +27,7 @@ pub fn analyze(scan_result: ScanResult) -> AnalysisResult {
 
     result
         .artifacts
-        .sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes));
+        .sort_by_key(|b| std::cmp::Reverse(b.size_bytes));
 
     result
 }

--- a/crates/dustfril-core/src/analyzer/analyze.rs
+++ b/crates/dustfril-core/src/analyzer/analyze.rs
@@ -1,0 +1,33 @@
+use crate::{
+    analyzer::{
+        calculate_age_days, calculate_directory_size, get_latest_modified, recommend_cleanup,
+    },
+    models::{AnalysisResult, ArtifactAnalysis, ScanResult},
+};
+
+pub fn analyze(scan_result: ScanResult) -> AnalysisResult {
+    let mut result = AnalysisResult::default();
+
+    for artifact in scan_result.artifacts {
+        let size_bytes = calculate_directory_size(&artifact.path);
+        let last_modified = get_latest_modified(&artifact.path);
+        let age_days = calculate_age_days(last_modified);
+        let recommendation = recommend_cleanup(age_days);
+
+        result.total_size_bytes += size_bytes;
+
+        result.artifacts.push(ArtifactAnalysis {
+            artifact,
+            size_bytes,
+            last_modified,
+            age_days,
+            recommendation,
+        });
+    }
+
+    result
+        .artifacts
+        .sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes));
+
+    result
+}

--- a/crates/dustfril-core/src/analyzer/format.rs
+++ b/crates/dustfril-core/src/analyzer/format.rs
@@ -1,0 +1,33 @@
+pub fn format_size(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = KB * 1024.0;
+    const GB: f64 = MB * 1024.0;
+    const TB: f64 = GB * 1024.0;
+
+    let bytes = bytes as f64;
+
+    if bytes >= TB {
+        format!("{:.2} TB", bytes / TB)
+    } else if bytes >= GB {
+        format!("{:.2} GB", bytes / GB)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes / KB)
+    } else {
+        format!("{:.0} B", bytes)
+    }
+}
+
+use chrono::{DateTime, Local};
+use std::time::SystemTime;
+
+pub fn format_modified(modified: Option<SystemTime>) -> String {
+    let Some(modified) = modified else {
+        return "Unknown".to_string();
+    };
+
+    let datetime: DateTime<Local> = modified.into();
+
+    datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+}

--- a/crates/dustfril-core/src/analyzer/metadata.rs
+++ b/crates/dustfril-core/src/analyzer/metadata.rs
@@ -1,0 +1,30 @@
+use std::{fs, path::Path, time::SystemTime};
+
+pub fn get_latest_modified(path: &Path) -> Option<SystemTime> {
+    let mut latest = fs::metadata(path).ok()?.modified().ok();
+
+    let Ok(entries) = fs::read_dir(path) else {
+        return latest;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+
+        let current = if path.is_dir() {
+            get_latest_modified(&path)
+        } else {
+            entry.metadata().ok().and_then(|m| m.modified().ok())
+        };
+
+        if let Some(current) = current {
+            match latest {
+                Some(existing) if current <= existing => {}
+                _ => {
+                    latest = Some(current);
+                }
+            }
+        }
+    }
+
+    latest
+}

--- a/crates/dustfril-core/src/analyzer/metadata.rs
+++ b/crates/dustfril-core/src/analyzer/metadata.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path, time::SystemTime};
 
-pub fn get_latest_modified(path: &Path) -> Option<SystemTime> {
+pub fn find_latest_modified(path: &Path) -> Option<SystemTime> {
     let mut latest = fs::metadata(path).ok()?.modified().ok();
 
     let Ok(entries) = fs::read_dir(path) else {
@@ -10,15 +10,20 @@ pub fn get_latest_modified(path: &Path) -> Option<SystemTime> {
     for entry in entries.flatten() {
         let path = entry.path();
 
-        let current = if path.is_dir() {
-            get_latest_modified(&path)
-        } else {
-            entry.metadata().ok().and_then(|m| m.modified().ok())
+        let metadata = entry.metadata().ok();
+
+        let current = match metadata {
+            Some(metadata) if metadata.is_dir() => find_latest_modified(&path),
+
+            Some(metadata) => metadata.modified().ok(),
+
+            None => None,
         };
 
         if let Some(current) = current {
             match latest {
                 Some(existing) if current <= existing => {}
+
                 _ => {
                     latest = Some(current);
                 }

--- a/crates/dustfril-core/src/analyzer/mod.rs
+++ b/crates/dustfril-core/src/analyzer/mod.rs
@@ -12,6 +12,6 @@ mod tests;
 pub use age::calculate_age_days;
 pub use analyze::analyze;
 pub use format::{format_modified, format_size};
-pub use metadata::get_latest_modified;
+pub use metadata::find_latest_modified;
 pub use recommendation::recommend_cleanup;
 pub use size::calculate_directory_size;

--- a/crates/dustfril-core/src/analyzer/mod.rs
+++ b/crates/dustfril-core/src/analyzer/mod.rs
@@ -1,1 +1,17 @@
 //! Analyzer module.
+mod age;
+mod analyze;
+mod format;
+mod metadata;
+mod recommendation;
+mod size;
+
+#[cfg(test)]
+mod tests;
+
+pub use age::calculate_age_days;
+pub use analyze::analyze;
+pub use format::{format_modified, format_size};
+pub use metadata::get_latest_modified;
+pub use recommendation::recommend_cleanup;
+pub use size::calculate_directory_size;

--- a/crates/dustfril-core/src/analyzer/recommendation.rs
+++ b/crates/dustfril-core/src/analyzer/recommendation.rs
@@ -1,0 +1,38 @@
+use crate::models::CleanupRecommendation;
+
+pub fn recommend_cleanup(age_days: Option<u64>) -> CleanupRecommendation {
+    let Some(days) = age_days else {
+        return CleanupRecommendation::Review;
+    };
+
+    match days {
+        0..=30 => CleanupRecommendation::Keep,
+
+        31..=90 => CleanupRecommendation::Review,
+
+        _ => CleanupRecommendation::SafeToClean,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keep_when_recent() {
+        assert_eq!(recommend_cleanup(Some(10)), CleanupRecommendation::Keep);
+    }
+
+    #[test]
+    fn review_when_middle_age() {
+        assert_eq!(recommend_cleanup(Some(60)), CleanupRecommendation::Review);
+    }
+
+    #[test]
+    fn safe_to_clean_when_old() {
+        assert_eq!(
+            recommend_cleanup(Some(180)),
+            CleanupRecommendation::SafeToClean
+        );
+    }
+}

--- a/crates/dustfril-core/src/analyzer/size.rs
+++ b/crates/dustfril-core/src/analyzer/size.rs
@@ -1,0 +1,23 @@
+use std::{fs, path::Path};
+
+pub fn calculate_directory_size(path: &Path) -> u64 {
+    let mut total_size = 0;
+
+    let Ok(entries) = fs::read_dir(path) else {
+        return 0;
+    };
+
+    for entry in entries.flatten() {
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+
+        if metadata.is_file() {
+            total_size += metadata.len();
+        } else if metadata.is_dir() {
+            total_size += calculate_directory_size(&entry.path());
+        }
+    }
+
+    total_size
+}

--- a/crates/dustfril-core/src/analyzer/tests.rs
+++ b/crates/dustfril-core/src/analyzer/tests.rs
@@ -1,0 +1,142 @@
+use std::fs;
+use tempfile::TempDir;
+
+use crate::analyzer::{
+    calculate_age_days, calculate_directory_size, format_size, get_latest_modified,
+    recommend_cleanup,
+};
+use crate::{
+    analyzer::analyze,
+    models::{ArtifactLocation, ArtifactType, CleanupRecommendation, ScanResult},
+};
+
+#[test]
+fn analyze_empty_scan_result() {
+    let result = analyze(ScanResult::default());
+
+    assert_eq!(result.total_size_bytes, 0);
+
+    assert!(result.artifacts.is_empty());
+}
+
+#[test]
+fn calculate_directory_size_returns_total_size() {
+    let temp_dir = TempDir::new().unwrap();
+
+    fs::write(temp_dir.path().join("a.txt"), vec![0_u8; 100]).unwrap();
+
+    fs::write(temp_dir.path().join("b.txt"), vec![0_u8; 200]).unwrap();
+
+    let size = calculate_directory_size(temp_dir.path());
+
+    assert_eq!(size, 300);
+}
+
+#[test]
+fn analyze_returns_total_size() {
+    let temp_dir = TempDir::new().unwrap();
+
+    fs::write(temp_dir.path().join("a.txt"), vec![0_u8; 100]).unwrap();
+
+    let artifact = ArtifactLocation {
+        path: temp_dir.path().to_path_buf(),
+        artifact_type: ArtifactType::Target,
+    };
+
+    let scan_result = ScanResult {
+        artifacts: vec![artifact],
+    };
+
+    let result = analyze(scan_result);
+
+    assert_eq!(result.total_size_bytes, 100);
+
+    assert_eq!(result.artifacts.len(), 1);
+}
+
+#[test]
+fn get_latest_modified_returns_some() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let modified = get_latest_modified(temp_dir.path());
+
+    assert!(modified.is_some());
+}
+
+#[test]
+fn format_size_bytes() {
+    assert_eq!(format_size(512), "512 B");
+}
+
+#[test]
+fn format_size_kilobytes() {
+    assert_eq!(format_size(2048), "2.00 KB");
+}
+
+#[test]
+fn format_size_megabytes() {
+    assert_eq!(format_size(1024 * 1024), "1.00 MB");
+}
+
+#[test]
+fn format_size_gigabytes() {
+    assert_eq!(format_size(1024 * 1024 * 1024), "1.00 GB");
+}
+
+#[test]
+fn analyze_sorts_by_size_descending() {
+    let small = TempDir::new().unwrap();
+    let large = TempDir::new().unwrap();
+
+    fs::write(small.path().join("small.bin"), vec![0_u8; 100]).unwrap();
+
+    fs::write(large.path().join("large.bin"), vec![0_u8; 200]).unwrap();
+
+    let scan_result = ScanResult {
+        artifacts: vec![
+            ArtifactLocation {
+                path: small.path().to_path_buf(),
+                artifact_type: ArtifactType::Target,
+            },
+            ArtifactLocation {
+                path: large.path().to_path_buf(),
+                artifact_type: ArtifactType::CargoRegistry,
+            },
+        ],
+    };
+
+    let result = analyze(scan_result);
+
+    assert_eq!(result.artifacts[0].size_bytes, 200);
+
+    assert_eq!(result.artifacts[1].size_bytes, 100);
+}
+
+use std::time::{Duration, SystemTime};
+
+#[test]
+fn calculate_age_days_returns_correct_days() {
+    let modified = SystemTime::now() - Duration::from_secs(10 * 86_400);
+
+    let age = calculate_age_days(Some(modified));
+
+    assert_eq!(age, Some(10),);
+}
+
+#[test]
+fn keep_when_recent() {
+    assert_eq!(recommend_cleanup(Some(10)), CleanupRecommendation::Keep);
+}
+
+#[test]
+fn review_when_middle_age() {
+    assert_eq!(recommend_cleanup(Some(60)), CleanupRecommendation::Review);
+}
+
+#[test]
+fn safe_to_clean_when_old() {
+    assert_eq!(
+        recommend_cleanup(Some(180)),
+        CleanupRecommendation::SafeToClean
+    );
+}

--- a/crates/dustfril-core/src/analyzer/tests.rs
+++ b/crates/dustfril-core/src/analyzer/tests.rs
@@ -2,12 +2,11 @@ use std::fs;
 use tempfile::TempDir;
 
 use crate::analyzer::{
-    calculate_age_days, calculate_directory_size, format_size, get_latest_modified,
-    recommend_cleanup,
+    calculate_age_days, calculate_directory_size, find_latest_modified, format_size,
 };
 use crate::{
     analyzer::analyze,
-    models::{ArtifactLocation, ArtifactType, CleanupRecommendation, ScanResult},
+    models::{ArtifactLocation, ArtifactType, ScanResult},
 };
 
 #[test]
@@ -55,10 +54,10 @@ fn analyze_returns_total_size() {
 }
 
 #[test]
-fn get_latest_modified_returns_some() {
+fn find_latest_modified_returns_some() {
     let temp_dir = TempDir::new().unwrap();
 
-    let modified = get_latest_modified(temp_dir.path());
+    let modified = find_latest_modified(temp_dir.path());
 
     assert!(modified.is_some());
 }
@@ -121,22 +120,4 @@ fn calculate_age_days_returns_correct_days() {
     let age = calculate_age_days(Some(modified));
 
     assert_eq!(age, Some(10),);
-}
-
-#[test]
-fn keep_when_recent() {
-    assert_eq!(recommend_cleanup(Some(10)), CleanupRecommendation::Keep);
-}
-
-#[test]
-fn review_when_middle_age() {
-    assert_eq!(recommend_cleanup(Some(60)), CleanupRecommendation::Review);
-}
-
-#[test]
-fn safe_to_clean_when_old() {
-    assert_eq!(
-        recommend_cleanup(Some(180)),
-        CleanupRecommendation::SafeToClean
-    );
 }

--- a/crates/dustfril-core/src/models/analysis_result.rs
+++ b/crates/dustfril-core/src/models/analysis_result.rs
@@ -1,0 +1,8 @@
+use super::ArtifactAnalysis;
+
+/// Total Analysis Results
+#[derive(Debug, Default)]
+pub struct AnalysisResult {
+    pub artifacts: Vec<ArtifactAnalysis>,
+    pub total_size_bytes: u64,
+}

--- a/crates/dustfril-core/src/models/artifact_analysis.rs
+++ b/crates/dustfril-core/src/models/artifact_analysis.rs
@@ -1,0 +1,14 @@
+use crate::models::{ArtifactLocation, CleanupRecommendation};
+use std::time::SystemTime;
+
+/// Analyzed artifact information
+#[derive(Debug)]
+pub struct ArtifactAnalysis {
+    pub artifact: ArtifactLocation,
+    pub size_bytes: u64,
+    // permission denied, broken symlink, network filesystem failed to detect
+    pub last_modified: Option<SystemTime>,
+    pub age_days: Option<u64>,
+
+    pub recommendation: CleanupRecommendation,
+}

--- a/crates/dustfril-core/src/models/cleanup_recommendation.rs
+++ b/crates/dustfril-core/src/models/cleanup_recommendation.rs
@@ -1,0 +1,26 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CleanupRecommendation {
+    Keep,
+    Review,
+    SafeToClean,
+}
+
+impl fmt::Display for CleanupRecommendation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CleanupRecommendation::Keep => {
+                write!(f, "Keep")
+            }
+
+            CleanupRecommendation::Review => {
+                write!(f, "Review")
+            }
+
+            CleanupRecommendation::SafeToClean => {
+                write!(f, "Safe To Clean")
+            }
+        }
+    }
+}

--- a/crates/dustfril-core/src/models/mod.rs
+++ b/crates/dustfril-core/src/models/mod.rs
@@ -3,6 +3,16 @@ mod artifact_location;
 mod artifact_type;
 mod scan_result;
 
+mod analysis_result;
+mod artifact_analysis;
+
+mod cleanup_recommendation;
+
 pub use artifact_location::*;
 pub use artifact_type::*;
 pub use scan_result::*;
+
+pub use analysis_result::*;
+pub use artifact_analysis::*;
+
+pub use cleanup_recommendation::*;


### PR DESCRIPTION
## Description

Analyze artifact size and disk usage and recommend files that you want to delete based on the last use date.

아티팩트 크기와 디스크 사용량을 분석하고 마지막 사용 날짜를 기준으로 삭제할 만 파일을 추천합니다.

## Expected Behavior

When using 'cargo run -p dustfril-cli--anyze', it outputs file analysis and 'Dustfril Analysis Summary'.

`cargo run -p dustfril-cli -- analyze` 사용 시 파일 분석과 'DustFril Analysis Summary'까지 출력합니다.

## Additional Notes

Closes #16
Closes #17 
Closes #18 
Closes #19 
Closes #36 
Closes #37 
Closes #38  

## Checklist

### Required

- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test` passes

### Functional Validation

- [x] I verified the behavior locally
- [x] I added or updated tests when necessary

### Documentation

- [ ] README or docs were updated if needed
- [ ] New configuration or behavior is documented

### Safety

- [ ] Cleanup behavior was reviewed for safety
- [ ] No destructive behavior was introduced without confirmation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analyze command now performs a scan→analyze→report flow with per-artifact details (type, path, size, modified time, age, recommendation), aggregated summary counts and sizes, and a clear message when no artifacts are found.

* **New Features (UX)**
  * Human-friendly size and timestamp formatting and age-based cleanup recommendations (Keep / Review / Safe To Clean).

* **Documentation**
  * Issue template updated with a structured verification checklist and artifact size/disk-usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->