### PR TITLE
Add part of Safe clean 

### DIFF
--- a/apps/dustfril-cli/src/cli.rs
+++ b/apps/dustfril-cli/src/cli.rs
@@ -1,7 +1,7 @@
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 /// DustFril CLI
-#[derive(Parser, Debug)]
+#[derive(Parser)]
 #[command(name = "dfr", version, about = "Rust artifact analyzer and cleaner")]
 pub struct Cli {
     #[command(subcommand)]
@@ -9,7 +9,7 @@ pub struct Cli {
 }
 
 /// Available commands
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand)]
 pub enum Commands {
     /// Scan Rust artifacts
     Scan,
@@ -18,5 +18,11 @@ pub enum Commands {
     Analyze,
 
     /// Clean artifacts
-    Clean,
+    Clean(CleanArgs),
+}
+
+#[derive(Args)]
+pub struct CleanArgs {
+    #[arg(long)]
+    pub dry_run: bool,
 }

--- a/apps/dustfril-cli/src/cli.rs
+++ b/apps/dustfril-cli/src/cli.rs
@@ -23,6 +23,7 @@ pub enum Commands {
 
 #[derive(Args)]
 pub struct CleanArgs {
+    // Preview cleanup operations without deleting files.
     #[arg(long)]
     pub dry_run: bool,
 }

--- a/apps/dustfril-cli/src/commands/clean.rs
+++ b/apps/dustfril-cli/src/commands/clean.rs
@@ -58,7 +58,10 @@ fn print_cleanup_plan(plan: &CleanupPlan) {
 
     println!("Total Reclaimable Space\n");
 
-    println!("  {}\n", analyzer::format_size(plan.reclaimable_size_bytes));
+    println!(
+        "  {}\n",
+        analyzer::format_size(plan.reclaimable_size_bytes())
+    );
 }
 
 fn print_cleanup_result(result: &CleanupResult) {

--- a/apps/dustfril-cli/src/commands/clean.rs
+++ b/apps/dustfril-cli/src/commands/clean.rs
@@ -1,3 +1,102 @@
+use std::path::Path;
+
+use dustfril_core::{
+    analyzer, cleaner, detector,
+    models::{CleanupPlan, CleanupResult},
+};
+
+// dry-run
+pub fn dry_run() {
+    let plan = build_cleanup_plan();
+
+    if plan.candidates.is_empty() {
+        println!("No cleanup candidates found.");
+
+        return;
+    }
+
+    print_cleanup_plan(&plan);
+
+    println!("No files were deleted.");
+}
+
+use std::io::{self, Write};
+
+fn build_cleanup_plan() -> CleanupPlan {
+    let scan_result = detector::scan(Path::new("."));
+
+    let analysis = analyzer::analyze(scan_result);
+
+    cleaner::create_cleanup_plan(analysis)
+}
+
+fn confirm_cleanup() -> bool {
+    print!("Continue? (y/N): ");
+
+    // Flush stdout to ensure the prompt is displayed before reading input
+    io::stdout().flush().expect("Failed to flush stdout");
+
+    let mut input = String::new();
+
+    io::stdin()
+        .read_line(&mut input)
+        .expect("Failed to read input");
+
+    matches!(input.trim(), "y" | "Y")
+}
+
+fn print_cleanup_plan(plan: &CleanupPlan) {
+    println!("Cleanup Preview\n");
+
+    for candidate in &plan.candidates {
+        println!("[{}]", candidate.artifact_type);
+
+        println!("  Path: {}", candidate.path.display());
+
+        println!("  Size: {}\n", analyzer::format_size(candidate.size_bytes));
+    }
+
+    println!("Total Reclaimable Space\n");
+
+    println!("  {}\n", analyzer::format_size(plan.reclaimable_size_bytes));
+}
+
+fn print_cleanup_result(result: &CleanupResult) {
+    println!("Cleanup completed.");
+
+    println!("Deleted: {}", result.deleted_paths.len());
+
+    println!("Failed: {}", result.failed_paths.len());
+
+    println!("Freed: {}", analyzer::format_size(result.freed_size_bytes,));
+
+    if !result.deleted_paths.is_empty() {
+        println!("Deleted\n");
+
+        for path in &result.deleted_paths {
+            println!("  {}", path.display());
+        }
+
+        println!();
+    }
+}
+
 pub fn execute() {
-    println!("Clean command is not implemented yet.");
+    let plan = build_cleanup_plan();
+
+    if plan.candidates.is_empty() {
+        println!("No cleanup candidates found.");
+        return;
+    }
+
+    print_cleanup_plan(&plan);
+
+    if !confirm_cleanup() {
+        println!("Cleanup cancelled.");
+        return;
+    }
+
+    let result = cleaner::execute_cleanup(&plan);
+
+    print_cleanup_result(&result);
 }

--- a/apps/dustfril-cli/src/main.rs
+++ b/apps/dustfril-cli/src/main.rs
@@ -17,8 +17,12 @@ fn main() {
             commands::analyze::execute();
         }
 
-        Commands::Clean => {
-            commands::clean::execute();
+        Commands::Clean(args) => {
+            if args.dry_run {
+                commands::clean::dry_run();
+            } else {
+                commands::clean::execute();
+            }
         }
     }
 }

--- a/crates/dustfril-core/src/cleaner/executor.rs
+++ b/crates/dustfril-core/src/cleaner/executor.rs
@@ -1,0 +1,27 @@
+use std::fs;
+
+use crate::models::{ArtifactType, CleanupPlan, CleanupResult};
+
+pub fn execute_cleanup(plan: &CleanupPlan) -> CleanupResult {
+    let mut result = CleanupResult {
+        deleted_paths: vec![],
+        failed_paths: vec![],
+        freed_size_bytes: 0,
+    };
+
+    for candidate in &plan.candidates {
+        match candidate.artifact_type {
+            ArtifactType::Target | ArtifactType::CargoRegistry | ArtifactType::CargoGit => {
+                if fs::remove_dir_all(&candidate.path).is_ok() {
+                    result.deleted_paths.push(candidate.path.clone());
+
+                    result.freed_size_bytes += candidate.size_bytes;
+                } else {
+                    result.failed_paths.push(candidate.path.clone());
+                }
+            }
+        }
+    }
+
+    result
+}

--- a/crates/dustfril-core/src/cleaner/mod.rs
+++ b/crates/dustfril-core/src/cleaner/mod.rs
@@ -1,1 +1,9 @@
 //! Cleaner module.
+mod executor;
+mod plan;
+
+#[cfg(test)]
+mod tests;
+
+pub use executor::execute_cleanup;
+pub use plan::create_cleanup_plan;

--- a/crates/dustfril-core/src/cleaner/plan.rs
+++ b/crates/dustfril-core/src/cleaner/plan.rs
@@ -5,8 +5,6 @@ pub fn create_cleanup_plan(analysis: AnalysisResult) -> CleanupPlan {
 
     for artifact in analysis.artifacts {
         if artifact.recommendation == CleanupRecommendation::SafeToClean {
-            plan.reclaimable_size_bytes += artifact.size_bytes;
-
             // Flatten the analysis into a cleanup candidate
             plan.candidates.push(CleanupCandidate {
                 path: artifact.artifact.path.clone(),

--- a/crates/dustfril-core/src/cleaner/plan.rs
+++ b/crates/dustfril-core/src/cleaner/plan.rs
@@ -1,0 +1,26 @@
+use crate::models::{AnalysisResult, CleanupCandidate, CleanupPlan, CleanupRecommendation};
+
+pub fn create_cleanup_plan(analysis: AnalysisResult) -> CleanupPlan {
+    let mut plan = CleanupPlan::default();
+
+    for artifact in analysis.artifacts {
+        if artifact.recommendation == CleanupRecommendation::SafeToClean {
+            plan.reclaimable_size_bytes += artifact.size_bytes;
+
+            // Flatten the analysis into a cleanup candidate
+            plan.candidates.push(CleanupCandidate {
+                path: artifact.artifact.path.clone(),
+
+                artifact_type: artifact.artifact.artifact_type.clone(),
+
+                size_bytes: artifact.size_bytes,
+
+                age_days: artifact.age_days,
+
+                recommendation: artifact.recommendation,
+            });
+        }
+    }
+
+    plan
+}

--- a/crates/dustfril-core/src/cleaner/tests.rs
+++ b/crates/dustfril-core/src/cleaner/tests.rs
@@ -13,7 +13,7 @@ fn create_empty_cleanup_plan() {
 
     assert!(plan.candidates.is_empty());
 
-    assert_eq!(plan.reclaimable_size_bytes, 0);
+    assert_eq!(plan.reclaimable_size_bytes(), 0);
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn safe_to_clean_becomes_candidate() {
 
     assert_eq!(plan.candidates.len(), 1,);
 
-    assert_eq!(plan.reclaimable_size_bytes, 100,);
+    assert_eq!(plan.reclaimable_size_bytes(), 100,);
 }
 
 #[test]
@@ -102,16 +102,16 @@ fn execute_cleanup_removes_target_directory() {
 
     let plan = CleanupPlan {
         candidates: vec![candidate],
-
-        reclaimable_size_bytes: 5,
     };
 
     let result = execute_cleanup(&plan);
 
+    let size_bytes = CleanupPlan::reclaimable_size_bytes(&plan);
+
     assert!(!target_dir.exists());
     assert_eq!(result.deleted_paths.len(), 1);
     assert_eq!(result.failed_paths.len(), 0);
-    assert_eq!(result.freed_size_bytes, 5);
+    assert_eq!(size_bytes, 5);
 }
 
 #[test]
@@ -129,12 +129,15 @@ fn cleanup_reports_failed_path() {
 
     let plan = CleanupPlan {
         candidates: vec![candidate],
-        reclaimable_size_bytes: 100,
     };
 
     let result = execute_cleanup(&plan);
 
     assert_eq!(result.deleted_paths.len(), 0);
+
     assert_eq!(result.failed_paths.len(), 1);
+
     assert_eq!(result.freed_size_bytes, 0);
+
+    assert_eq!(plan.reclaimable_size_bytes(), 100);
 }

--- a/crates/dustfril-core/src/cleaner/tests.rs
+++ b/crates/dustfril-core/src/cleaner/tests.rs
@@ -1,0 +1,140 @@
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+use crate::{
+    cleaner::{create_cleanup_plan, execute_cleanup},
+    models::*,
+};
+
+#[test]
+fn create_empty_cleanup_plan() {
+    let plan = create_cleanup_plan(AnalysisResult::default());
+
+    assert!(plan.candidates.is_empty());
+
+    assert_eq!(plan.reclaimable_size_bytes, 0);
+}
+
+#[test]
+fn safe_to_clean_becomes_candidate() {
+    let artifact = ArtifactAnalysis {
+        artifact: ArtifactLocation {
+            path: PathBuf::from("target"),
+
+            artifact_type: ArtifactType::Target,
+        },
+
+        size_bytes: 100,
+
+        last_modified: None,
+
+        age_days: Some(200),
+
+        recommendation: CleanupRecommendation::SafeToClean,
+    };
+
+    let analysis = AnalysisResult {
+        artifacts: vec![artifact],
+
+        total_size_bytes: 100,
+    };
+
+    let plan = create_cleanup_plan(analysis);
+
+    assert_eq!(plan.candidates.len(), 1,);
+
+    assert_eq!(plan.reclaimable_size_bytes, 100,);
+}
+
+#[test]
+fn keep_is_not_candidate() {
+    let artifact = ArtifactAnalysis {
+        artifact: ArtifactLocation {
+            path: PathBuf::from("target"),
+
+            artifact_type: ArtifactType::Target,
+        },
+
+        size_bytes: 100,
+
+        last_modified: None,
+
+        age_days: Some(5),
+
+        recommendation: CleanupRecommendation::Keep,
+    };
+
+    let analysis = AnalysisResult {
+        artifacts: vec![artifact],
+
+        total_size_bytes: 100,
+    };
+
+    let plan = create_cleanup_plan(analysis);
+
+    assert!(plan.candidates.is_empty());
+}
+
+#[test]
+fn execute_cleanup_removes_target_directory() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let target_dir = temp_dir.path().join("target");
+
+    fs::create_dir_all(&target_dir).unwrap();
+
+    fs::write(target_dir.join("test.bin"), b"hello").unwrap();
+
+    assert!(target_dir.exists());
+
+    let candidate = CleanupCandidate {
+        path: target_dir.clone(),
+
+        artifact_type: ArtifactType::Target,
+
+        size_bytes: 5,
+
+        age_days: Some(100),
+
+        recommendation: CleanupRecommendation::SafeToClean,
+    };
+
+    let plan = CleanupPlan {
+        candidates: vec![candidate],
+
+        reclaimable_size_bytes: 5,
+    };
+
+    let result = execute_cleanup(&plan);
+
+    assert!(!target_dir.exists());
+    assert_eq!(result.deleted_paths.len(), 1);
+    assert_eq!(result.failed_paths.len(), 0);
+    assert_eq!(result.freed_size_bytes, 5);
+}
+
+#[test]
+fn cleanup_reports_failed_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let missing = temp_dir.path().join("missing");
+
+    let candidate = CleanupCandidate {
+        path: missing,
+        artifact_type: ArtifactType::Target,
+        size_bytes: 100,
+        age_days: None,
+        recommendation: CleanupRecommendation::SafeToClean,
+    };
+
+    let plan = CleanupPlan {
+        candidates: vec![candidate],
+        reclaimable_size_bytes: 100,
+    };
+
+    let result = execute_cleanup(&plan);
+
+    assert_eq!(result.deleted_paths.len(), 0);
+    assert_eq!(result.failed_paths.len(), 1);
+    assert_eq!(result.freed_size_bytes, 0);
+}

--- a/crates/dustfril-core/src/models/cleanup_candidate.rs
+++ b/crates/dustfril-core/src/models/cleanup_candidate.rs
@@ -1,0 +1,16 @@
+use std::path::PathBuf;
+
+use crate::models::{ArtifactType, CleanupRecommendation};
+
+#[derive(Debug)]
+pub struct CleanupCandidate {
+    pub path: PathBuf,
+
+    pub artifact_type: ArtifactType,
+
+    pub size_bytes: u64,
+
+    pub age_days: Option<u64>,
+
+    pub recommendation: CleanupRecommendation,
+}

--- a/crates/dustfril-core/src/models/cleanup_plan.rs
+++ b/crates/dustfril-core/src/models/cleanup_plan.rs
@@ -3,6 +3,13 @@ use crate::models::CleanupCandidate;
 #[derive(Debug, Default)]
 pub struct CleanupPlan {
     pub candidates: Vec<CleanupCandidate>,
+}
 
-    pub reclaimable_size_bytes: u64,
+impl CleanupPlan {
+    pub fn reclaimable_size_bytes(&self) -> u64 {
+        self.candidates
+            .iter()
+            .map(|candidate| candidate.size_bytes)
+            .sum()
+    }
 }

--- a/crates/dustfril-core/src/models/cleanup_plan.rs
+++ b/crates/dustfril-core/src/models/cleanup_plan.rs
@@ -1,0 +1,8 @@
+use crate::models::CleanupCandidate;
+
+#[derive(Debug, Default)]
+pub struct CleanupPlan {
+    pub candidates: Vec<CleanupCandidate>,
+
+    pub reclaimable_size_bytes: u64,
+}

--- a/crates/dustfril-core/src/models/cleanup_result.rs
+++ b/crates/dustfril-core/src/models/cleanup_result.rs
@@ -1,0 +1,10 @@
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct CleanupResult {
+    pub deleted_paths: Vec<PathBuf>,
+
+    pub failed_paths: Vec<PathBuf>,
+
+    pub freed_size_bytes: u64,
+}

--- a/crates/dustfril-core/src/models/mod.rs
+++ b/crates/dustfril-core/src/models/mod.rs
@@ -1,18 +1,32 @@
 //! Shared models.
+// scan
 mod artifact_location;
 mod artifact_type;
 mod scan_result;
 
+// analysis
 mod analysis_result;
 mod artifact_analysis;
-
+// analysis - recommendation
 mod cleanup_recommendation;
 
+// cleanup
+mod cleanup_candidate;
+mod cleanup_plan;
+mod cleanup_result;
+
+// scan
 pub use artifact_location::*;
 pub use artifact_type::*;
 pub use scan_result::*;
 
+// analysis
 pub use analysis_result::*;
 pub use artifact_analysis::*;
-
+// analysis - recommendation
 pub use cleanup_recommendation::*;
+
+// cleanup
+pub use cleanup_candidate::*;
+pub use cleanup_plan::*;
+pub use cleanup_result::*;


### PR DESCRIPTION
## What

Safe cleaning and additional cleaning commands

Create cleanup plan and result
Add clean command
Add dry run support
Add confirmation prompt
Add cleanup summary and tests

Closes #22
Closes #23
Closes #24
Closes #25

## Checklist

### Required

- [x] cargo check passes
- [x] cargo fmt --check passes
- [x] cargo clippy --workspace --all-targets -- -D warnings passes
- [x] cargo test passes

### Functional Validation

- [x] I verified the behavior locally
- [x] I added or updated tests when necessary

### Documentation

- [ ] README or docs were updated if needed
- [ ] New configuration or behavior is documented

### Safety

- [x] Cleanup behavior was reviewed for safety
- [x] No destructive behavior was introduced without confirmation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented a functional clean command with cleanup preview, user confirmation prompt, and detailed result reporting (deleted/failed counts and freed size)
  * Added a --dry-run flag to preview cleanup operations without deleting files
  * Improved cleanup planning and accurate reclaimable-size reporting

* **Tests**
  * Added comprehensive end-to-end tests covering planning and execution of cleanup workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->