### PR TITLE
feat: add suspicious lifecycle command rule engine

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -18,6 +18,7 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 - 실제 삭제 전 정리 계획 미리 보기
 - 휴지통 이동 또는 영구 삭제 모드로 정리 실행
 - `preinstall`, `postinstall` 같은 Node 라이프사이클 스크립트 점검
+- 규칙 기반 보안 경고로 의심스러운 라이프사이클 명령 탐지
 - CLI 정리 이력을 운영체제 앱 데이터 디렉터리에 저장
 
 ## 현재 탐지 대상
@@ -45,6 +46,7 @@ cargo run -p dustfril-cli -- clean --dry-run
 cargo run -p dustfril-cli -- clean
 cargo run -p dustfril-cli -- clean --permanent
 cargo run -p dustfril-cli -- audit --node
+cargo run -p dustfril-cli -- security scan --node
 ```
 
 생태계 필터나 대상 경로를 함께 지정할 수 있습니다.
@@ -60,6 +62,11 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 - `analyze [path] [--rust] [--node] [--java]`
 - `clean [path] [--dry-run] [--permanent] [--rust] [--node] [--java]`
 - `audit [path] [--node]`
+- `security scan [path] [--node]`
+
+`security scan`은 Node 라이프사이클 스크립트를 정적으로 검사합니다. 원격
+스크립트 실행, PowerShell 실행, 권한 변경, 다운로드 후 실행 체인을 경고하며
+탐지된 명령을 실행하거나 프로젝트 파일을 변경하지 않습니다.
 
 ## 데스크톱 앱
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Build a cleanup plan before deleting anything
 - Clean artifacts with Trash or permanent deletion mode
 - Audit Node lifecycle scripts such as `preinstall` and `postinstall`
+- Detect suspicious lifecycle commands with rule-based security warnings
 - Persist CLI cleanup history to the OS app data directory
 
 ## Detected Artifacts
@@ -45,6 +46,7 @@ cargo run -p dustfril-cli -- clean --dry-run
 cargo run -p dustfril-cli -- clean
 cargo run -p dustfril-cli -- clean --permanent
 cargo run -p dustfril-cli -- audit --node
+cargo run -p dustfril-cli -- security scan --node
 ```
 
 Filter by ecosystem or pass a target path:
@@ -60,6 +62,11 @@ Available commands:
 - `analyze [path] [--rust] [--node] [--java]`
 - `clean [path] [--dry-run] [--permanent] [--rust] [--node] [--java]`
 - `audit [path] [--node]`
+- `security scan [path] [--node]`
+
+`security scan` statically checks Node lifecycle scripts for suspicious remote
+script execution, PowerShell execution, permission changes, and download-then-
+execute chains. It never runs the detected commands or modifies project files.
 
 ## Desktop App
 

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -10,6 +10,7 @@ This package exposes the `dfr` binary and wraps the shared logic from `dustfril-
 - `analyze`: report artifact size, age, and cleanup recommendation
 - `clean`: preview or execute cleanup
 - `audit`: inspect Node lifecycle scripts
+- `security scan`: detect suspicious Node lifecycle commands
 
 ## Run
 
@@ -20,6 +21,7 @@ cargo run -p dustfril-cli -- scan
 cargo run -p dustfril-cli -- analyze
 cargo run -p dustfril-cli -- clean --dry-run
 cargo run -p dustfril-cli -- audit --node
+cargo run -p dustfril-cli -- security scan --node
 ```
 
 Direct package build:

--- a/apps/dustfril-cli/src/cli.rs
+++ b/apps/dustfril-cli/src/cli.rs
@@ -29,6 +29,21 @@ pub enum Commands {
 
     /// Audit lifecycle scripts
     Audit(PathArgs),
+
+    /// Scan lifecycle scripts for suspicious commands
+    Security(SecurityArgs),
+}
+
+#[derive(Args)]
+pub struct SecurityArgs {
+    #[command(subcommand)]
+    pub command: SecurityCommands,
+}
+
+#[derive(Subcommand)]
+pub enum SecurityCommands {
+    /// Scan Node lifecycle scripts for suspicious commands
+    Scan(PathArgs),
 }
 
 #[derive(Args)]
@@ -133,5 +148,17 @@ mod tests {
         };
 
         assert_eq!(args.ecosystems(), vec![Ecosystem::Node, Ecosystem::Java]);
+    }
+
+    #[test]
+    fn cli_parses_security_scan_command() {
+        let cli = Cli::try_parse_from(["dfr", "security", "scan", "--node"]).unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Commands::Security(SecurityArgs {
+                command: SecurityCommands::Scan(PathArgs { node: true, .. })
+            })
+        ));
     }
 }

--- a/apps/dustfril-cli/src/commands/mod.rs
+++ b/apps/dustfril-cli/src/commands/mod.rs
@@ -2,3 +2,4 @@ pub mod analyze;
 pub mod audit;
 pub mod clean;
 pub mod scan;
+pub mod security;

--- a/apps/dustfril-cli/src/commands/security.rs
+++ b/apps/dustfril-cli/src/commands/security.rs
@@ -1,0 +1,33 @@
+use dustfril_core::api;
+
+use crate::{
+    cli::PathArgs,
+    format,
+    shared::path::{resolve_path, validate_path},
+};
+
+pub fn scan(args: &PathArgs) {
+    let path = resolve_path(&args.path);
+
+    if !validate_path(&path) {
+        eprintln!("Invalid path");
+        return;
+    }
+
+    let ecosystems = args.ecosystems();
+
+    let warnings = match api::security_scan(&path, &ecosystems) {
+        Ok(warnings) => warnings,
+        Err(error) => {
+            eprintln!("Security scan failed: {error}");
+            return;
+        }
+    };
+
+    if warnings.is_empty() {
+        println!("No suspicious lifecycle scripts detected.");
+        return;
+    }
+
+    format::print_security_report(&warnings);
+}

--- a/apps/dustfril-cli/src/format/mod.rs
+++ b/apps/dustfril-cli/src/format/mod.rs
@@ -1,7 +1,9 @@
 pub mod audit_format;
+pub mod security_format;
 pub mod size_format;
 pub mod time_format;
 
 pub use audit_format::*;
+pub use security_format::*;
 pub use size_format::*;
 pub use time_format::*;

--- a/apps/dustfril-cli/src/format/security_format.rs
+++ b/apps/dustfril-cli/src/format/security_format.rs
@@ -1,0 +1,17 @@
+use dustfril_core::models::SecurityWarning;
+
+pub fn print_security_report(warnings: &[SecurityWarning]) {
+    println!("Suspicious lifecycle scripts detected\n");
+    println!("Found {} warning(s)\n", warnings.len());
+
+    for warning in warnings {
+        println!("----------------------------------------");
+        println!("Package:      {}", warning.package);
+        println!("Script Type:  {}", warning.script_type);
+        println!("Risk Level:   {}", warning.risk_level);
+        println!("Command:      {}", warning.command);
+        println!("Reason:       {}", warning.reason);
+    }
+
+    println!("\n----------------------------------------");
+}

--- a/apps/dustfril-cli/src/main.rs
+++ b/apps/dustfril-cli/src/main.rs
@@ -31,5 +31,11 @@ fn main() {
         Commands::Audit(args) => {
             commands::audit::execute(&args);
         }
+
+        Commands::Security(args) => match args.command {
+            cli::SecurityCommands::Scan(args) => {
+                commands::security::scan(&args);
+            }
+        },
     }
 }

--- a/apps/dustfril-tauri/src-tauri/src/contract.rs
+++ b/apps/dustfril-tauri/src-tauri/src/contract.rs
@@ -185,6 +185,7 @@ pub(crate) enum RiskLevelDto {
     Low,
     Medium,
     High,
+    Critical,
 }
 
 impl From<RiskLevel> for RiskLevelDto {
@@ -194,6 +195,7 @@ impl From<RiskLevel> for RiskLevelDto {
             RiskLevel::Low => Self::Low,
             RiskLevel::Medium => Self::Medium,
             RiskLevel::High => Self::High,
+            RiskLevel::Critical => Self::Critical,
         }
     }
 }
@@ -357,6 +359,28 @@ mod tests {
                 "scriptType": "prepublishOnly",
                 "command": "node publish.js",
                 "riskLevel": "High"
+            })
+        );
+    }
+
+    #[test]
+    fn critical_lifecycle_risk_is_preserved_in_wire_contract() {
+        let response = LifecycleScriptDto {
+            package: "demo".to_string(),
+            package_manager: PackageManagerDto::Npm,
+            script_type: ScriptTypeDto::Postinstall,
+            command: "curl payload && ./payload".to_string(),
+            risk_level: RiskLevelDto::Critical,
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            json!({
+                "package": "demo",
+                "packageManager": "npm",
+                "scriptType": "postinstall",
+                "command": "curl payload && ./payload",
+                "riskLevel": "Critical"
             })
         );
     }

--- a/apps/dustfril-tauri/src/lib/format.ts
+++ b/apps/dustfril-tauri/src/lib/format.ts
@@ -49,6 +49,8 @@ export function riskTone(level: RiskLevel) {
   switch (level) {
     case 'High':
       return 'border-rose-400/30 bg-rose-400/10 text-rose-100';
+    case 'Critical':
+      return 'border-red-500/40 bg-red-500/15 text-red-50';
     case 'Medium':
       return 'border-amber-400/30 bg-amber-400/10 text-amber-100';
     case 'Low':

--- a/apps/dustfril-tauri/src/types/workflow.ts
+++ b/apps/dustfril-tauri/src/types/workflow.ts
@@ -1,7 +1,7 @@
 export type Ecosystem = 'Rust' | 'Node' | 'Java';
 export type Recommendation = 'Keep' | 'NeedsReview' | 'SafeToClean';
 export type DeleteMode = 'Trash' | 'Permanent';
-export type RiskLevel = 'Low' | 'Medium' | 'High' | 'None';
+export type RiskLevel = 'Low' | 'Medium' | 'High' | 'Critical' | 'None';
 
 export type Artifact = {
   path: string;

--- a/apps/dustfril-tauri/src/types/workflow.ts
+++ b/apps/dustfril-tauri/src/types/workflow.ts
@@ -1,7 +1,7 @@
 export type Ecosystem = 'Rust' | 'Node' | 'Java';
 export type Recommendation = 'Keep' | 'NeedsReview' | 'SafeToClean';
 export type DeleteMode = 'Trash' | 'Permanent';
-export type RiskLevel = 'Low' | 'Medium' | 'High' | 'None';
+export type RiskLevel = 'Low' | 'Medium' | 'High' | 'Critical' | 'None';
 export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'unknown';
 export type ScriptType =
   | 'preinstall'

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -11,6 +11,7 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - `api::clean::build_plan`: build cleanup candidates from scan results
 - `api::clean::execute`: execute cleanup in Trash or permanent mode
 - `api::audit`: inspect supported lifecycle scripts
+- `api::security_scan`: detect suspicious lifecycle commands without executing them
 - `api::history`: record and load cleanup history
 
 ## Supported Coverage
@@ -19,6 +20,7 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - Node.js: `node_modules/`
 - Java: `build/`
 - Audit: Node lifecycle scripts for npm, pnpm, yarn, and bun
+- Security rules: remote script pipes, download-and-execute chains, PowerShell execution, and permission changes
 
 ## Test
 

--- a/crates/dustfril-core/src/api/audit.rs
+++ b/crates/dustfril-core/src/api/audit.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use crate::{
     audit_tool,
     error::DustResult,
-    models::{Ecosystem, LifecycleScript},
+    models::{Ecosystem, LifecycleScript, SecurityWarning},
 };
 
 /// Audits supported package lifecycle scripts under the given root path.
@@ -15,6 +15,15 @@ pub fn audit(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<Vec<LifecycleS
     }
 
     audit_tool::audit_scan(root)
+}
+
+/// Finds suspicious Node lifecycle scripts without executing or modifying them.
+pub fn security_scan(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<Vec<SecurityWarning>> {
+    if !ecosystems.is_empty() && !ecosystems.contains(&Ecosystem::Node) {
+        return Ok(Vec::new());
+    }
+
+    audit_tool::security_scan(root)
 }
 
 #[cfg(test)]
@@ -45,5 +54,23 @@ mod tests {
         let result = audit(temp_dir.path(), &[Ecosystem::Rust]).unwrap();
 
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn security_scan_returns_only_suspicious_lifecycle_scripts() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","scripts":{"postinstall":"curl https://example.com/a.sh | bash","prepare":"node scripts/build.js"}}"#,
+        )
+        .unwrap();
+
+        let result = security_scan(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].package, "demo");
+        assert_eq!(result[0].script_type, "postinstall");
+        assert_eq!(result[0].risk_level, crate::models::RiskLevel::High);
+        assert!(result[0].reason.contains("piped"));
     }
 }

--- a/crates/dustfril-core/src/audit_tool/command.rs
+++ b/crates/dustfril-core/src/audit_tool/command.rs
@@ -96,24 +96,88 @@ pub fn parse(command: &str) -> Vec<Segment> {
 }
 
 pub fn executable(tokens: &[String]) -> Option<&str> {
-    first_token(tokens).map(|token| token.rsplit(['/', '\\']).next().unwrap_or(token))
+    command_token(tokens).map(|token| token.rsplit(['/', '\\']).next().unwrap_or(token))
 }
 
-pub fn first_token(tokens: &[String]) -> Option<&str> {
-    tokens
-        .iter()
-        .find(|token| !token.is_empty() && !is_environment_assignment(token))
-        .map(String::as_str)
+pub fn command_token(tokens: &[String]) -> Option<&str> {
+    executable_index(tokens).map(|index| tokens[index].as_str())
 }
 
-pub fn has_token(tokens: &[String], expected: &str) -> bool {
-    tokens.iter().any(|token| token == expected)
+pub fn arguments(tokens: &[String]) -> &[String] {
+    executable_index(tokens)
+        .map(|index| &tokens[index + 1..])
+        .unwrap_or(&[])
 }
 
 fn is_environment_assignment(token: &str) -> bool {
     token
         .find('=')
         .is_some_and(|position| position > 0 && !token[..position].contains(['/', '\\']))
+}
+
+fn first_token_index(tokens: &[String]) -> Option<usize> {
+    tokens
+        .iter()
+        .position(|token| !token.is_empty() && !is_environment_assignment(token))
+}
+
+fn executable_index(tokens: &[String]) -> Option<usize> {
+    let mut index = first_token_index(tokens)?;
+
+    loop {
+        let executable = tokens[index]
+            .rsplit(['/', '\\'])
+            .next()
+            .unwrap_or(&tokens[index]);
+
+        match executable {
+            "command" => {
+                index += 1;
+            }
+            "env" => {
+                index += 1;
+                while index < tokens.len()
+                    && (is_environment_assignment(&tokens[index]) || tokens[index] == "-i")
+                {
+                    index += 1;
+                }
+            }
+            "sudo" => {
+                index += 1;
+                skip_sudo_options(tokens, &mut index);
+            }
+            _ => return (index < tokens.len()).then_some(index),
+        }
+
+        if index >= tokens.len() {
+            return None;
+        }
+    }
+}
+
+fn skip_sudo_options(tokens: &[String], index: &mut usize) {
+    while *index < tokens.len() {
+        let token = &tokens[*index];
+
+        if is_environment_assignment(token) {
+            *index += 1;
+            continue;
+        }
+
+        if !token.starts_with('-') {
+            break;
+        }
+
+        let takes_value = matches!(
+            token.as_str(),
+            "-u" | "--user" | "-g" | "--group" | "-p" | "--prompt" | "-C" | "--chdir"
+        );
+        *index += 1;
+
+        if takes_value && *index < tokens.len() {
+            *index += 1;
+        }
+    }
 }
 
 fn push_token(tokens: &mut Vec<String>, token: &mut String) {
@@ -166,5 +230,13 @@ mod tests {
         let segments = parse(r".\payload");
 
         assert_eq!(segments[0].tokens, [r".\payload"]);
+    }
+
+    #[test]
+    fn executable_skips_command_wrappers() {
+        let segments = parse("sudo -u root rm -rf /tmp/example");
+
+        assert_eq!(executable(&segments[0].tokens), Some("rm"));
+        assert_eq!(arguments(&segments[0].tokens), ["-rf", "/tmp/example"]);
     }
 }

--- a/crates/dustfril-core/src/audit_tool/command.rs
+++ b/crates/dustfril-core/src/audit_tool/command.rs
@@ -1,0 +1,170 @@
+//! Small, shell-aware helpers used by the lifecycle security rules.
+//!
+//! This is intentionally not a shell parser. It only separates the common
+//! command-chain operators and keeps quoted text together so that examples in
+//! an `echo` argument do not look like executable commands.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Separator {
+    Pipe,
+    And,
+    Or,
+    Sequence,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Segment {
+    pub preceding: Option<Separator>,
+    pub tokens: Vec<String>,
+}
+
+pub fn parse(command: &str) -> Vec<Segment> {
+    let mut segments = Vec::new();
+    let mut tokens = Vec::new();
+    let mut token = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+    let mut preceding = None;
+
+    let mut characters = command.chars().peekable();
+
+    while let Some(character) = characters.next() {
+        if escaped {
+            token.push(character.to_ascii_lowercase());
+            escaped = false;
+            continue;
+        }
+
+        if character == '\\' && quote != Some('\'') {
+            if characters.peek().is_some_and(|next| {
+                next.is_whitespace() || matches!(next, '&' | '|' | ';' | '\\' | '\'' | '"')
+            }) {
+                escaped = true;
+                continue;
+            }
+
+            token.push('\\');
+            continue;
+        }
+
+        if let Some(quote_character) = quote {
+            if character == quote_character {
+                quote = None;
+            } else {
+                token.push(character.to_ascii_lowercase());
+            }
+            continue;
+        }
+
+        match character {
+            '\'' | '"' => quote = Some(character),
+            character if character.is_whitespace() => push_token(&mut tokens, &mut token),
+            '&' | '|' | ';' => {
+                push_token(&mut tokens, &mut token);
+                push_segment(&mut segments, &mut tokens, preceding.take());
+                preceding = Some(match character {
+                    '&' => {
+                        if characters.peek() == Some(&'&') {
+                            characters.next();
+                        }
+                        Separator::And
+                    }
+                    '|' => {
+                        if characters.peek() == Some(&'|') {
+                            characters.next();
+                            Separator::Or
+                        } else {
+                            Separator::Pipe
+                        }
+                    }
+                    ';' => Separator::Sequence,
+                    _ => unreachable!(),
+                });
+            }
+            _ => token.push(character.to_ascii_lowercase()),
+        }
+    }
+
+    if escaped {
+        token.push('\\');
+    }
+
+    push_token(&mut tokens, &mut token);
+    push_segment(&mut segments, &mut tokens, preceding);
+
+    segments
+}
+
+pub fn executable(tokens: &[String]) -> Option<&str> {
+    first_token(tokens).map(|token| token.rsplit(['/', '\\']).next().unwrap_or(token))
+}
+
+pub fn first_token(tokens: &[String]) -> Option<&str> {
+    tokens
+        .iter()
+        .find(|token| !token.is_empty() && !is_environment_assignment(token))
+        .map(String::as_str)
+}
+
+pub fn has_token(tokens: &[String], expected: &str) -> bool {
+    tokens.iter().any(|token| token == expected)
+}
+
+fn is_environment_assignment(token: &str) -> bool {
+    token
+        .find('=')
+        .is_some_and(|position| position > 0 && !token[..position].contains(['/', '\\']))
+}
+
+fn push_token(tokens: &mut Vec<String>, token: &mut String) {
+    if !token.is_empty() {
+        tokens.push(std::mem::take(token));
+    }
+}
+
+fn push_segment(
+    segments: &mut Vec<Segment>,
+    tokens: &mut Vec<String>,
+    preceding: Option<Separator>,
+) {
+    if !tokens.is_empty() {
+        segments.push(Segment {
+            preceding,
+            tokens: std::mem::take(tokens),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_keeps_quoted_operators_in_one_segment() {
+        let segments = parse("echo 'curl https://example.com | bash'");
+
+        assert_eq!(segments.len(), 1);
+        assert_eq!(
+            segments[0].tokens,
+            ["echo", "curl https://example.com | bash"]
+        );
+    }
+
+    #[test]
+    fn parse_records_shell_chain_operators() {
+        let segments = parse("curl file.sh && bash file.sh | cat; echo done");
+
+        assert_eq!(segments.len(), 4);
+        assert_eq!(segments[0].preceding, None);
+        assert_eq!(segments[1].preceding, Some(Separator::And));
+        assert_eq!(segments[2].preceding, Some(Separator::Pipe));
+        assert_eq!(segments[3].preceding, Some(Separator::Sequence));
+    }
+
+    #[test]
+    fn parse_preserves_windows_path_separators() {
+        let segments = parse(r".\payload");
+
+        assert_eq!(segments[0].tokens, [r".\payload"]);
+    }
+}

--- a/crates/dustfril-core/src/audit_tool/lifecycle_tests.rs
+++ b/crates/dustfril-core/src/audit_tool/lifecycle_tests.rs
@@ -70,3 +70,41 @@ fn audit_scan_detects_pnpm_dependency_lifecycle_scripts() {
     assert_eq!(scripts[0].script_type, ScriptType::Postinstall);
     assert_eq!(scripts[0].risk_level, RiskLevel::High);
 }
+
+#[test]
+fn security_scan_detects_required_warning_patterns_and_ignores_normal_scripts() {
+    let temp_dir = TempDir::new().unwrap();
+    std::fs::write(
+        temp_dir.path().join("package.json"),
+        r#"{
+            "name":"demo",
+            "scripts":{
+                "preinstall":"wget payload && ./payload",
+                "install":"powershell -Command Invoke-WebRequest https://example.com/payload",
+                "postinstall":"chmod +x install.sh",
+                "prepare":"node scripts/build.js"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let warnings = crate::audit_tool::security_scan(temp_dir.path()).unwrap();
+
+    assert_eq!(warnings.len(), 3);
+    assert!(warnings.iter().any(|warning| {
+        warning.risk_level == RiskLevel::Critical
+            && warning.reason.contains("download")
+            && warning.script_type == "preinstall"
+    }));
+    assert!(warnings.iter().any(|warning| {
+        warning.risk_level == RiskLevel::High && warning.script_type == "install"
+    }));
+    assert!(warnings.iter().any(|warning| {
+        warning.risk_level == RiskLevel::Medium && warning.script_type == "postinstall"
+    }));
+    assert!(
+        !warnings
+            .iter()
+            .any(|warning| warning.script_type == "prepare")
+    );
+}

--- a/crates/dustfril-core/src/audit_tool/mod.rs
+++ b/crates/dustfril-core/src/audit_tool/mod.rs
@@ -1,12 +1,14 @@
+mod command;
 mod lifecycle;
 mod package_manager;
 mod risk;
+mod rule;
 
 use std::path::Path;
 
 use crate::{
     error::DustResult,
-    models::{LifecycleScript, RiskLevel},
+    models::{LifecycleScript, RiskLevel, SecurityWarning},
 };
 
 pub fn audit_scan(root: &Path) -> DustResult<Vec<LifecycleScript>> {
@@ -15,6 +17,25 @@ pub fn audit_scan(root: &Path) -> DustResult<Vec<LifecycleScript>> {
 
 pub fn classify(command: &str) -> RiskLevel {
     risk::classify(command)
+}
+
+pub fn security_scan(root: &Path) -> DustResult<Vec<SecurityWarning>> {
+    lifecycle::audit_scan(root).map(|scripts| {
+        scripts
+            .into_iter()
+            .filter_map(|script| {
+                let rule = rule::find(&script.command)?;
+
+                Some(SecurityWarning {
+                    package: script.package,
+                    script_type: script.script_type.to_string(),
+                    command: script.command,
+                    risk_level: rule.risk_level,
+                    reason: rule.reason.to_string(),
+                })
+            })
+            .collect()
+    })
 }
 
 #[cfg(test)]

--- a/crates/dustfril-core/src/audit_tool/risk.rs
+++ b/crates/dustfril-core/src/audit_tool/risk.rs
@@ -1,38 +1,24 @@
-use crate::models::RiskLevel;
+use crate::{
+    audit_tool::{command, rule},
+    models::RiskLevel,
+};
 
 /// Estimates the risk level of a lifecycle script command.
 pub fn classify(command: &str) -> RiskLevel {
-    let command = command.to_ascii_lowercase();
-
-    if contains_any(
-        &command,
-        &[
-            "curl",
-            "wget",
-            "invoke-webrequest",
-            "powershell",
-            "bash",
-            "sh ",
-            "chmod",
-            "sudo",
-            "rm -rf",
-        ],
-    ) {
-        return RiskLevel::High;
+    if let Some(rule) = rule::find(command) {
+        return rule.risk_level;
     }
 
-    if contains_any(
-        &command,
-        &[
-            "node", "tsx", "ts-node", "python", "python3", "npm", "pnpm", "yarn", "bun",
-        ],
-    ) {
+    if command::parse(command).iter().any(is_known_runtime_command) {
         return RiskLevel::Medium;
     }
 
     RiskLevel::Low
 }
 
-fn contains_any(command: &str, patterns: &[&str]) -> bool {
-    patterns.iter().any(|pattern| command.contains(pattern))
+fn is_known_runtime_command(segment: &command::Segment) -> bool {
+    matches!(
+        command::executable(&segment.tokens),
+        Some("node" | "tsx" | "ts-node" | "python" | "python3" | "npm" | "pnpm" | "yarn" | "bun")
+    )
 }

--- a/crates/dustfril-core/src/audit_tool/rule.rs
+++ b/crates/dustfril-core/src/audit_tool/rule.rs
@@ -39,6 +39,12 @@ pub static SECURITY_RULES: &[SecurityRule] = &[
         reason: "The script changes file ownership or executable permissions.",
         matcher: matches_permission_modification,
     },
+    SecurityRule {
+        id: "destructive-delete",
+        risk_level: RiskLevel::High,
+        reason: "The script recursively and forcibly deletes files.",
+        matcher: matches_destructive_delete,
+    },
 ];
 
 pub fn find(command: &str) -> Option<&'static SecurityRule> {
@@ -48,20 +54,27 @@ pub fn find(command: &str) -> Option<&'static SecurityRule> {
 }
 
 fn matches_download_and_execute(segments: &[Segment]) -> bool {
-    segments.windows(2).any(|pair| {
-        let [download, execute] = pair else {
-            return false;
-        };
+    segments
+        .iter()
+        .enumerate()
+        .any(|(download_index, download)| {
+            if !is_download_command(download) {
+                return false;
+            }
 
-        matches!(
-            download.preceding,
-            None | Some(Separator::And | Separator::Or | Separator::Sequence)
-        ) && matches!(
-            execute.preceding,
-            Some(Separator::And | Separator::Or | Separator::Sequence)
-        ) && is_download_command(download)
-            && is_executable_command(execute)
-    })
+            for segment in segments.iter().skip(download_index + 1) {
+                match segment.preceding {
+                    Some(Separator::And | Separator::Or | Separator::Sequence) => {
+                        if is_executable_command(segment) {
+                            return true;
+                        }
+                    }
+                    Some(Separator::Pipe) | None => break,
+                }
+            }
+
+            false
+        })
 }
 
 fn matches_remote_script_pipe(segments: &[Segment]) -> bool {
@@ -79,9 +92,10 @@ fn matches_remote_script_pipe(segments: &[Segment]) -> bool {
 fn matches_powershell_execution(segments: &[Segment]) -> bool {
     segments.iter().any(|segment| {
         is_powershell_command(segment)
-            || command::has_token(&segment.tokens, "invoke-webrequest")
-            || command::has_token(&segment.tokens, "iex")
-            || command::has_token(&segment.tokens, "invoke-expression")
+            || matches!(
+                command::executable(&segment.tokens),
+                Some("invoke-webrequest" | "iex" | "invoke-expression")
+            )
     })
 }
 
@@ -102,6 +116,31 @@ fn matches_permission_modification(segments: &[Segment]) -> bool {
     })
 }
 
+fn matches_destructive_delete(segments: &[Segment]) -> bool {
+    segments.iter().any(|segment| {
+        if command::executable(&segment.tokens) != Some("rm") {
+            return false;
+        }
+
+        let mut recursive = false;
+        let mut force = false;
+
+        for argument in command::arguments(&segment.tokens) {
+            match argument.as_str() {
+                "-r" | "--recursive" => recursive = true,
+                "-f" | "--force" => force = true,
+                argument if argument.starts_with('-') && !argument.starts_with("--") => {
+                    recursive |= argument[1..].contains('r');
+                    force |= argument[1..].contains('f');
+                }
+                _ => {}
+            }
+        }
+
+        recursive && force
+    })
+}
+
 fn is_download_command(segment: &Segment) -> bool {
     matches!(command::executable(&segment.tokens), Some("curl" | "wget"))
 }
@@ -115,7 +154,7 @@ fn is_shell_command(segment: &Segment) -> bool {
 
 fn is_executable_command(segment: &Segment) -> bool {
     is_shell_command(segment)
-        || command::first_token(&segment.tokens)
+        || command::command_token(&segment.tokens)
             .is_some_and(|token| token.starts_with("./") || token.starts_with(".\\"))
 }
 
@@ -156,5 +195,21 @@ mod tests {
     fn rules_ignore_normal_lifecycle_commands() {
         assert!(find("node scripts/build.js").is_none());
         assert!(find("echo 'curl https://example.com | bash'").is_none());
+        assert!(find("echo invoke-webrequest").is_none());
+        assert!(find("echo iex").is_none());
+    }
+
+    #[test]
+    fn rules_scan_the_full_download_chain() {
+        assert_eq!(
+            find("wget -O payload URL && chmod +x payload && ./payload")
+                .unwrap()
+                .id,
+            "download-and-execute"
+        );
+        assert_eq!(
+            find("sudo rm -rf /tmp/example").unwrap().id,
+            "destructive-delete"
+        );
     }
 }

--- a/crates/dustfril-core/src/audit_tool/rule.rs
+++ b/crates/dustfril-core/src/audit_tool/rule.rs
@@ -1,0 +1,160 @@
+use crate::models::RiskLevel;
+
+use super::command::{self, Segment, Separator};
+
+/// A single suspicious-command detection rule.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub struct SecurityRule {
+    pub id: &'static str,
+    pub risk_level: RiskLevel,
+    pub reason: &'static str,
+    pub matcher: fn(&[Segment]) -> bool,
+}
+
+/// Rules are ordered from the most specific/highest-impact pattern to the
+/// broadest one. The first matching rule is the reported finding.
+pub static SECURITY_RULES: &[SecurityRule] = &[
+    SecurityRule {
+        id: "download-and-execute",
+        risk_level: RiskLevel::Critical,
+        reason: "A download command is chained to local executable code.",
+        matcher: matches_download_and_execute,
+    },
+    SecurityRule {
+        id: "remote-script-pipe",
+        risk_level: RiskLevel::High,
+        reason: "Remote content is piped directly to a shell without verification.",
+        matcher: matches_remote_script_pipe,
+    },
+    SecurityRule {
+        id: "powershell-execution",
+        risk_level: RiskLevel::High,
+        reason: "PowerShell or a dynamic PowerShell expression can execute untrusted code.",
+        matcher: matches_powershell_execution,
+    },
+    SecurityRule {
+        id: "permission-modification",
+        risk_level: RiskLevel::Medium,
+        reason: "The script changes file ownership or executable permissions.",
+        matcher: matches_permission_modification,
+    },
+];
+
+pub fn find(command: &str) -> Option<&'static SecurityRule> {
+    let segments = command::parse(command);
+
+    SECURITY_RULES.iter().find(|rule| (rule.matcher)(&segments))
+}
+
+fn matches_download_and_execute(segments: &[Segment]) -> bool {
+    segments.windows(2).any(|pair| {
+        let [download, execute] = pair else {
+            return false;
+        };
+
+        matches!(
+            download.preceding,
+            None | Some(Separator::And | Separator::Or | Separator::Sequence)
+        ) && matches!(
+            execute.preceding,
+            Some(Separator::And | Separator::Or | Separator::Sequence)
+        ) && is_download_command(download)
+            && is_executable_command(execute)
+    })
+}
+
+fn matches_remote_script_pipe(segments: &[Segment]) -> bool {
+    segments.windows(2).any(|pair| {
+        let [download, shell] = pair else {
+            return false;
+        };
+
+        shell.preceding == Some(Separator::Pipe)
+            && is_download_command(download)
+            && is_shell_command(shell)
+    })
+}
+
+fn matches_powershell_execution(segments: &[Segment]) -> bool {
+    segments.iter().any(|segment| {
+        is_powershell_command(segment)
+            || command::has_token(&segment.tokens, "invoke-webrequest")
+            || command::has_token(&segment.tokens, "iex")
+            || command::has_token(&segment.tokens, "invoke-expression")
+    })
+}
+
+fn matches_permission_modification(segments: &[Segment]) -> bool {
+    segments.iter().any(|segment| {
+        let Some(executable) = command::executable(&segment.tokens) else {
+            return false;
+        };
+
+        if executable == "chown" {
+            return true;
+        }
+
+        executable == "chmod"
+            && segment.tokens.iter().skip(1).any(|token| {
+                token == "+x" || token.ends_with("+x") || token == "777" || token == "0777"
+            })
+    })
+}
+
+fn is_download_command(segment: &Segment) -> bool {
+    matches!(command::executable(&segment.tokens), Some("curl" | "wget"))
+}
+
+fn is_shell_command(segment: &Segment) -> bool {
+    matches!(
+        command::executable(&segment.tokens),
+        Some("bash" | "bash.exe" | "sh" | "sh.exe")
+    )
+}
+
+fn is_executable_command(segment: &Segment) -> bool {
+    is_shell_command(segment)
+        || command::first_token(&segment.tokens)
+            .is_some_and(|token| token.starts_with("./") || token.starts_with(".\\"))
+}
+
+fn is_powershell_command(segment: &Segment) -> bool {
+    matches!(
+        command::executable(&segment.tokens),
+        Some("powershell" | "powershell.exe" | "pwsh" | "pwsh.exe")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rules_match_specific_patterns() {
+        assert_eq!(
+            find("curl https://example.com/a.sh | bash").unwrap().id,
+            "remote-script-pipe"
+        );
+        assert_eq!(
+            find("wget payload && ./payload").unwrap().id,
+            "download-and-execute"
+        );
+        assert_eq!(
+            find("powershell -Command Invoke-WebRequest https://example.com")
+                .unwrap()
+                .id,
+            "powershell-execution"
+        );
+        assert_eq!(
+            find("chmod +x install.sh").unwrap().id,
+            "permission-modification"
+        );
+    }
+
+    #[test]
+    fn rules_ignore_normal_lifecycle_commands() {
+        assert!(find("node scripts/build.js").is_none());
+        assert!(find("echo 'curl https://example.com | bash'").is_none());
+    }
+}

--- a/crates/dustfril-core/src/models/audit.rs
+++ b/crates/dustfril-core/src/models/audit.rs
@@ -10,6 +10,16 @@ pub struct LifecycleScript {
     pub risk_level: RiskLevel,
 }
 
+/// A lifecycle script finding produced by the security rule engine.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecurityWarning {
+    pub package: String,
+    pub script_type: String,
+    pub command: String,
+    pub risk_level: RiskLevel,
+    pub reason: String,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PackageManager {
     Npm,
@@ -78,6 +88,7 @@ pub enum RiskLevel {
     Low,
     Medium,
     High,
+    Critical,
 }
 
 impl fmt::Display for RiskLevel {
@@ -87,6 +98,7 @@ impl fmt::Display for RiskLevel {
             Self::Low => "Low",
             Self::Medium => "Medium",
             Self::High => "High",
+            Self::Critical => "Critical",
         };
 
         write!(f, "{value}")


### PR DESCRIPTION
## Summary

- add a rule-based detector under `audit_tool` for suspicious Node lifecycle commands
- classify remote script pipes and PowerShell execution as high risk
- classify download-and-execute chains as critical and permission changes as medium
- expose structured warnings through `api::security_scan` and `dfr security scan`
- add regression tests and documentation

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #54