### PR TITLE
feat(cli): Record cleanup operations.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,7 +960,11 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "directories",
  "dustfril-core",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/apps/dustfril-cli/Cargo.toml
+++ b/apps/dustfril-cli/Cargo.toml
@@ -9,6 +9,11 @@ path = "src/main.rs"
 
 [dependencies]
 dustfril-core = { path = "../../crates/dustfril-core" }
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+directories = "6"
 
+[dev-dependencies]
+tempfile = "3.0"

--- a/apps/dustfril-cli/src/commands/clean.rs
+++ b/apps/dustfril-cli/src/commands/clean.rs
@@ -8,7 +8,7 @@ use dustfril_core::{
 
 use crate::{
     cli::CleanArgs,
-    format,
+    format, history,
     shared::path::{resolve_path, validate_path},
 };
 
@@ -64,6 +64,8 @@ pub fn execute(args: &CleanArgs) {
             return;
         }
     };
+    history::record(mode, &result)
+        .unwrap_or_else(|e| eprintln!("Failed to record cleanup history: {}", e));
 
     print_cleanup_result(&result);
 }

--- a/apps/dustfril-cli/src/history.rs
+++ b/apps/dustfril-cli/src/history.rs
@@ -1,0 +1,104 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use chrono::{DateTime, Utc};
+use directories::ProjectDirs;
+use dustfril_core::models::{CleanupResult, DeleteMode};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CleanupHistory {
+    pub executed_at: DateTime<Utc>,
+    pub mode: DeleteMode,
+    pub freed_size_bytes: u64,
+    pub deleted_paths: Vec<PathBuf>,
+    pub failed_paths: Vec<PathBuf>,
+}
+
+pub fn record(mode: DeleteMode, result: &CleanupResult) -> io::Result<()> {
+    let path = history_path()?;
+
+    record_to(&path, mode, result)
+}
+
+fn record_to(path: &Path, mode: DeleteMode, result: &CleanupResult) -> io::Result<()> {
+    let mut histories = load(path)?;
+
+    histories.push(CleanupHistory {
+        executed_at: Utc::now(),
+        mode,
+        freed_size_bytes: result.freed_size_bytes,
+        deleted_paths: result.deleted_paths.clone(),
+        failed_paths: result
+            .failed_paths
+            .iter()
+            .map(|failure| failure.path.clone())
+            .collect(),
+    });
+
+    save(path, &histories)
+}
+
+fn history_path() -> io::Result<PathBuf> {
+    let dirs = ProjectDirs::from("dev", "FrilLab", "DustFril")
+        .ok_or_else(|| io::Error::other("Failed to determine data directory"))?;
+
+    let data_dir = dirs.data_dir();
+
+    fs::create_dir_all(data_dir)?;
+
+    Ok(data_dir.join("history.json"))
+}
+
+fn load(path: &Path) -> io::Result<Vec<CleanupHistory>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let json = fs::read_to_string(path)?;
+
+    Ok(serde_json::from_str(&json).unwrap_or_default())
+}
+
+fn save(path: &Path, histories: &[CleanupHistory]) -> io::Result<()> {
+    let json = serde_json::to_string_pretty(histories).map_err(io::Error::other)?;
+
+    fs::write(path, json)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+    use dustfril_core::models::{CleanupFailure, CleanupFailureReason, CleanupResult, DeleteMode};
+
+    #[test]
+    fn record_appends_history() {
+        let temp = TempDir::new().unwrap();
+
+        let result = CleanupResult {
+            deleted_paths: vec!["target".into()],
+            failed_paths: vec![CleanupFailure {
+                path: "node_modules".into(),
+                reason: CleanupFailureReason::NotFound,
+            }],
+            freed_size_bytes: 1024,
+        };
+
+        let path = temp.path().join("history.json");
+
+        record_to(&path, DeleteMode::Trash, &result).unwrap();
+
+        let history = load(&path).unwrap();
+
+        assert_eq!(history.len(), 1);
+
+        assert_eq!(history[0].mode, DeleteMode::Trash);
+        assert_eq!(history[0].freed_size_bytes, 1024);
+        assert_eq!(history[0].deleted_paths.len(), 1);
+        assert_eq!(history[0].failed_paths.len(), 1);
+    }
+}

--- a/apps/dustfril-cli/src/main.rs
+++ b/apps/dustfril-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod commands;
 mod format;
+mod history;
 mod shared;
 
 use clap::Parser;

--- a/crates/dustfril-core/src/cleaner/executor.rs
+++ b/crates/dustfril-core/src/cleaner/executor.rs
@@ -70,6 +70,11 @@ fn failure_reason(error: &io::Error) -> CleanupFailureReason {
 }
 
 fn validate_candidate(candidate: &CleanupCandidate) -> Result<(), CleanupFailureReason> {
+    let metadata = fs::symlink_metadata(&candidate.path).map_err(|e| failure_reason(&e))?;
+    if metadata.file_type().is_symlink() {
+        return Err(CleanupFailureReason::SymbolicLink);
+    }
+
     if !is_safe_cleanup_candidate(candidate) {
         return Err(CleanupFailureReason::UnsafePath);
     }

--- a/crates/dustfril-core/src/models/cleanup.rs
+++ b/crates/dustfril-core/src/models/cleanup.rs
@@ -44,6 +44,7 @@ pub enum CleanupFailureReason {
     PermissionDenied,
     NotFound,
     UnsafePath,
+    SymbolicLink,
     Other(String),
 }
 
@@ -53,6 +54,7 @@ impl fmt::Display for CleanupFailureReason {
             Self::PermissionDenied => write!(f, "Permission denied"),
             Self::NotFound => write!(f, "Not found"),
             Self::UnsafePath => write!(f, "Unsafe path"),
+            Self::SymbolicLink => write!(f, "Symbolic link"),
             Self::Other(msg) => write!(f, "{msg}"),
         }
     }


### PR DESCRIPTION
## What

Prevent cleanup through symbolic links.
Record cleanup operations.

Closes #30
Closes #31

## Checklist

### Required

- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test` passes

### Functional Validation

- [x] I verified the behavior locally
- [x] I added or updated tests when necessary

### Documentation

- [ ] README or docs were updated if needed
- [ ] New configuration or behavior is documented

### Safety

- [x] Cleanup behavior was reviewed for safety
- [x] No destructive behavior was introduced without confirmation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cleanup actions are now saved to a local history file, including time, mode, freed space, and paths affected.
* **Bug Fixes**
  * Cleanup now rejects symbolic links before deletion, helping prevent unintended changes.
  * If history saving fails, the cleanup still completes and reports the issue separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->