### PR TITLE
feat(core): add lockfile integrity checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -972,6 +974,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "directories",
+ "git2",
  "rayon",
  "serde",
  "serde_json",
@@ -1453,6 +1456,18 @@ dependencies = [
  "libc",
  "system-deps",
  "winapi",
+]
+
+[[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libgit2-sys",
+ "log",
 ]
 
 [[package]]
@@ -1994,6 +2009,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2108,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.8+1.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,6 +2136,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4285,6 +4334,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,6 +18,7 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 - 실제 삭제 전 정리 계획 미리 보기
 - 휴지통 이동 또는 영구 삭제 모드로 정리 실행
 - `preinstall`, `postinstall` 같은 Node 라이프사이클 스크립트 점검
+- 지원 lockfile의 존재 여부와 Git 상태 점검
 - CLI 정리 이력을 운영체제 앱 데이터 디렉터리에 저장
 
 ## 현재 탐지 대상
@@ -27,6 +28,11 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 | Rust   | `target/` |
 | Node.js | `node_modules/` |
 | Java   | `build/` |
+
+지원 lockfile은 `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`,
+`Cargo.lock`입니다. Core API는 `Missing`, `Modified`, `Untracked`, `Clean`
+상태를 반환합니다. Git worktree에서는 porcelain과 같은 상태를 사용하고,
+Git 저장소가 아니면 파일 존재 여부만 확인합니다.
 
 ## CLI 사용법
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Build a cleanup plan before deleting anything
 - Clean artifacts with Trash or permanent deletion mode
 - Audit Node lifecycle scripts such as `preinstall` and `postinstall`
+- Check supported lockfile presence and Git status
 - Persist CLI cleanup history to the OS app data directory
 
 ## Detected Artifacts
@@ -27,6 +28,11 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 | Rust      | `target/`          |
 | Node.js   | `node_modules/`    |
 | Java      | `build/`           |
+
+Supported lockfiles are `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`,
+and `Cargo.lock`. The Core API reports `Missing`, `Modified`, `Untracked`, or
+`Clean`; Git worktrees use porcelain-equivalent status, while non-Git paths
+only validate existence.
 
 ## CLI Usage
 

--- a/crates/dustfril-core/Cargo.toml
+++ b/crates/dustfril-core/Cargo.toml
@@ -11,6 +11,7 @@ trash = "5"
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 directories = "6"
+git2 = "0.21"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -11,6 +11,7 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - `api::clean::build_plan`: build cleanup candidates from scan results
 - `api::clean::execute`: execute cleanup in Trash or permanent mode
 - `api::audit`: inspect supported lifecycle scripts
+- `api::check_lockfile_integrity`: check supported lockfile presence and Git status
 - `api::history`: record and load cleanup history
 
 ## Supported Coverage
@@ -19,6 +20,12 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - Node.js: `node_modules/`
 - Java: `build/`
 - Audit: Node lifecycle scripts for npm, pnpm, yarn, and bun
+- Lockfile integrity: `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `Cargo.lock`
+
+Lockfile checks report `Missing`, `Modified`, `Untracked`, or `Clean`. Git
+worktrees use libgit2 status information equivalent to
+`git status --porcelain -- <lockfile>`; outside Git, only file existence is
+validated, so existing files are reported as `Clean`.
 
 ## Test
 

--- a/crates/dustfril-core/src/api/lockfile.rs
+++ b/crates/dustfril-core/src/api/lockfile.rs
@@ -1,0 +1,44 @@
+use std::path::Path;
+
+use crate::{
+    error::DustResult,
+    lockfile,
+    models::{LockfileCheck, LockfileKind},
+};
+
+/// Checks lockfiles expected by a project and additional supported lockfiles
+/// found at its root.
+pub fn check_lockfiles(root: &Path, expected: &[LockfileKind]) -> DustResult<Vec<LockfileCheck>> {
+    lockfile::check_lockfiles(root, expected)
+}
+
+/// Checks one supported lockfile at a project root.
+pub fn check_lockfile(root: &Path, kind: LockfileKind) -> DustResult<LockfileCheck> {
+    lockfile::check_lockfile(root, kind)
+}
+
+/// Checks lockfiles inferred from project manifests.
+pub fn check_lockfile_integrity(root: &Path) -> DustResult<Vec<LockfileCheck>> {
+    lockfile::check_lockfile_integrity(root)
+}
+
+/// Spelled-out alias for callers that use “lock file” as two words.
+pub fn check_lock_file_integrity(root: &Path) -> DustResult<Vec<LockfileCheck>> {
+    check_lockfile_integrity(root)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn api_exposes_missing_lockfile_check() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let checks = check_lockfiles(temp_dir.path(), &[LockfileKind::CargoLock]).unwrap();
+
+        assert_eq!(checks[0].status, crate::models::LockfileStatus::Missing);
+    }
+}

--- a/crates/dustfril-core/src/api/mod.rs
+++ b/crates/dustfril-core/src/api/mod.rs
@@ -2,10 +2,12 @@ pub mod analyze;
 pub mod audit;
 pub mod clean;
 pub mod history;
+pub mod lockfile;
 pub mod scan;
 
 pub use analyze::*;
 pub use audit::*;
 pub use clean::*;
 pub use history::*;
+pub use lockfile::*;
 pub use scan::*;

--- a/crates/dustfril-core/src/error.rs
+++ b/crates/dustfril-core/src/error.rs
@@ -15,6 +15,8 @@ pub enum DustError {
     CleanupFailed,
     /// Indicates that Git status could not be read for an integrity check.
     Git(String),
+    /// Indicates that a project manifest could not be parsed for an integrity check.
+    Manifest(String),
 }
 
 /// Standard result type used by the core crate.
@@ -40,6 +42,9 @@ impl fmt::Display for DustError {
             }
             DustError::Git(message) => {
                 write!(f, "Git error: {message}")
+            }
+            DustError::Manifest(message) => {
+                write!(f, "Manifest error: {message}")
             }
         }
     }
@@ -77,5 +82,12 @@ mod tests {
     #[test]
     fn display_formats_cleanup_error() {
         assert_eq!(DustError::CleanupFailed.to_string(), "Cleanup failed");
+    }
+
+    #[test]
+    fn display_formats_manifest_error() {
+        let error = DustError::Manifest("package.json is invalid".to_owned());
+
+        assert_eq!(error.to_string(), "Manifest error: package.json is invalid");
     }
 }

--- a/crates/dustfril-core/src/error.rs
+++ b/crates/dustfril-core/src/error.rs
@@ -13,6 +13,8 @@ pub enum DustError {
     AnalysisFailed,
     /// Indicates an unrecoverable cleanup failure.
     CleanupFailed,
+    /// Indicates that Git status could not be read for an integrity check.
+    Git(String),
 }
 
 /// Standard result type used by the core crate.
@@ -35,6 +37,9 @@ impl fmt::Display for DustError {
             }
             DustError::CleanupFailed => {
                 write!(f, "Cleanup failed")
+            }
+            DustError::Git(message) => {
+                write!(f, "Git error: {message}")
             }
         }
     }

--- a/crates/dustfril-core/src/lib.rs
+++ b/crates/dustfril-core/src/lib.rs
@@ -7,4 +7,5 @@ mod audit_tool;
 mod cleaner;
 mod fs;
 mod history;
+mod lockfile;
 mod scanner;

--- a/crates/dustfril-core/src/lockfile/check.rs
+++ b/crates/dustfril-core/src/lockfile/check.rs
@@ -1,0 +1,267 @@
+use std::{fs, path::Path};
+
+use serde_json::Value;
+
+use crate::{
+    error::{DustError, DustResult},
+    lockfile::git::{GitStatusProvider, Libgit2StatusProvider},
+    models::{Ecosystem, LockfileCheck, LockfileKind, LockfileStatus},
+};
+
+/// Checks explicitly expected lockfiles and any additional supported
+/// lockfiles present at the project root.
+pub fn check_lockfiles(root: &Path, expected: &[LockfileKind]) -> DustResult<Vec<LockfileCheck>> {
+    check_lockfiles_with_provider(root, expected, &Libgit2StatusProvider)
+}
+
+/// Checks one supported lockfile, including a missing-file result.
+pub fn check_lockfile(root: &Path, kind: LockfileKind) -> DustResult<LockfileCheck> {
+    check_lockfiles(root, &[kind])?
+        .into_iter()
+        .find(|check| check.kind == kind)
+        .ok_or_else(|| DustError::InvalidPath(root.to_path_buf()))
+}
+
+/// Checks lockfiles expected from the project manifests.
+///
+/// `Cargo.toml` expects `Cargo.lock`. For Node projects, the optional
+/// `packageManager` field selects npm, pnpm, or bun. Without that field, an
+/// existing supported Node lockfile is used; when none exists, npm's
+/// `package-lock.json` is the default expectation. Additional supported
+/// lockfiles are always included so stale or untracked alternatives are
+/// visible.
+pub fn check_lockfile_integrity(root: &Path) -> DustResult<Vec<LockfileCheck>> {
+    let expected = infer_expected_lockfiles(root)?;
+
+    check_lockfiles(root, &expected)
+}
+
+fn check_lockfiles_with_provider(
+    root: &Path,
+    expected: &[LockfileKind],
+    git: &impl GitStatusProvider,
+) -> DustResult<Vec<LockfileCheck>> {
+    if !root.is_dir() {
+        return Err(DustError::InvalidPath(root.to_path_buf()));
+    }
+
+    let mut kinds = if expected.is_empty() {
+        existing_lockfiles(root)
+    } else {
+        expected.to_vec()
+    };
+
+    for kind in LockfileKind::all() {
+        if root.join(kind.filename()).exists() && !kinds.contains(kind) {
+            kinds.push(*kind);
+        }
+    }
+
+    deduplicate(&mut kinds);
+
+    kinds
+        .into_iter()
+        .map(|kind| {
+            let path = root.join(kind.filename());
+            let status = if !path.is_file() {
+                LockfileStatus::Missing
+            } else {
+                git.status(root, Path::new(kind.filename()))?
+                    .unwrap_or(LockfileStatus::Clean)
+            };
+
+            Ok(LockfileCheck::new(path, kind, status))
+        })
+        .collect()
+}
+
+fn existing_lockfiles(root: &Path) -> Vec<LockfileKind> {
+    LockfileKind::all()
+        .iter()
+        .copied()
+        .filter(|kind| root.join(kind.filename()).exists())
+        .collect()
+}
+
+fn infer_expected_lockfiles(root: &Path) -> DustResult<Vec<LockfileKind>> {
+    if !root.is_dir() {
+        return Err(DustError::InvalidPath(root.to_path_buf()));
+    }
+
+    let mut expected = Vec::new();
+
+    if root.join("Cargo.toml").is_file() {
+        expected.push(LockfileKind::CargoLock);
+    }
+
+    if root.join("package.json").is_file() {
+        let node_lockfiles = existing_lockfiles(root)
+            .into_iter()
+            .filter(|kind| kind.ecosystem() == Ecosystem::Node)
+            .collect::<Vec<_>>();
+
+        if let Some(kind) = package_manager_lockfile(&root.join("package.json")) {
+            expected.push(kind);
+        } else if node_lockfiles.is_empty() {
+            expected.push(LockfileKind::PackageLockJson);
+        } else {
+            expected.extend(node_lockfiles);
+        }
+    }
+
+    if expected.is_empty() {
+        expected.extend(existing_lockfiles(root));
+    }
+
+    deduplicate(&mut expected);
+
+    Ok(expected)
+}
+
+fn package_manager_lockfile(path: &Path) -> Option<LockfileKind> {
+    let content = fs::read_to_string(path).ok()?;
+    let package_json: Value = serde_json::from_str(&content).ok()?;
+    let package_manager = package_json.get("packageManager")?.as_str()?;
+
+    if package_manager.starts_with("pnpm@") {
+        Some(LockfileKind::PnpmLockYaml)
+    } else if package_manager.starts_with("bun@") {
+        Some(LockfileKind::BunLock)
+    } else if package_manager.starts_with("npm@") {
+        Some(LockfileKind::PackageLockJson)
+    } else {
+        None
+    }
+}
+
+fn deduplicate(kinds: &mut Vec<LockfileKind>) {
+    let mut seen = Vec::with_capacity(kinds.len());
+    kinds.retain(|kind| {
+        if seen.contains(kind) {
+            false
+        } else {
+            seen.push(*kind);
+            true
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use git2::{Repository, Signature};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn git_repository_with_committed_lockfile() -> TempDir {
+        let temp_dir = TempDir::new().unwrap();
+        let repository = Repository::init(temp_dir.path()).unwrap();
+        fs::write(temp_dir.path().join("Cargo.lock"), "version = 3\n").unwrap();
+
+        let mut index = repository.index().unwrap();
+        index.add_path(Path::new("Cargo.lock")).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repository.find_tree(tree_id).unwrap();
+        let signature = Signature::now("DustFril Test", "test@dustfril.invalid").unwrap();
+        repository
+            .commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                "Add lockfile",
+                &tree,
+                &[],
+            )
+            .unwrap();
+
+        temp_dir
+    }
+
+    #[test]
+    fn explicit_expected_lockfile_reports_missing() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let checks = check_lockfiles(temp_dir.path(), &[LockfileKind::CargoLock]).unwrap();
+
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, LockfileStatus::Missing);
+    }
+
+    #[test]
+    fn non_git_existing_lockfile_is_clean() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("bun.lock"), "lockfile\n").unwrap();
+
+        let check = check_lockfile(temp_dir.path(), LockfileKind::BunLock).unwrap();
+
+        assert_eq!(check.status, LockfileStatus::Clean);
+    }
+
+    #[test]
+    fn non_git_lockfile_cannot_be_reported_as_untracked() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("pnpm-lock.yaml"),
+            "lockfileVersion: 9\n",
+        )
+        .unwrap();
+
+        let check = check_lockfile(temp_dir.path(), LockfileKind::PnpmLockYaml).unwrap();
+
+        assert_ne!(check.status, LockfileStatus::Untracked);
+        assert_eq!(check.status, LockfileStatus::Clean);
+    }
+
+    #[test]
+    fn git_status_distinguishes_clean_modified_and_untracked_lockfiles() {
+        let temp_dir = git_repository_with_committed_lockfile();
+
+        let clean = check_lockfile(temp_dir.path(), LockfileKind::CargoLock).unwrap();
+        assert_eq!(clean.status, LockfileStatus::Clean);
+
+        fs::write(temp_dir.path().join("Cargo.lock"), "version = 4\n").unwrap();
+        let modified = check_lockfile(temp_dir.path(), LockfileKind::CargoLock).unwrap();
+        assert_eq!(modified.status, LockfileStatus::Modified);
+
+        fs::write(temp_dir.path().join("package-lock.json"), "{}\n").unwrap();
+        let untracked = check_lockfile(temp_dir.path(), LockfileKind::PackageLockJson).unwrap();
+        assert_eq!(untracked.status, LockfileStatus::Untracked);
+    }
+
+    #[test]
+    fn integrity_check_infers_manifest_expectations() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"pnpm@9.0.0"}"#,
+        )
+        .unwrap();
+
+        let checks = check_lockfile_integrity(temp_dir.path()).unwrap();
+
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].kind, LockfileKind::PnpmLockYaml);
+        assert_eq!(checks[0].status, LockfileStatus::Missing);
+    }
+
+    #[test]
+    fn integrity_check_includes_additional_supported_lockfiles() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("Cargo.toml"), "[package]\n").unwrap();
+        fs::write(temp_dir.path().join("Cargo.lock"), "version = 3\n").unwrap();
+        fs::write(temp_dir.path().join("bun.lock"), "lockfile\n").unwrap();
+
+        let checks = check_lockfile_integrity(temp_dir.path()).unwrap();
+
+        assert_eq!(checks.len(), 2);
+        assert!(checks.iter().any(|check| {
+            check.kind == LockfileKind::CargoLock && check.status == LockfileStatus::Clean
+        }));
+        assert!(checks.iter().any(|check| {
+            check.kind == LockfileKind::BunLock && check.status == LockfileStatus::Clean
+        }));
+    }
+}

--- a/crates/dustfril-core/src/lockfile/check.rs
+++ b/crates/dustfril-core/src/lockfile/check.rs
@@ -36,6 +36,11 @@ pub fn check_lockfile_integrity(root: &Path) -> DustResult<Vec<LockfileCheck>> {
     check_lockfiles(root, &expected)
 }
 
+enum NodeLockfileSelection {
+    Supported(LockfileKind),
+    Unsupported,
+}
+
 fn check_lockfiles_with_provider(
     root: &Path,
     expected: &[LockfileKind],
@@ -100,12 +105,11 @@ fn infer_expected_lockfiles(root: &Path) -> DustResult<Vec<LockfileKind>> {
             .filter(|kind| kind.ecosystem() == Ecosystem::Node)
             .collect::<Vec<_>>();
 
-        if let Some(kind) = package_manager_lockfile(&root.join("package.json")) {
-            expected.push(kind);
-        } else if node_lockfiles.is_empty() {
-            expected.push(LockfileKind::PackageLockJson);
-        } else {
-            expected.extend(node_lockfiles);
+        match package_manager_lockfile(&root.join("package.json"))? {
+            Some(NodeLockfileSelection::Supported(kind)) => expected.push(kind),
+            Some(NodeLockfileSelection::Unsupported) => {}
+            None if node_lockfiles.is_empty() => expected.push(LockfileKind::PackageLockJson),
+            None => expected.extend(node_lockfiles),
         }
     }
 
@@ -118,20 +122,31 @@ fn infer_expected_lockfiles(root: &Path) -> DustResult<Vec<LockfileKind>> {
     Ok(expected)
 }
 
-fn package_manager_lockfile(path: &Path) -> Option<LockfileKind> {
-    let content = fs::read_to_string(path).ok()?;
-    let package_json: Value = serde_json::from_str(&content).ok()?;
-    let package_manager = package_json.get("packageManager")?.as_str()?;
+fn package_manager_lockfile(path: &Path) -> DustResult<Option<NodeLockfileSelection>> {
+    let content = fs::read_to_string(path)?;
+    let package_json: Value = serde_json::from_str(&content)
+        .map_err(|error| DustError::Manifest(format!("{}: {error}", path.display())))?;
+    let Some(package_manager_value) = package_json.get("packageManager") else {
+        return Ok(None);
+    };
+    let package_manager = package_manager_value.as_str().ok_or_else(|| {
+        DustError::Manifest(format!(
+            "{}: packageManager must be a string",
+            path.display()
+        ))
+    })?;
 
-    if package_manager.starts_with("pnpm@") {
-        Some(LockfileKind::PnpmLockYaml)
+    let selection = if package_manager.starts_with("pnpm@") {
+        NodeLockfileSelection::Supported(LockfileKind::PnpmLockYaml)
     } else if package_manager.starts_with("bun@") {
-        Some(LockfileKind::BunLock)
+        NodeLockfileSelection::Supported(LockfileKind::BunLock)
     } else if package_manager.starts_with("npm@") {
-        Some(LockfileKind::PackageLockJson)
+        NodeLockfileSelection::Supported(LockfileKind::PackageLockJson)
     } else {
-        None
-    }
+        NodeLockfileSelection::Unsupported
+    };
+
+    Ok(Some(selection))
 }
 
 fn deduplicate(kinds: &mut Vec<LockfileKind>) {
@@ -245,6 +260,31 @@ mod tests {
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].kind, LockfileKind::PnpmLockYaml);
         assert_eq!(checks[0].status, LockfileStatus::Missing);
+    }
+
+    #[test]
+    fn integrity_check_does_not_assume_npm_for_unsupported_package_manager() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"yarn@4.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(temp_dir.path().join("yarn.lock"), "__metadata:\n").unwrap();
+
+        let checks = check_lockfile_integrity(temp_dir.path()).unwrap();
+
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn integrity_check_reports_malformed_package_manifest() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("package.json"), "{invalid json").unwrap();
+
+        let result = check_lockfile_integrity(temp_dir.path());
+
+        assert!(matches!(result, Err(DustError::Manifest(_))));
     }
 
     #[test]

--- a/crates/dustfril-core/src/lockfile/git.rs
+++ b/crates/dustfril-core/src/lockfile/git.rs
@@ -1,0 +1,106 @@
+use std::path::Path;
+
+use git2::{ErrorCode, Repository, Status};
+
+use crate::{
+    error::{DustError, DustResult},
+    models::LockfileStatus,
+};
+
+/// Source of Git file status used by the lockfile checker.
+pub trait GitStatusProvider {
+    /// Returns `None` when `root` is not inside a Git worktree.
+    fn status(&self, root: &Path, path: &Path) -> DustResult<Option<LockfileStatus>>;
+}
+
+/// Git status provider backed by libgit2.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Libgit2StatusProvider;
+
+impl GitStatusProvider for Libgit2StatusProvider {
+    fn status(&self, root: &Path, path: &Path) -> DustResult<Option<LockfileStatus>> {
+        let repository = match Repository::discover(root) {
+            Ok(repository) => repository,
+            Err(error) if error.code() == ErrorCode::NotFound => return Ok(None),
+            Err(error) => return Err(git_error(error.message())),
+        };
+
+        let Some(workdir) = repository.workdir() else {
+            // A bare repository has no worktree whose lockfile can be checked.
+            return Ok(None);
+        };
+
+        let workdir = workdir.canonicalize()?;
+        let root = root.canonicalize()?;
+        let path = root.join(path);
+        let relative_path = path
+            .strip_prefix(&workdir)
+            .map_err(|_| git_error("lockfile is outside the Git worktree"))?;
+
+        let status = match repository.status_file(relative_path) {
+            Ok(status) => status,
+            // `git status --porcelain -- <path>` produces no output for paths
+            // Git does not report, such as ignored files. The caller has
+            // already validated that the lockfile exists, so that is clean for
+            // this v1 status model.
+            Err(error) if error.code() == ErrorCode::NotFound => Status::CURRENT,
+            Err(error) => return Err(git_error(error.message())),
+        };
+
+        Ok(Some(status_to_lockfile_status(status)))
+    }
+}
+
+fn status_to_lockfile_status(status: Status) -> LockfileStatus {
+    if status == Status::WT_NEW {
+        LockfileStatus::Untracked
+    } else if status.is_empty() || status == Status::CURRENT || status == Status::IGNORED {
+        LockfileStatus::Clean
+    } else {
+        LockfileStatus::Modified
+    }
+}
+
+fn git_error(message: &str) -> DustError {
+    DustError::Git(message.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use git2::Status;
+
+    use super::status_to_lockfile_status;
+    use crate::models::LockfileStatus;
+
+    #[test]
+    fn maps_only_worktree_new_to_untracked() {
+        assert_eq!(
+            status_to_lockfile_status(Status::WT_NEW),
+            LockfileStatus::Untracked
+        );
+    }
+
+    #[test]
+    fn maps_clean_and_ignored_statuses_to_clean() {
+        assert_eq!(
+            status_to_lockfile_status(Status::CURRENT),
+            LockfileStatus::Clean
+        );
+        assert_eq!(
+            status_to_lockfile_status(Status::IGNORED),
+            LockfileStatus::Clean
+        );
+    }
+
+    #[test]
+    fn maps_all_other_git_changes_to_modified() {
+        assert_eq!(
+            status_to_lockfile_status(Status::WT_MODIFIED),
+            LockfileStatus::Modified
+        );
+        assert_eq!(
+            status_to_lockfile_status(Status::INDEX_NEW),
+            LockfileStatus::Modified
+        );
+    }
+}

--- a/crates/dustfril-core/src/lockfile/mod.rs
+++ b/crates/dustfril-core/src/lockfile/mod.rs
@@ -1,0 +1,4 @@
+mod check;
+mod git;
+
+pub use check::{check_lockfile, check_lockfile_integrity, check_lockfiles};

--- a/crates/dustfril-core/src/models/lockfile.rs
+++ b/crates/dustfril-core/src/models/lockfile.rs
@@ -1,0 +1,139 @@
+use core::fmt;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Lockfiles whose integrity can be checked by DustFril.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum LockfileKind {
+    PackageLockJson,
+    PnpmLockYaml,
+    BunLock,
+    CargoLock,
+}
+
+impl LockfileKind {
+    /// Returns every lockfile supported by the v1 integrity check.
+    pub const fn all() -> &'static [Self] {
+        &[
+            Self::PackageLockJson,
+            Self::PnpmLockYaml,
+            Self::BunLock,
+            Self::CargoLock,
+        ]
+    }
+
+    /// Returns the filename used by this lockfile kind.
+    pub const fn filename(self) -> &'static str {
+        match self {
+            Self::PackageLockJson => "package-lock.json",
+            Self::PnpmLockYaml => "pnpm-lock.yaml",
+            Self::BunLock => "bun.lock",
+            Self::CargoLock => "Cargo.lock",
+        }
+    }
+
+    /// Returns the ecosystem associated with this lockfile.
+    pub const fn ecosystem(self) -> crate::models::Ecosystem {
+        match self {
+            Self::PackageLockJson | Self::PnpmLockYaml | Self::BunLock => {
+                crate::models::Ecosystem::Node
+            }
+            Self::CargoLock => crate::models::Ecosystem::Rust,
+        }
+    }
+
+    /// Finds a supported lockfile kind by its exact filename.
+    pub fn from_filename(filename: &str) -> Option<Self> {
+        Self::all()
+            .iter()
+            .copied()
+            .find(|kind| kind.filename() == filename)
+    }
+}
+
+impl fmt::Display for LockfileKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.filename())
+    }
+}
+
+/// Integrity state for a supported lockfile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LockfileStatus {
+    /// The expected lockfile is not a regular file.
+    Missing,
+    /// A tracked lockfile differs from HEAD or the index.
+    Modified,
+    /// The lockfile exists in the worktree but is not tracked by Git.
+    Untracked,
+    /// The lockfile exists and has no reported Git changes.
+    Clean,
+}
+
+impl fmt::Display for LockfileStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Missing => "Missing",
+            Self::Modified => "Modified",
+            Self::Untracked => "Untracked",
+            Self::Clean => "Clean",
+        };
+
+        f.write_str(value)
+    }
+}
+
+/// Integrity information for one lockfile at a project root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockfileCheck {
+    /// Path checked by the integrity scanner.
+    pub path: PathBuf,
+    /// Format and filename of the lockfile.
+    pub kind: LockfileKind,
+    /// Status observed for the lockfile.
+    pub status: LockfileStatus,
+}
+
+impl LockfileCheck {
+    /// Creates an integrity result for a lockfile path.
+    pub fn new(path: PathBuf, kind: LockfileKind, status: LockfileStatus) -> Self {
+        Self { path, kind, status }
+    }
+}
+
+/// Alias emphasizing that a check is an integrity result.
+pub type LockfileIntegrity = LockfileCheck;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_lockfile_filenames_are_stable() {
+        assert_eq!(
+            LockfileKind::PackageLockJson.filename(),
+            "package-lock.json"
+        );
+        assert_eq!(LockfileKind::PnpmLockYaml.filename(), "pnpm-lock.yaml");
+        assert_eq!(LockfileKind::BunLock.filename(), "bun.lock");
+        assert_eq!(LockfileKind::CargoLock.filename(), "Cargo.lock");
+    }
+
+    #[test]
+    fn from_filename_rejects_unsupported_lockfiles() {
+        assert_eq!(
+            LockfileKind::from_filename("package-lock.json"),
+            Some(LockfileKind::PackageLockJson)
+        );
+        assert_eq!(LockfileKind::from_filename("bun.lockb"), None);
+    }
+
+    #[test]
+    fn status_display_matches_report_labels() {
+        assert_eq!(LockfileStatus::Missing.to_string(), "Missing");
+        assert_eq!(LockfileStatus::Modified.to_string(), "Modified");
+        assert_eq!(LockfileStatus::Untracked.to_string(), "Untracked");
+        assert_eq!(LockfileStatus::Clean.to_string(), "Clean");
+    }
+}

--- a/crates/dustfril-core/src/models/mod.rs
+++ b/crates/dustfril-core/src/models/mod.rs
@@ -3,10 +3,12 @@ mod analysis;
 mod audit;
 mod cleanup;
 mod history;
+mod lockfile;
 mod scan;
 
 pub use analysis::*;
 pub use audit::*;
 pub use cleanup::*;
 pub use history::*;
+pub use lockfile::*;
 pub use scan::*;


### PR DESCRIPTION
## Summary

- Add Core lockfile integrity models and APIs for package-lock.json, pnpm-lock.yaml, bun.lock, and Cargo.lock
- Report Missing, Modified, Untracked, and Clean states
- Use libgit2 status in Git worktrees and existence validation outside Git
- Defer baseline hash verification to a future feature

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #56