### PR TITLE
feat(core): handle cleanup errors

### DIFF
--- a/apps/dustfril-cli/src/commands/clean.rs
+++ b/apps/dustfril-cli/src/commands/clean.rs
@@ -127,8 +127,8 @@ fn print_cleanup_result(result: &CleanupResult) {
     if !result.failed_paths.is_empty() {
         println!("\nFailed");
 
-        for path in &result.failed_paths {
-            println!("  {}", path.display());
+        for failure in &result.failed_paths {
+            println!("  {} ({})", failure.path.display(), failure.reason);
         }
     }
 }

--- a/crates/dustfril-core/src/cleaner/executor.rs
+++ b/crates/dustfril-core/src/cleaner/executor.rs
@@ -2,33 +2,42 @@ use std::fs;
 
 use crate::{
     error::DustResult,
-    models::{CleanupPlan, CleanupResult},
+    models::{CleanupFailure, CleanupFailureReason, CleanupPlan, CleanupResult},
 };
 
 /// Deletes all paths in a cleanup plan and summarizes reclaimed space.
 pub fn execute_cleanup(plan: &CleanupPlan) -> DustResult<CleanupResult> {
-    let mut result = CleanupResult {
-        deleted_paths: Vec::new(),
-        failed_paths: Vec::new(),
-        freed_size_bytes: 0,
-    };
+    let mut result = CleanupResult::default();
 
     for candidate in &plan.candidates {
-        match if candidate.path.is_dir() {
+        let delete_result = if candidate.path.is_dir() {
             fs::remove_dir_all(&candidate.path)
         } else {
             fs::remove_file(&candidate.path)
-        } {
+        };
+
+        match delete_result {
             Ok(_) => {
                 result.deleted_paths.push(candidate.path.clone());
                 result.freed_size_bytes += candidate.size_bytes;
             }
 
-            Err(_) => {
-                result.failed_paths.push(candidate.path.clone());
+            Err(error) => {
+                result.failed_paths.push(CleanupFailure {
+                    path: candidate.path.clone(),
+                    reason: failure_reason(&error),
+                });
             }
         }
     }
 
     Ok(result)
+}
+
+fn failure_reason(error: &std::io::Error) -> CleanupFailureReason {
+    match error.kind() {
+        std::io::ErrorKind::PermissionDenied => CleanupFailureReason::PermissionDenied,
+        std::io::ErrorKind::NotFound => CleanupFailureReason::NotFound,
+        _ => CleanupFailureReason::Other(error.to_string()),
+    }
 }

--- a/crates/dustfril-core/src/models/cleanup.rs
+++ b/crates/dustfril-core/src/models/cleanup.rs
@@ -23,14 +23,37 @@ impl CleanupPlan {
 }
 
 /// Summary of an attempted cleanup operation.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CleanupResult {
     /// Paths successfully deleted.
     pub deleted_paths: Vec<PathBuf>,
     /// Paths that could not be deleted.
-    pub failed_paths: Vec<PathBuf>,
+    pub failed_paths: Vec<CleanupFailure>,
     /// Total bytes reclaimed from deleted paths.
     pub freed_size_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CleanupFailure {
+    pub path: PathBuf,
+    pub reason: CleanupFailureReason,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CleanupFailureReason {
+    PermissionDenied,
+    NotFound,
+    Other(String),
+}
+
+impl fmt::Display for CleanupFailureReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PermissionDenied => write!(f, "Permission denied"),
+            Self::NotFound => write!(f, "Not found"),
+            Self::Other(msg) => write!(f, "{msg}"),
+        }
+    }
 }
 
 /// Suggested user action for an analyzed artifact.


### PR DESCRIPTION
## What

Handle cleanup errors

## Why

Displays errors, such as when you do not have permission

Closes #27 

## Checklist

### Required

- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test` passes

### Functional Validation

- [x] I verified the behavior locally
- [ ] I added or updated tests when necessary

### Documentation

- [ ] README or docs were updated if needed
- [ ] New configuration or behavior is documented

### Safety

- [x] Cleanup behavior was reviewed for safety
- [x] No destructive behavior was introduced without confirmation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup results now show why individual items could not be removed, not just which items failed.
  * Failure messages are more readable and include common causes like permission issues or missing files.
  * Successful cleanup behavior remains unchanged, including freed space reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->