### PR TITLE
Stabilize Tauri API contract

### DIFF
--- a/apps/dustfril-tauri/README.md
+++ b/apps/dustfril-tauri/README.md
@@ -18,6 +18,27 @@ Scanner / Analyzer / Cleaner / History
 
 All business rules remain in `dustfril-core`. The desktop layer handles presentation, navigation, and user confirmation only.
 
+## Tauri API Contract
+
+The v0.0.1 frontend/backend boundary is defined by the Rust DTOs in
+`src-tauri/src/contract.rs` and mirrored by TypeScript types in
+`src/types/workflow.ts`. Payload fields use `camelCase`; enum values are
+case-sensitive.
+
+| Command | Request | Response |
+| --- | --- | --- |
+| `default_root` | none | path string |
+| `scan` | `{ options: RunOptions }` | `ScanResponse` |
+| `analyze` | `{ options: RunOptions }` | `AnalysisResponse` |
+| `build_cleanup_plan` | `{ options: RunOptions }` | `CleanupPlanResponse` |
+| `audit` | `{ options: RunOptions }` | `LifecycleScript[]` |
+| `execute_cleanup` | `{ request: { candidates, mode } }` | `CleanupResultResponse` |
+| `load_cleanup_history` | none | `CleanupHistoryEntry[]` |
+
+Contract changes must preserve existing command names, field names, nullability,
+and enum wire values for v0.0.1. Intentional breaking changes require a versioned
+boundary and matching Rust serialization tests and TypeScript updates.
+
 ## v0.0.1 Features
 
 - Dashboard with reclaimable storage, last scan time, and cleanup summary

--- a/apps/dustfril-tauri/src-tauri/src/contract.rs
+++ b/apps/dustfril-tauri/src-tauri/src/contract.rs
@@ -1,0 +1,460 @@
+use std::path::Path;
+
+use dustfril_core::models::{
+    CleanupFailureReason, CleanupRecommendation, DeleteMode, Ecosystem, LifecycleScript,
+    PackageManager, RiskLevel, ScriptType,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct RunOptions {
+    pub(crate) root: Option<String>,
+    pub(crate) ecosystems: Vec<EcosystemDto>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ExecuteCleanupRequest {
+    pub(crate) candidates: Vec<CleanupCandidateInput>,
+    pub(crate) mode: DeleteModeDto,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct CleanupCandidateInput {
+    pub(crate) path: String,
+    pub(crate) ecosystem: EcosystemDto,
+    pub(crate) size_bytes: u64,
+    pub(crate) age_days: Option<u64>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ScanResponse {
+    pub(crate) artifacts: Vec<ArtifactDto>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ArtifactDto {
+    pub(crate) path: String,
+    pub(crate) ecosystem: EcosystemDto,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AnalysisResponse {
+    pub(crate) artifacts: Vec<ArtifactAnalysisDto>,
+    pub(crate) total_size_bytes: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ArtifactAnalysisDto {
+    pub(crate) path: String,
+    pub(crate) ecosystem: EcosystemDto,
+    pub(crate) size_bytes: u64,
+    pub(crate) last_modified_ms: Option<u64>,
+    pub(crate) age_days: Option<u64>,
+    pub(crate) recommendation: RecommendationDto,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CleanupPlanResponse {
+    pub(crate) candidates: Vec<CleanupCandidateDto>,
+    pub(crate) reclaimable_size_bytes: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CleanupCandidateDto {
+    pub(crate) path: String,
+    pub(crate) ecosystem: EcosystemDto,
+    pub(crate) size_bytes: u64,
+    pub(crate) age_days: Option<u64>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CleanupResultResponse {
+    pub(crate) deleted_paths: Vec<String>,
+    pub(crate) failed_paths: Vec<CleanupFailureDto>,
+    pub(crate) freed_size_bytes: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CleanupFailureDto {
+    pub(crate) path: String,
+    pub(crate) reason: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CleanupHistoryEntryDto {
+    pub(crate) executed_at_ms: u64,
+    pub(crate) mode: DeleteModeDto,
+    pub(crate) freed_size_bytes: u64,
+    pub(crate) deleted_paths: Vec<String>,
+    pub(crate) failed_paths: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LifecycleScriptDto {
+    pub(crate) package: String,
+    pub(crate) package_manager: PackageManagerDto,
+    pub(crate) script_type: ScriptTypeDto,
+    pub(crate) command: String,
+    pub(crate) risk_level: RiskLevelDto,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EcosystemDto {
+    Rust,
+    Node,
+    Java,
+}
+
+impl From<EcosystemDto> for Ecosystem {
+    fn from(value: EcosystemDto) -> Self {
+        match value {
+            EcosystemDto::Rust => Self::Rust,
+            EcosystemDto::Node => Self::Node,
+            EcosystemDto::Java => Self::Java,
+        }
+    }
+}
+
+impl From<Ecosystem> for EcosystemDto {
+    fn from(value: Ecosystem) -> Self {
+        match value {
+            Ecosystem::Rust => Self::Rust,
+            Ecosystem::Node => Self::Node,
+            Ecosystem::Java => Self::Java,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeleteModeDto {
+    Trash,
+    Permanent,
+}
+
+impl From<DeleteModeDto> for DeleteMode {
+    fn from(value: DeleteModeDto) -> Self {
+        match value {
+            DeleteModeDto::Trash => Self::Trash,
+            DeleteModeDto::Permanent => Self::Permanent,
+        }
+    }
+}
+
+impl From<DeleteMode> for DeleteModeDto {
+    fn from(value: DeleteMode) -> Self {
+        match value {
+            DeleteMode::Trash => Self::Trash,
+            DeleteMode::Permanent => Self::Permanent,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecommendationDto {
+    Keep,
+    NeedsReview,
+    SafeToClean,
+}
+
+impl From<CleanupRecommendation> for RecommendationDto {
+    fn from(value: CleanupRecommendation) -> Self {
+        match value {
+            CleanupRecommendation::Keep => Self::Keep,
+            CleanupRecommendation::NeedsReview => Self::NeedsReview,
+            CleanupRecommendation::SafeToClean => Self::SafeToClean,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RiskLevelDto {
+    None,
+    Low,
+    Medium,
+    High,
+}
+
+impl From<RiskLevel> for RiskLevelDto {
+    fn from(value: RiskLevel) -> Self {
+        match value {
+            RiskLevel::None => Self::None,
+            RiskLevel::Low => Self::Low,
+            RiskLevel::Medium => Self::Medium,
+            RiskLevel::High => Self::High,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum PackageManagerDto {
+    Npm,
+    Pnpm,
+    Yarn,
+    Bun,
+    Unknown,
+}
+
+impl From<PackageManager> for PackageManagerDto {
+    fn from(value: PackageManager) -> Self {
+        match value {
+            PackageManager::Npm => Self::Npm,
+            PackageManager::Pnpm => Self::Pnpm,
+            PackageManager::Yarn => Self::Yarn,
+            PackageManager::Bun => Self::Bun,
+            PackageManager::Unknown => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ScriptTypeDto {
+    Preinstall,
+    Install,
+    Postinstall,
+    Prepare,
+    Prepublish,
+    PrepublishOnly,
+}
+
+impl From<ScriptType> for ScriptTypeDto {
+    fn from(value: ScriptType) -> Self {
+        match value {
+            ScriptType::Preinstall => Self::Preinstall,
+            ScriptType::Install => Self::Install,
+            ScriptType::Postinstall => Self::Postinstall,
+            ScriptType::Prepare => Self::Prepare,
+            ScriptType::Prepublish => Self::Prepublish,
+            ScriptType::PrepublishOnly => Self::PrepublishOnly,
+        }
+    }
+}
+
+pub(crate) fn artifact_path(path: &Path) -> String {
+    path.display().to_string()
+}
+
+pub(crate) fn cleanup_failure_reason(reason: &CleanupFailureReason) -> String {
+    match reason {
+        CleanupFailureReason::PermissionDenied => "PermissionDenied".to_string(),
+        CleanupFailureReason::NotFound => "NotFound".to_string(),
+        CleanupFailureReason::UnsafePath => "UnsafePath".to_string(),
+        CleanupFailureReason::SymbolicLink => "SymbolicLink".to_string(),
+        CleanupFailureReason::Other(message) => message.clone(),
+    }
+}
+
+impl From<LifecycleScript> for LifecycleScriptDto {
+    fn from(script: LifecycleScript) -> Self {
+        Self {
+            package: script.package,
+            package_manager: script.package_manager.into(),
+            script_type: script.script_type.into(),
+            command: script.command,
+            risk_level: script.risk_level.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn run_options_wire_format_is_stable() {
+        let options: RunOptions = serde_json::from_value(json!({
+            "root": "/workspace",
+            "ecosystems": ["Rust", "Node", "Java"]
+        }))
+        .unwrap();
+
+        assert_eq!(options.root.as_deref(), Some("/workspace"));
+        assert_eq!(
+            options.ecosystems,
+            vec![EcosystemDto::Rust, EcosystemDto::Node, EcosystemDto::Java]
+        );
+    }
+
+    #[test]
+    fn cleanup_request_wire_format_is_stable() {
+        let request: ExecuteCleanupRequest = serde_json::from_value(json!({
+            "candidates": [{
+                "path": "/workspace/target",
+                "ecosystem": "Rust",
+                "sizeBytes": 42,
+                "ageDays": null
+            }],
+            "mode": "Trash"
+        }))
+        .unwrap();
+
+        assert_eq!(request.mode, DeleteModeDto::Trash);
+        assert_eq!(request.candidates[0].size_bytes, 42);
+        assert_eq!(request.candidates[0].age_days, None);
+    }
+
+    #[test]
+    fn analysis_response_wire_format_is_stable() {
+        let response = AnalysisResponse {
+            artifacts: vec![ArtifactAnalysisDto {
+                path: "/workspace/target".to_string(),
+                ecosystem: EcosystemDto::Rust,
+                size_bytes: 42,
+                last_modified_ms: None,
+                age_days: Some(120),
+                recommendation: RecommendationDto::SafeToClean,
+            }],
+            total_size_bytes: 42,
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            json!({
+                "artifacts": [{
+                    "path": "/workspace/target",
+                    "ecosystem": "Rust",
+                    "sizeBytes": 42,
+                    "lastModifiedMs": null,
+                    "ageDays": 120,
+                    "recommendation": "SafeToClean"
+                }],
+                "totalSizeBytes": 42
+            })
+        );
+    }
+
+    #[test]
+    fn lifecycle_script_wire_values_are_stable() {
+        let response = LifecycleScriptDto {
+            package: "demo".to_string(),
+            package_manager: PackageManagerDto::Pnpm,
+            script_type: ScriptTypeDto::PrepublishOnly,
+            command: "node publish.js".to_string(),
+            risk_level: RiskLevelDto::High,
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            json!({
+                "package": "demo",
+                "packageManager": "pnpm",
+                "scriptType": "prepublishOnly",
+                "command": "node publish.js",
+                "riskLevel": "High"
+            })
+        );
+    }
+
+    #[test]
+    fn cleanup_response_wire_formats_are_stable() {
+        let plan = CleanupPlanResponse {
+            candidates: vec![CleanupCandidateDto {
+                path: "/workspace/target".to_string(),
+                ecosystem: EcosystemDto::Rust,
+                size_bytes: 42,
+                age_days: None,
+            }],
+            reclaimable_size_bytes: 42,
+        };
+        let result = CleanupResultResponse {
+            deleted_paths: vec!["/workspace/target".to_string()],
+            failed_paths: vec![CleanupFailureDto {
+                path: "/workspace/node_modules".to_string(),
+                reason: "PermissionDenied".to_string(),
+            }],
+            freed_size_bytes: 42,
+        };
+
+        assert_eq!(
+            serde_json::to_value(plan).unwrap(),
+            json!({
+                "candidates": [{
+                    "path": "/workspace/target",
+                    "ecosystem": "Rust",
+                    "sizeBytes": 42,
+                    "ageDays": null
+                }],
+                "reclaimableSizeBytes": 42
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(result).unwrap(),
+            json!({
+                "deletedPaths": ["/workspace/target"],
+                "failedPaths": [{
+                    "path": "/workspace/node_modules",
+                    "reason": "PermissionDenied"
+                }],
+                "freedSizeBytes": 42
+            })
+        );
+    }
+
+    #[test]
+    fn scan_and_history_wire_formats_are_stable() {
+        let scan = ScanResponse {
+            artifacts: vec![ArtifactDto {
+                path: "/workspace/node_modules".to_string(),
+                ecosystem: EcosystemDto::Node,
+            }],
+        };
+        let history = CleanupHistoryEntryDto {
+            executed_at_ms: 1_750_000_000_000,
+            mode: DeleteModeDto::Trash,
+            freed_size_bytes: 42,
+            deleted_paths: vec!["/workspace/target".to_string()],
+            failed_paths: Vec::new(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(scan).unwrap(),
+            json!({
+                "artifacts": [{
+                    "path": "/workspace/node_modules",
+                    "ecosystem": "Node"
+                }]
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(history).unwrap(),
+            json!({
+                "executedAtMs": 1_750_000_000_000_u64,
+                "mode": "Trash",
+                "freedSizeBytes": 42,
+                "deletedPaths": ["/workspace/target"],
+                "failedPaths": []
+            })
+        );
+    }
+
+    #[test]
+    fn request_rejects_unknown_fields_and_enum_values() {
+        assert!(serde_json::from_value::<RunOptions>(json!({
+            "root": null,
+            "ecosystems": ["Python"]
+        }))
+        .is_err());
+        assert!(serde_json::from_value::<RunOptions>(json!({
+            "root": null,
+            "ecosystems": [],
+            "global": true
+        }))
+        .is_err());
+    }
+}

--- a/apps/dustfril-tauri/src-tauri/src/history.rs
+++ b/apps/dustfril-tauri/src-tauri/src/history.rs
@@ -3,21 +3,13 @@ use dustfril_core::{
     models::{CleanupResult, DeleteMode},
 };
 
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CleanupHistoryEntryDto {
-    pub executed_at_ms: u64,
-    pub mode: String,
-    pub freed_size_bytes: u64,
-    pub deleted_paths: Vec<String>,
-    pub failed_paths: Vec<String>,
-}
+use crate::contract::CleanupHistoryEntryDto;
 
 pub fn record(mode: DeleteMode, result: &CleanupResult) -> Result<(), String> {
     api::history::record(mode, result).map_err(|error| error.to_string())
 }
 
-pub fn load_entries() -> Result<Vec<CleanupHistoryEntryDto>, String> {
+pub(crate) fn load_entries() -> Result<Vec<CleanupHistoryEntryDto>, String> {
     api::history::load_all()
         .map_err(|error| error.to_string())?
         .into_iter()
@@ -37,7 +29,7 @@ fn history_entry_to_dto(
 
     Ok(CleanupHistoryEntryDto {
         executed_at_ms,
-        mode: delete_mode_to_string(entry.mode),
+        mode: entry.mode.into(),
         freed_size_bytes: entry.freed_size_bytes,
         deleted_paths: entry
             .deleted_paths
@@ -50,11 +42,4 @@ fn history_entry_to_dto(
             .map(|path| path.display().to_string())
             .collect(),
     })
-}
-
-fn delete_mode_to_string(mode: DeleteMode) -> String {
-    match mode {
-        DeleteMode::Trash => "Trash".to_string(),
-        DeleteMode::Permanent => "Permanent".to_string(),
-    }
 }

--- a/apps/dustfril-tauri/src-tauri/src/lib.rs
+++ b/apps/dustfril-tauri/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod contract;
 mod history;
 
 use std::{
@@ -6,109 +7,15 @@ use std::{
     time::UNIX_EPOCH,
 };
 
+use contract::{
+    artifact_path, cleanup_failure_reason, AnalysisResponse, ArtifactAnalysisDto, ArtifactDto,
+    CleanupCandidateDto, CleanupFailureDto, CleanupHistoryEntryDto, CleanupPlanResponse,
+    CleanupResultResponse, ExecuteCleanupRequest, LifecycleScriptDto, RunOptions, ScanResponse,
+};
 use dustfril_core::{
     api,
-    models::{
-        CleanupCandidate, CleanupFailureReason, CleanupPlan, DeleteMode, Ecosystem,
-        LifecycleScript, RiskLevel, ScriptType,
-    },
+    models::{CleanupCandidate, CleanupPlan},
 };
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RunOptions {
-    root: Option<String>,
-    ecosystems: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ExecuteCleanupRequest {
-    candidates: Vec<CleanupCandidateInput>,
-    mode: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct CleanupCandidateInput {
-    path: String,
-    ecosystem: String,
-    size_bytes: u64,
-    age_days: Option<u64>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ScanResponse {
-    artifacts: Vec<ArtifactDto>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ArtifactDto {
-    path: String,
-    ecosystem: String,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct AnalysisResponse {
-    artifacts: Vec<ArtifactAnalysisDto>,
-    total_size_bytes: u64,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ArtifactAnalysisDto {
-    path: String,
-    ecosystem: String,
-    size_bytes: u64,
-    last_modified_ms: Option<u64>,
-    age_days: Option<u64>,
-    recommendation: String,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct CleanupPlanResponse {
-    candidates: Vec<CleanupCandidateDto>,
-    reclaimable_size_bytes: u64,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct CleanupCandidateDto {
-    path: String,
-    ecosystem: String,
-    size_bytes: u64,
-    age_days: Option<u64>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct CleanupResultResponse {
-    deleted_paths: Vec<String>,
-    failed_paths: Vec<CleanupFailureDto>,
-    freed_size_bytes: u64,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct CleanupFailureDto {
-    path: String,
-    reason: String,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct LifecycleScriptDto {
-    package: String,
-    package_manager: String,
-    script_type: String,
-    command: String,
-    risk_level: String,
-}
 
 fn resolve_root(root: Option<String>) -> Result<PathBuf, String> {
     match root.map(|value| value.trim().to_string()) {
@@ -135,53 +42,11 @@ fn default_root_path() -> Result<PathBuf, String> {
     Ok(discover_workspace_root(&current_dir).unwrap_or(current_dir))
 }
 
-fn parse_ecosystems(values: &[String]) -> Result<Vec<Ecosystem>, String> {
-    values
-        .iter()
-        .map(|value| match value.as_str() {
-            "Rust" => Ok(Ecosystem::Rust),
-            "Node" => Ok(Ecosystem::Node),
-            "Java" => Ok(Ecosystem::Java),
-            _ => Err(format!("Unsupported ecosystem: {value}")),
-        })
-        .collect()
-}
-
-fn parse_delete_mode(value: &str) -> Result<DeleteMode, String> {
-    match value {
-        "Trash" => Ok(DeleteMode::Trash),
-        "Permanent" => Ok(DeleteMode::Permanent),
-        _ => Err(format!("Unsupported delete mode: {value}")),
-    }
-}
-
 fn system_time_to_ms(value: std::time::SystemTime) -> Option<u64> {
     value
         .duration_since(UNIX_EPOCH)
         .ok()
         .and_then(|duration| u64::try_from(duration.as_millis()).ok())
-}
-
-fn cleanup_failure_reason_to_string(reason: &CleanupFailureReason) -> String {
-    match reason {
-        CleanupFailureReason::PermissionDenied => "PermissionDenied".to_string(),
-        CleanupFailureReason::NotFound => "NotFound".to_string(),
-        CleanupFailureReason::UnsafePath => "UnsafePath".to_string(),
-        CleanupFailureReason::SymbolicLink => "SymbolicLink".to_string(),
-        CleanupFailureReason::Other(message) => message.clone(),
-    }
-}
-
-fn script_type_to_string(script_type: ScriptType) -> String {
-    script_type.to_string()
-}
-
-fn risk_level_to_string(risk_level: RiskLevel) -> String {
-    risk_level.to_string()
-}
-
-fn artifact_path(path: &Path) -> String {
-    path.display().to_string()
 }
 
 #[tauri::command]
@@ -192,7 +57,11 @@ fn default_root() -> Result<String, String> {
 #[tauri::command]
 fn scan(options: RunOptions) -> Result<ScanResponse, String> {
     let root = resolve_root(options.root)?;
-    let ecosystems = parse_ecosystems(&options.ecosystems)?;
+    let ecosystems = options
+        .ecosystems
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<_>>();
     let result = api::scan(&root, &ecosystems).map_err(|error| error.to_string())?;
 
     Ok(ScanResponse {
@@ -201,7 +70,7 @@ fn scan(options: RunOptions) -> Result<ScanResponse, String> {
             .into_iter()
             .map(|artifact| ArtifactDto {
                 path: artifact_path(&artifact.path),
-                ecosystem: artifact.ecosystem.to_string(),
+                ecosystem: artifact.ecosystem.into(),
             })
             .collect(),
     })
@@ -210,7 +79,11 @@ fn scan(options: RunOptions) -> Result<ScanResponse, String> {
 #[tauri::command]
 fn analyze(options: RunOptions) -> Result<AnalysisResponse, String> {
     let root = resolve_root(options.root)?;
-    let ecosystems = parse_ecosystems(&options.ecosystems)?;
+    let ecosystems = options
+        .ecosystems
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<_>>();
     let scan_result = api::scan(&root, &ecosystems).map_err(|error| error.to_string())?;
     let analysis = api::analyze(scan_result).map_err(|error| error.to_string())?;
 
@@ -221,11 +94,11 @@ fn analyze(options: RunOptions) -> Result<AnalysisResponse, String> {
             .into_iter()
             .map(|artifact| ArtifactAnalysisDto {
                 path: artifact_path(&artifact.artifact.path),
-                ecosystem: artifact.artifact.ecosystem.to_string(),
+                ecosystem: artifact.artifact.ecosystem.into(),
                 size_bytes: artifact.size_bytes,
                 last_modified_ms: artifact.last_modified.and_then(system_time_to_ms),
                 age_days: artifact.age_days,
-                recommendation: artifact.recommendation.to_string(),
+                recommendation: artifact.recommendation.into(),
             })
             .collect(),
     })
@@ -234,7 +107,11 @@ fn analyze(options: RunOptions) -> Result<AnalysisResponse, String> {
 #[tauri::command]
 fn build_cleanup_plan(options: RunOptions) -> Result<CleanupPlanResponse, String> {
     let root = resolve_root(options.root)?;
-    let ecosystems = parse_ecosystems(&options.ecosystems)?;
+    let ecosystems = options
+        .ecosystems
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<_>>();
     let scan_result = api::scan(&root, &ecosystems).map_err(|error| error.to_string())?;
     let plan = api::clean::build_plan(scan_result).map_err(|error| error.to_string())?;
 
@@ -245,7 +122,7 @@ fn build_cleanup_plan(options: RunOptions) -> Result<CleanupPlanResponse, String
             .into_iter()
             .map(|candidate| CleanupCandidateDto {
                 path: artifact_path(&candidate.path),
-                ecosystem: candidate.ecosystem.to_string(),
+                ecosystem: candidate.ecosystem.into(),
                 size_bytes: candidate.size_bytes,
                 age_days: candidate.age_days,
             })
@@ -255,22 +132,17 @@ fn build_cleanup_plan(options: RunOptions) -> Result<CleanupPlanResponse, String
 
 #[tauri::command]
 fn execute_cleanup(request: ExecuteCleanupRequest) -> Result<CleanupResultResponse, String> {
-    let mode = parse_delete_mode(&request.mode)?;
+    let mode = request.mode.into();
     let candidates = request
         .candidates
         .into_iter()
-        .map(|candidate| {
-            Ok(CleanupCandidate {
-                path: PathBuf::from(candidate.path),
-                ecosystem: parse_ecosystems(&[candidate.ecosystem])?
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| "Missing ecosystem".to_string())?,
-                size_bytes: candidate.size_bytes,
-                age_days: candidate.age_days,
-            })
+        .map(|candidate| CleanupCandidate {
+            path: PathBuf::from(candidate.path),
+            ecosystem: candidate.ecosystem.into(),
+            size_bytes: candidate.size_bytes,
+            age_days: candidate.age_days,
         })
-        .collect::<Result<Vec<_>, String>>()?;
+        .collect::<Vec<_>>();
     let plan = CleanupPlan { candidates };
     let result = api::clean::execute(&plan, mode).map_err(|error| error.to_string())?;
     history::record(mode, &result).map_err(|error| error.to_string())?;
@@ -286,7 +158,7 @@ fn execute_cleanup(request: ExecuteCleanupRequest) -> Result<CleanupResultRespon
             .into_iter()
             .map(|failure| CleanupFailureDto {
                 path: artifact_path(&failure.path),
-                reason: cleanup_failure_reason_to_string(&failure.reason),
+                reason: cleanup_failure_reason(&failure.reason),
             })
             .collect(),
         freed_size_bytes: result.freed_size_bytes,
@@ -294,27 +166,21 @@ fn execute_cleanup(request: ExecuteCleanupRequest) -> Result<CleanupResultRespon
 }
 
 #[tauri::command]
-fn load_cleanup_history() -> Result<Vec<history::CleanupHistoryEntryDto>, String> {
+fn load_cleanup_history() -> Result<Vec<CleanupHistoryEntryDto>, String> {
     history::load_entries().map_err(|error| error.to_string())
 }
 
 #[tauri::command]
 fn audit(options: RunOptions) -> Result<Vec<LifecycleScriptDto>, String> {
     let root = resolve_root(options.root)?;
-    let ecosystems = parse_ecosystems(&options.ecosystems)?;
+    let ecosystems = options
+        .ecosystems
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<_>>();
     let result = api::audit(&root, &ecosystems).map_err(|error| error.to_string())?;
 
-    Ok(result.into_iter().map(lifecycle_script_to_dto).collect())
-}
-
-fn lifecycle_script_to_dto(script: LifecycleScript) -> LifecycleScriptDto {
-    LifecycleScriptDto {
-        package: script.package,
-        package_manager: script.package_manager.to_string(),
-        script_type: script_type_to_string(script.script_type),
-        command: script.command,
-        risk_level: risk_level_to_string(script.risk_level),
-    }
+    Ok(result.into_iter().map(Into::into).collect())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/apps/dustfril-tauri/src/lib/tauri.ts
+++ b/apps/dustfril-tauri/src/lib/tauri.ts
@@ -11,32 +11,42 @@ import type {
   ScanResponse,
 } from '../types/workflow';
 
+const commands = {
+  defaultRoot: 'default_root',
+  scan: 'scan',
+  analyze: 'analyze',
+  buildCleanupPlan: 'build_cleanup_plan',
+  audit: 'audit',
+  executeCleanup: 'execute_cleanup',
+  loadCleanupHistory: 'load_cleanup_history',
+} as const;
+
 export function defaultRoot() {
-  return invoke<string>('default_root');
+  return invoke<string>(commands.defaultRoot);
 }
 
 export function scanArtifacts(options: RunOptions) {
-  return invoke<ScanResponse>('scan', { options });
+  return invoke<ScanResponse>(commands.scan, { options });
 }
 
 export function analyzeArtifacts(options: RunOptions) {
-  return invoke<AnalysisResponse>('analyze', { options });
+  return invoke<AnalysisResponse>(commands.analyze, { options });
 }
 
 export function buildCleanupPlan(options: RunOptions) {
-  return invoke<CleanupPlanResponse>('build_cleanup_plan', { options });
+  return invoke<CleanupPlanResponse>(commands.buildCleanupPlan, { options });
 }
 
 export function auditScripts(options: RunOptions) {
-  return invoke<LifecycleScript[]>('audit', { options });
+  return invoke<LifecycleScript[]>(commands.audit, { options });
 }
 
 export function executeCleanup(candidates: CleanupCandidate[], mode: DeleteMode) {
-  return invoke<CleanupResultResponse>('execute_cleanup', {
+  return invoke<CleanupResultResponse>(commands.executeCleanup, {
     request: { candidates, mode },
   });
 }
 
 export function loadCleanupHistory() {
-  return invoke<CleanupHistoryEntry[]>('load_cleanup_history');
+  return invoke<CleanupHistoryEntry[]>(commands.loadCleanupHistory);
 }

--- a/apps/dustfril-tauri/src/types/workflow.ts
+++ b/apps/dustfril-tauri/src/types/workflow.ts
@@ -2,6 +2,14 @@ export type Ecosystem = 'Rust' | 'Node' | 'Java';
 export type Recommendation = 'Keep' | 'NeedsReview' | 'SafeToClean';
 export type DeleteMode = 'Trash' | 'Permanent';
 export type RiskLevel = 'Low' | 'Medium' | 'High' | 'None';
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'unknown';
+export type ScriptType =
+  | 'preinstall'
+  | 'install'
+  | 'postinstall'
+  | 'prepare'
+  | 'prepublish'
+  | 'prepublishOnly';
 
 export type Artifact = {
   path: string;
@@ -51,8 +59,8 @@ export type CleanupResultResponse = {
 
 export type LifecycleScript = {
   package: string;
-  packageManager: string;
-  scriptType: string;
+  packageManager: PackageManager;
+  scriptType: ScriptType;
   command: string;
   riskLevel: RiskLevel;
 };


### PR DESCRIPTION
## Summary

- extract the Tauri request and response DTOs into an explicit contract module
- replace stringly typed boundary enums with compiler-checked wire mappings while preserving existing payload values
- centralize frontend command names and tighten matching TypeScript types
- document the v0.0.1 contract and add exact serialization regression tests

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (72 passed)
- `npm run build`
- `git diff --check`

Closes #81