### PR TITLE
refactor: strengthen architecture and test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Check supported lockfile presence and Git status
 - Persist CLI cleanup history to the OS app data directory
 
+Scans reject missing, symbolic-link, or non-directory roots and report
+filesystem traversal errors. Cleanup only accepts real artifact directories,
+refuses symbolic links and protected paths, and reports Trash failures without
+permanently deleting the candidate as a fallback.
+
 ## Detected Artifacts
 
 | Ecosystem | Detected Artifacts |

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -34,5 +34,6 @@ cargo build -p dustfril-cli
 
 - Supported ecosystem filters: `--rust`, `--node`, `--java`
 - `clean` asks for confirmation before deletion
+- command failures return a non-zero process exit status
 - Activity history is stored in the OS app data directory as a versioned `history.json`.
   Existing cleanup-history arrays are migrated when the file is read or appended to.

--- a/apps/dustfril-cli/src/commands/analyze.rs
+++ b/apps/dustfril-cli/src/commands/analyze.rs
@@ -56,12 +56,17 @@ fn print_summary(analysis: &AnalysisResult) {
     println!("\n----------------------------------------\n");
 }
 
-pub fn execute(args: PathArgs) {
-    let path = resolve_path(&args.path);
+pub fn execute(args: PathArgs) -> bool {
+    let path = match resolve_path(&args.path) {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("Failed to resolve path: {error}");
+            return false;
+        }
+    };
 
     if !validate_path(&path) {
-        eprintln!("Invalid path");
-        return;
+        return false;
     }
 
     let ecosystems = args.ecosystems();
@@ -70,7 +75,7 @@ pub fn execute(args: PathArgs) {
         Ok(res) => res,
         Err(e) => {
             eprintln!("Scan failed: {}", e);
-            return;
+            return false;
         }
     };
 
@@ -78,7 +83,7 @@ pub fn execute(args: PathArgs) {
         Ok(res) => res,
         Err(e) => {
             eprintln!("Analysis failed: {}", e);
-            return;
+            return false;
         }
     };
 
@@ -90,7 +95,7 @@ pub fn execute(args: PathArgs) {
 
     if analysis_result.artifacts.is_empty() {
         println!("No artifacts found.");
-        return;
+        return true;
     }
 
     println!("Found {} artifact(s)\n", analysis_result.artifacts.len());
@@ -116,4 +121,6 @@ pub fn execute(args: PathArgs) {
     }
 
     print_summary(&analysis_result);
+
+    true
 }

--- a/apps/dustfril-cli/src/commands/audit.rs
+++ b/apps/dustfril-cli/src/commands/audit.rs
@@ -6,11 +6,17 @@ use crate::{
     shared::path::{resolve_path, validate_path},
 };
 
-pub fn execute(args: &PathArgs) {
-    let path = resolve_path(&args.path);
+pub fn execute(args: &PathArgs) -> bool {
+    let path = match resolve_path(&args.path) {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("Failed to resolve path: {error}");
+            return false;
+        }
+    };
 
     if !validate_path(&path) {
-        return;
+        return false;
     }
 
     let ecosystems = args.ecosystems();
@@ -19,14 +25,16 @@ pub fn execute(args: &PathArgs) {
         Ok(scripts) => scripts,
         Err(error) => {
             eprintln!("Audit failed: {error}");
-            return;
+            return false;
         }
     };
 
     if scripts.is_empty() {
         println!("No lifecycle scripts found.");
-        return;
+        return true;
     }
 
     format::print_audit_report(&scripts);
+
+    true
 }

--- a/apps/dustfril-cli/src/commands/clean.rs
+++ b/apps/dustfril-cli/src/commands/clean.rs
@@ -12,43 +12,52 @@ use crate::{
     shared::path::{resolve_path, validate_path},
 };
 
-pub fn dry_run(args: &CleanArgs) {
+pub fn dry_run(args: &CleanArgs) -> bool {
     let plan = match build_cleanup_plan(args) {
         Ok(plan) => plan,
         Err(e) => {
             eprintln!("Cleanup preview failed: {}", e);
-            return;
+            return false;
         }
     };
 
     if plan.candidates.is_empty() {
         println!("No cleanup candidates found.");
-        return;
+        return true;
     }
 
     print_cleanup_plan(&plan);
     println!("No files were deleted.");
+
+    true
 }
 
-pub fn execute(args: &CleanArgs) {
+pub fn execute(args: &CleanArgs) -> bool {
     let plan = match build_cleanup_plan(args) {
         Ok(plan) => plan,
         Err(e) => {
             eprintln!("Cleanup preparation failed: {}", e);
-            return;
+            return false;
         }
     };
 
     if plan.candidates.is_empty() {
         println!("No cleanup candidates found.");
-        return;
+        return true;
     }
 
     print_cleanup_plan(&plan);
 
-    if !confirm_cleanup() {
-        println!("Cleanup cancelled.");
-        return;
+    match confirm_cleanup() {
+        Ok(true) => {}
+        Ok(false) => {
+            println!("Cleanup cancelled.");
+            return true;
+        }
+        Err(error) => {
+            eprintln!("Could not read cleanup confirmation: {error}");
+            return false;
+        }
     }
 
     let mode = if args.permanent {
@@ -61,17 +70,19 @@ pub fn execute(args: &CleanArgs) {
         Ok(res) => res,
         Err(e) => {
             eprintln!("Cleanup failed: {}", e);
-            return;
+            return false;
         }
     };
     history::record(mode, &result)
         .unwrap_or_else(|e| eprintln!("Failed to record cleanup history: {}", e));
 
     print_cleanup_result(&result);
+
+    true
 }
 
 fn build_cleanup_plan(args: &CleanArgs) -> Result<CleanupPlan, DustError> {
-    let path = resolve_path(&args.path_args.path);
+    let path = resolve_path(&args.path_args.path)?;
 
     if !validate_path(&path) {
         return Err(DustError::InvalidPath(path));
@@ -89,18 +100,15 @@ fn build_cleanup_plan(args: &CleanArgs) -> Result<CleanupPlan, DustError> {
     Ok(plan)
 }
 
-fn confirm_cleanup() -> bool {
+fn confirm_cleanup() -> io::Result<bool> {
     print!("Continue? (y/N): ");
-
-    io::stdout().flush().expect("Failed to flush stdout");
+    io::stdout().flush()?;
 
     let mut input = String::new();
 
-    io::stdin()
-        .read_line(&mut input)
-        .expect("Failed to read input");
+    io::stdin().read_line(&mut input)?;
 
-    matches!(input.trim(), "y" | "Y")
+    Ok(matches!(input.trim(), "y" | "Y"))
 }
 
 fn print_cleanup_plan(plan: &CleanupPlan) {

--- a/apps/dustfril-cli/src/commands/clean.rs
+++ b/apps/dustfril-cli/src/commands/clean.rs
@@ -78,7 +78,11 @@ pub fn execute(args: &CleanArgs) -> bool {
 
     print_cleanup_result(&result);
 
-    true
+    cleanup_succeeded(&result)
+}
+
+fn cleanup_succeeded(result: &CleanupResult) -> bool {
+    result.failed_paths.is_empty()
 }
 
 fn build_cleanup_plan(args: &CleanArgs) -> Result<CleanupPlan, DustError> {
@@ -150,5 +154,29 @@ fn print_cleanup_result(result: &CleanupResult) {
         for failure in &result.failed_paths {
             println!("  {} ({})", failure.path.display(), failure.reason);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dustfril_core::models::{CleanupFailure, CleanupFailureReason};
+
+    #[test]
+    fn incomplete_cleanup_is_reported_as_a_command_failure() {
+        let result = CleanupResult {
+            failed_paths: vec![CleanupFailure {
+                path: "target".into(),
+                reason: CleanupFailureReason::PermissionDenied,
+            }],
+            ..CleanupResult::default()
+        };
+
+        assert!(!cleanup_succeeded(&result));
+    }
+
+    #[test]
+    fn complete_cleanup_is_reported_as_a_command_success() {
+        assert!(cleanup_succeeded(&CleanupResult::default()));
     }
 }

--- a/apps/dustfril-cli/src/commands/scan.rs
+++ b/apps/dustfril-cli/src/commands/scan.rs
@@ -5,12 +5,17 @@ use crate::{
     shared::path::{resolve_path, validate_path},
 };
 
-pub fn execute(args: PathArgs) {
-    let path = resolve_path(&args.path);
+pub fn execute(args: PathArgs) -> bool {
+    let path = match resolve_path(&args.path) {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("Failed to resolve path: {error}");
+            return false;
+        }
+    };
 
     if !validate_path(&path) {
-        eprintln!("Invalid path");
-        return;
+        return false;
     }
 
     let ecosystems = args.ecosystems();
@@ -19,20 +24,25 @@ pub fn execute(args: PathArgs) {
         Ok(res) => res,
         Err(e) => {
             eprintln!("Scan failed: {}", e);
-            return;
+            return false;
         }
     };
 
-    let total_size_bytes = api::analyze(result.clone())
-        .map(|analysis| analysis.total_size_bytes)
-        .unwrap_or_default();
-    if let Err(error) = api::history::record_scan(&path, &result, total_size_bytes) {
-        eprintln!("Failed to record scan history: {error}");
+    match api::analyze(result.clone()) {
+        Ok(analysis) => {
+            if let Err(error) = api::history::record_scan(&path, &result, analysis.total_size_bytes)
+            {
+                eprintln!("Failed to record scan history: {error}");
+            }
+        }
+        Err(error) => {
+            eprintln!("Failed to calculate scan size; history was not recorded: {error}");
+        }
     }
 
     if result.artifacts.is_empty() {
         println!("No artifacts found.");
-        return;
+        return true;
     }
 
     println!("Found {} artifact(s)\n", result.artifacts.len());
@@ -40,4 +50,6 @@ pub fn execute(args: PathArgs) {
     for artifact in result.artifacts {
         println!("  [{}] {}", artifact.ecosystem, artifact.path.display());
     }
+
+    true
 }

--- a/apps/dustfril-cli/src/commands/security.rs
+++ b/apps/dustfril-cli/src/commands/security.rs
@@ -6,12 +6,17 @@ use crate::{
     shared::path::{resolve_path, validate_path},
 };
 
-pub fn scan(args: &PathArgs) {
-    let path = resolve_path(&args.path);
+pub fn scan(args: &PathArgs) -> bool {
+    let path = match resolve_path(&args.path) {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("Failed to resolve path: {error}");
+            return false;
+        }
+    };
 
     if !validate_path(&path) {
-        eprintln!("Invalid path");
-        return;
+        return false;
     }
 
     let ecosystems = args.ecosystems();
@@ -20,14 +25,16 @@ pub fn scan(args: &PathArgs) {
         Ok(warnings) => warnings,
         Err(error) => {
             eprintln!("Security scan failed: {error}");
-            return;
+            return false;
         }
     };
 
     if warnings.is_empty() {
         println!("No suspicious lifecycle scripts detected.");
-        return;
+        return true;
     }
 
     format::print_security_report(&warnings);
+
+    true
 }

--- a/apps/dustfril-cli/src/main.rs
+++ b/apps/dustfril-cli/src/main.rs
@@ -5,37 +5,36 @@ mod history;
 mod shared;
 
 use clap::Parser;
+use std::process::ExitCode;
 
 use cli::{Cli, Commands};
 
-fn main() {
+fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    match cli.command {
-        Commands::Scan(args) => {
-            commands::scan::execute(args);
-        }
+    let succeeded = match cli.command {
+        Commands::Scan(args) => commands::scan::execute(args),
 
-        Commands::Analyze(args) => {
-            commands::analyze::execute(args);
-        }
+        Commands::Analyze(args) => commands::analyze::execute(args),
 
         Commands::Clean(args) => {
             if args.dry_run {
-                commands::clean::dry_run(&args);
+                commands::clean::dry_run(&args)
             } else {
-                commands::clean::execute(&args);
+                commands::clean::execute(&args)
             }
         }
 
-        Commands::Audit(args) => {
-            commands::audit::execute(&args);
-        }
+        Commands::Audit(args) => commands::audit::execute(&args),
 
         Commands::Security(args) => match args.command {
-            cli::SecurityCommands::Scan(args) => {
-                commands::security::scan(&args);
-            }
+            cli::SecurityCommands::Scan(args) => commands::security::scan(&args),
         },
+    };
+
+    if succeeded {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
     }
 }

--- a/apps/dustfril-cli/src/shared/path.rs
+++ b/apps/dustfril-cli/src/shared/path.rs
@@ -1,22 +1,32 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
 
-/// Returns `true` when the given path exists on disk.
+/// Returns `true` when the given path is an accessible directory.
 pub fn validate_path(path: &Path) -> bool {
-    if !path.exists() {
-        eprintln!("Path does not exist: {}", path.display());
-
-        return false;
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            eprintln!("Path must not be a symbolic link: {}", path.display());
+            false
+        }
+        Ok(metadata) if metadata.is_dir() => true,
+        Ok(_) => {
+            eprintln!("Path is not a directory: {}", path.display());
+            false
+        }
+        Err(error) => {
+            eprintln!("Cannot access path {}: {error}", path.display());
+            false
+        }
     }
-
-    true
 }
 
 /// Resolves an optional CLI path to an explicit filesystem path.
 ///
 /// When no path is provided, the current working directory is used.
-pub fn resolve_path(path: &Option<PathBuf>) -> PathBuf {
-    path.clone()
-        .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"))
+pub fn resolve_path(path: &Option<PathBuf>) -> io::Result<PathBuf> {
+    path.clone().map(Ok).unwrap_or_else(std::env::current_dir)
 }
 
 #[cfg(test)]
@@ -30,18 +40,44 @@ mod tests {
 
     #[test]
     fn validate_path_returns_false_for_missing_path() {
-        let missing = std::env::temp_dir().join("dustfril-cli-missing-path");
+        let missing = tempfile::tempdir().unwrap().path().join("missing");
         assert!(!validate_path(&missing));
+    }
+
+    #[test]
+    fn validate_path_returns_false_for_a_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("file");
+        std::fs::write(&file, "not a directory").unwrap();
+
+        assert!(!validate_path(&file));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_path_returns_false_for_a_symbolic_link() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        let link = temp.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        assert!(!validate_path(&link));
     }
 
     #[test]
     fn resolve_path_returns_explicit_path_when_provided() {
         let path = PathBuf::from("/tmp/dustfril-explicit");
-        assert_eq!(resolve_path(&Some(path.clone())), path);
+        assert_eq!(resolve_path(&Some(path.clone())).unwrap(), path);
     }
 
     #[test]
     fn resolve_path_uses_current_dir_when_not_provided() {
-        assert_eq!(resolve_path(&None), std::env::current_dir().unwrap());
+        assert_eq!(
+            resolve_path(&None).unwrap(),
+            std::env::current_dir().unwrap()
+        );
     }
 }

--- a/apps/dustfril-tauri/src-tauri/src/history.rs
+++ b/apps/dustfril-tauri/src-tauri/src/history.rs
@@ -98,3 +98,47 @@ fn cleanup_entry_to_dto(
             .collect(),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract::DeleteModeDto;
+    use dustfril_core::models::{ActivityResult, CleanupHistoryEntry};
+    use serde_json::json;
+
+    #[test]
+    fn activity_record_conversion_preserves_kind_and_result() {
+        let entry = ActivityRecord::new(
+            ActivityKind::Security,
+            ActivityResult::new(true, json!({"warnings": 0})),
+        );
+
+        let dto = activity_record_to_dto(entry).unwrap();
+
+        assert_eq!(dto.kind, "Security");
+        assert!(dto.timestamp_ms > 0);
+        assert_eq!(dto.result.details["warnings"], 0);
+    }
+
+    #[test]
+    fn cleanup_entry_conversion_maps_paths_and_mode() {
+        let entry = CleanupHistoryEntry {
+            executed_at: ActivityRecord::new(
+                ActivityKind::Cleanup,
+                ActivityResult::new(true, json!({})),
+            )
+            .timestamp,
+            mode: DeleteMode::Permanent,
+            freed_size_bytes: 10,
+            deleted_paths: vec!["target".into()],
+            failed_paths: vec!["node_modules".into()],
+        };
+
+        let dto = cleanup_entry_to_dto(entry).unwrap();
+
+        assert_eq!(dto.mode, DeleteModeDto::Permanent);
+        assert_eq!(dto.freed_size_bytes, 10);
+        assert_eq!(dto.deleted_paths, vec!["target"]);
+        assert_eq!(dto.failed_paths, vec!["node_modules"]);
+    }
+}

--- a/apps/dustfril-tauri/src-tauri/src/lib.rs
+++ b/apps/dustfril-tauri/src-tauri/src/lib.rs
@@ -2,7 +2,8 @@ mod contract;
 mod history;
 
 use std::{
-    env,
+    env, fs,
+    io::ErrorKind,
     path::{Path, PathBuf},
     time::UNIX_EPOCH,
 };
@@ -21,10 +22,18 @@ fn resolve_root(root: Option<String>) -> Result<PathBuf, String> {
     match root.map(|value| value.trim().to_string()) {
         Some(value) if !value.is_empty() => {
             let path = PathBuf::from(value);
-            if !path.exists() {
-                return Err(format!("Path does not exist: {}", path.display()));
+            match fs::symlink_metadata(&path) {
+                Ok(metadata) if metadata.file_type().is_symlink() => Err(format!(
+                    "Path must not be a symbolic link: {}",
+                    path.display()
+                )),
+                Ok(metadata) if metadata.is_dir() => Ok(path),
+                Ok(_) => Err(format!("Path is not a directory: {}", path.display())),
+                Err(error) if error.kind() == ErrorKind::NotFound => {
+                    Err(format!("Path does not exist: {}", path.display()))
+                }
+                Err(error) => Err(format!("Cannot access path {}: {error}", path.display())),
             }
-            Ok(path)
         }
         _ => default_root_path(),
     }

--- a/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
@@ -338,6 +338,9 @@ export function useAppState() {
       const result = await executeCleanup(candidates, deleteMode);
 
       setCleanupResult(result);
+      if (result.failedPaths.length) {
+        setError(formatCleanupFailure(result));
+      }
       setCleanupPlan((current) =>
         current
           ? {
@@ -403,4 +406,12 @@ export function useAppState() {
     handleRequestCleanup,
     handleConfirmCleanup,
   };
+}
+
+function formatCleanupFailure(result: CleanupResultResponse): string {
+  const failures = result.failedPaths
+    .map((failure) => `${failure.path} (${failure.reason})`)
+    .join('; ');
+
+  return `Cleanup completed with ${result.failedPaths.length} failure(s). Freed ${formatBytes(result.freedSizeBytes)}. Failed: ${failures}`;
 }

--- a/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
@@ -54,10 +54,12 @@ export function useAppState() {
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [lastScanAtMs, setLastScanAtMs] = useState<number | null>(null);
   const previousRootRef = useRef<string | null>(null);
+  const workspaceRequestRef = useRef(0);
+  const actionRequestRef = useRef(0);
 
   useEffect(() => {
     defaultRoot()
-      .then(setRoot)
+      .then(handleRootChange)
       .catch((invokeError) => setError(String(invokeError)));
 
     loadActivityHistory()
@@ -228,24 +230,34 @@ export function useAppState() {
   const confirmSamplePaths = selectedCleanupPaths.slice(0, 5);
 
   async function runAction(action: string, runner: () => Promise<void>) {
+    const requestId = ++actionRequestRef.current;
     setBusyAction(action);
     setError(null);
 
     try {
       await runner();
     } catch (invokeError) {
-      setError(String(invokeError));
+      if (requestId === actionRequestRef.current) {
+        setError(String(invokeError));
+      }
     } finally {
-      setBusyAction(null);
+      if (requestId === actionRequestRef.current) {
+        setBusyAction(null);
+      }
     }
   }
 
   async function refreshWorkspaceData(options: RunOptions) {
+    const requestId = ++workspaceRequestRef.current;
     const [scan, analysis, plan] = await Promise.all([
       scanArtifacts(options),
       analyzeArtifacts(options),
       buildCleanupPlan(options),
     ]);
+
+    if (requestId !== workspaceRequestRef.current) {
+      return;
+    }
 
     setScanResult(scan);
     setAnalysisResult(analysis);
@@ -253,6 +265,25 @@ export function useAppState() {
     setSelectedCleanupPaths(plan.candidates.map((candidate) => candidate.path));
     setLastScanAtMs(Date.now());
     setHistoryEntries(await loadActivityHistory());
+  }
+
+  function handleRootChange(nextRoot: string) {
+    if (nextRoot === root) {
+      return;
+    }
+
+    workspaceRequestRef.current += 1;
+    setRoot(nextRoot);
+    setError(null);
+    setScanResult(null);
+    setAnalysisResult(null);
+    setCleanupPlan(null);
+    setCleanupResult(null);
+    setSelectedCleanupPaths([]);
+    setSelectedItemId(null);
+    setConfirmDialogOpen(false);
+    setLastScanAtMs(null);
+    setExplorerWorkflow('scan');
   }
 
   function toggleCleanupPath(path: string) {
@@ -358,7 +389,7 @@ export function useAppState() {
     supportedEcosystems: ecosystems,
     isLanguageCategory,
     isFutureCategory,
-    setRoot,
+    setRoot: handleRootChange,
     setSearch,
     setActiveCategory,
     setExplorerWorkflow,

--- a/apps/dustfril-tauri/src/lib/tauri.ts
+++ b/apps/dustfril-tauri/src/lib/tauri.ts
@@ -18,6 +18,7 @@ const commands = {
   buildCleanupPlan: 'build_cleanup_plan',
   audit: 'audit',
   executeCleanup: 'execute_cleanup',
+  loadActivityHistory: 'load_activity_history',
   loadCleanupHistory: 'load_cleanup_history',
 } as const;
 
@@ -48,5 +49,5 @@ export function executeCleanup(candidates: CleanupCandidate[], mode: DeleteMode)
 }
 
 export function loadActivityHistory() {
-  return invoke<ActivityRecord[]>('load_activity_history');
+  return invoke<ActivityRecord[]>(commands.loadActivityHistory);
 }

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -10,11 +10,16 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - `api::analyze`: compute size, age, and cleanup recommendation
 - `api::clean::build_plan`: build cleanup candidates from scan results
 - `api::clean::execute`: execute cleanup in Trash or permanent mode
-- `api::audit`: inspect supported lifecycle scripts
+- `api::audit`: inspect supported lifecycle scripts; malformed manifests are
+  returned as errors instead of being silently ignored
 - `api::history`: record and load versioned activity history, including cleanup-history migration
 - `api::security_scan`: detect suspicious lifecycle commands without executing them
 - `api::check_lockfile_integrity`: check supported lockfile presence and Git status
-- `api::history`: record and load cleanup history
+- `api::history`: record and load cleanup history using atomic replacement;
+  corrupted or unsupported history files are returned as errors
+
+Cleanup execution validates artifact type and protected paths, refuses
+symbolic links, and never falls back from Trash mode to permanent deletion.
 
 ## Supported Coverage
 

--- a/crates/dustfril-core/src/analyzer/analyze.rs
+++ b/crates/dustfril-core/src/analyzer/analyze.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use std::time::SystemTime;
+use std::{fs, path::Path};
 
 use crate::error::DustResult;
 use crate::models::{
@@ -21,7 +21,10 @@ impl Analyzer {
 
         artifacts.sort_by_key(|artifact| std::cmp::Reverse(artifact.size_bytes));
 
-        let total_size_bytes = artifacts.iter().map(|a| a.size_bytes).sum();
+        let total_size_bytes = artifacts
+            .iter()
+            .map(|artifact| artifact.size_bytes)
+            .fold(0, u64::saturating_add);
 
         Ok(AnalysisResult {
             artifacts,
@@ -30,8 +33,7 @@ impl Analyzer {
     }
 
     fn analyze_artifact(artifact: Artifact) -> ArtifactAnalysis {
-        let size_bytes = calculate_directory_size(&artifact.path);
-        let last_modified = find_latest_modified(&artifact.path);
+        let (size_bytes, last_modified) = calculate_artifact_metadata(&artifact.path);
         let age_days = calculate_age_days(last_modified);
         let recommendation = recommend_cleanup(age_days);
 
@@ -71,24 +73,62 @@ fn recommend_cleanup(age_days: Option<u64>) -> CleanupRecommendation {
     }
 }
 
-fn calculate_directory_size(path: &Path) -> u64 {
+fn calculate_artifact_metadata(path: &Path) -> (u64, Option<SystemTime>) {
     WalkDir::new(path)
         .into_iter()
         .filter_map(Result::ok)
         .filter_map(|entry| {
-            entry
-                .metadata()
-                .ok()
-                .filter(|metadata| metadata.is_file())
-                .map(|metadata| metadata.len())
+            let metadata = fs::symlink_metadata(entry.path()).ok()?;
+            let size = if metadata.is_file() {
+                metadata.len()
+            } else {
+                0
+            };
+            let modified = metadata.modified().ok();
+
+            Some((size, modified))
         })
-        .sum()
+        .fold(
+            (0, None),
+            |(size, latest_modified), (entry_size, modified)| {
+                (
+                    size.saturating_add(entry_size),
+                    latest_modified.max(modified),
+                )
+            },
+        )
 }
 
-fn find_latest_modified(path: &Path) -> Option<SystemTime> {
-    WalkDir::new(path)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter_map(|entry| entry.metadata().ok()?.modified().ok())
-        .max()
+#[cfg(test)]
+mod tests {
+    use super::{calculate_age_days, recommend_cleanup};
+    use crate::models::CleanupRecommendation;
+
+    #[test]
+    fn cleanup_recommendations_use_documented_age_boundaries() {
+        assert_eq!(recommend_cleanup(None), CleanupRecommendation::NeedsReview);
+        assert_eq!(recommend_cleanup(Some(30)), CleanupRecommendation::Keep);
+        assert_eq!(
+            recommend_cleanup(Some(31)),
+            CleanupRecommendation::NeedsReview
+        );
+        assert_eq!(
+            recommend_cleanup(Some(90)),
+            CleanupRecommendation::NeedsReview
+        );
+        assert_eq!(
+            recommend_cleanup(Some(91)),
+            CleanupRecommendation::SafeToClean
+        );
+    }
+
+    #[test]
+    fn future_modification_times_have_unknown_age() {
+        assert_eq!(
+            calculate_age_days(Some(
+                std::time::SystemTime::now() + std::time::Duration::from_secs(1),
+            )),
+            None
+        );
+    }
 }

--- a/crates/dustfril-core/src/analyzer/tests.rs
+++ b/crates/dustfril-core/src/analyzer/tests.rs
@@ -44,12 +44,10 @@ fn analyze_sets_cleanup_recommendation() {
     let analysis =
         Analyzer::analyze(scan_result(dir.path().to_path_buf(), Ecosystem::Rust)).unwrap();
 
-    assert!(matches!(
+    assert_eq!(
         analysis.artifacts[0].recommendation,
         CleanupRecommendation::Keep
-            | CleanupRecommendation::NeedsReview
-            | CleanupRecommendation::SafeToClean
-    ));
+    );
 }
 
 #[test]
@@ -120,4 +118,25 @@ fn analyze_preserves_artifact_metadata() {
     assert_eq!(artifact.artifact.ecosystem, Ecosystem::Node);
 
     assert_eq!(artifact.artifact.path, dir.path());
+}
+
+#[cfg(unix)]
+#[test]
+fn analyze_does_not_count_files_reached_through_symbolic_links() {
+    use std::os::unix::fs::symlink;
+
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    fs::write(outside.path().join("outside.txt"), b"outside").unwrap();
+    symlink(
+        outside.path().join("outside.txt"),
+        root.path().join("link.txt"),
+    )
+    .unwrap();
+
+    let analysis =
+        Analyzer::analyze(scan_result(root.path().to_path_buf(), Ecosystem::Rust)).unwrap();
+
+    assert_eq!(analysis.artifacts[0].size_bytes, 0);
+    assert_eq!(analysis.total_size_bytes, 0);
 }

--- a/crates/dustfril-core/src/api/clean.rs
+++ b/crates/dustfril-core/src/api/clean.rs
@@ -76,7 +76,7 @@ mod tests {
             }],
         };
 
-        let result = execute(&plan, DeleteMode::default()).unwrap();
+        let result = execute(&plan, DeleteMode::Permanent).unwrap();
 
         assert!(!target.exists());
         assert_eq!(result.deleted_paths, vec![target]);

--- a/crates/dustfril-core/src/api/history.rs
+++ b/crates/dustfril-core/src/api/history.rs
@@ -80,3 +80,63 @@ fn cleanup_entry(activity: ActivityRecord) -> Option<CleanupHistoryEntry> {
         failed_paths,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::models::{ActivityKind, ActivityResult};
+
+    #[test]
+    fn cleanup_history_projection_preserves_cleanup_details() {
+        let activity = ActivityRecord {
+            id: "activity-1".to_owned(),
+            timestamp: chrono::DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            kind: ActivityKind::Cleanup,
+            result: ActivityResult::new(
+                false,
+                json!({
+                    "mode": "permanent",
+                    "deleted": ["target"],
+                    "failed": [{"path": "node_modules", "reason": "NotFound"}],
+                    "freed": 2048
+                }),
+            ),
+        };
+
+        let entry = cleanup_entry(activity).unwrap();
+
+        assert_eq!(entry.mode, DeleteMode::Permanent);
+        assert_eq!(entry.freed_size_bytes, 2048);
+        assert_eq!(
+            entry.deleted_paths,
+            vec![std::path::PathBuf::from("target")]
+        );
+        assert_eq!(
+            entry.failed_paths,
+            vec![std::path::PathBuf::from("node_modules")]
+        );
+    }
+
+    #[test]
+    fn cleanup_history_projection_ignores_non_cleanup_or_invalid_records() {
+        let scan = ActivityRecord {
+            id: "scan-1".to_owned(),
+            timestamp: chrono::Utc::now(),
+            kind: ActivityKind::Scan,
+            result: ActivityResult::new(true, json!({})),
+        };
+        let invalid_cleanup = ActivityRecord {
+            id: "cleanup-1".to_owned(),
+            timestamp: chrono::Utc::now(),
+            kind: ActivityKind::Cleanup,
+            result: ActivityResult::new(true, json!({"mode": "unknown"})),
+        };
+
+        assert!(cleanup_entry(scan).is_none());
+        assert!(cleanup_entry(invalid_cleanup).is_none());
+    }
+}

--- a/crates/dustfril-core/src/api/scan.rs
+++ b/crates/dustfril-core/src/api/scan.rs
@@ -32,4 +32,17 @@ mod tests {
         assert_eq!(result.artifacts[0].path, target);
         assert_eq!(result.artifacts[0].ecosystem, Ecosystem::Rust);
     }
+
+    #[test]
+    fn scan_rejects_a_missing_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let missing = temp_dir.path().join("missing");
+
+        let result = scan(&missing, &[]);
+
+        assert!(matches!(
+            result,
+            Err(crate::error::DustError::InvalidPath(path)) if path == missing
+        ));
+    }
 }

--- a/crates/dustfril-core/src/audit_tool/lifecycle.rs
+++ b/crates/dustfril-core/src/audit_tool/lifecycle.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashMap, fs, path::Path};
+use std::{collections::BTreeMap, fs, path::Path};
 
 use serde::Deserialize;
 
 use crate::{
     audit_tool::{self, package_manager},
-    error::DustResult,
+    error::{DustError, DustResult},
     fs::walk_dirs,
     models::{LifecycleScript, ScriptType},
 };
@@ -12,14 +12,14 @@ use crate::{
 #[derive(Debug, Deserialize)]
 struct PackageJson {
     name: Option<String>,
-    scripts: Option<HashMap<String, String>>,
+    scripts: Option<BTreeMap<String, String>>,
 }
 
 /// Scans package.json files under supported Node package managers and returns lifecycle scripts.
 pub fn audit_scan(root: &Path) -> DustResult<Vec<LifecycleScript>> {
     let mut scripts = Vec::new();
 
-    for dir in walk_dirs(root) {
+    for dir in walk_dirs(root)? {
         let package_json = dir.join("package.json");
 
         if !package_json.is_file() {
@@ -38,33 +38,41 @@ fn audit_scan_package(
     package_manager: crate::models::PackageManager,
 ) -> DustResult<Vec<LifecycleScript>> {
     let json = fs::read_to_string(path)?;
+    let package = parse_package_json(path, &json)?;
 
-    let package: PackageJson = serde_json::from_str(&json).unwrap_or(PackageJson {
-        name: None,
-        scripts: None,
-    });
+    Ok(lifecycle_scripts(package, package_manager))
+}
 
-    let mut result = Vec::new();
+fn parse_package_json(path: &Path, json: &str) -> DustResult<PackageJson> {
+    let package: PackageJson = serde_json::from_str(json)
+        .map_err(|error| DustError::Manifest(format!("{}: {error}", path.display())))?;
+
+    Ok(package)
+}
+
+fn lifecycle_scripts(
+    package: PackageJson,
+    package_manager: crate::models::PackageManager,
+) -> Vec<LifecycleScript> {
+    let mut result: Vec<LifecycleScript> = Vec::new();
 
     let Some(scripts) = package.scripts else {
-        return Ok(result);
+        return result;
     };
 
     let package_name = package.name.unwrap_or_else(|| "<unknown>".into());
 
-    for (name, command) in scripts {
-        let Some(script_type) = ScriptType::from_script_name(&name) else {
-            continue;
-        };
+    result.extend(scripts.into_iter().filter_map(|(name, command)| {
+        let script_type = ScriptType::from_script_name(&name)?;
 
-        result.push(LifecycleScript {
+        Some(LifecycleScript {
             package: package_name.clone(),
             package_manager,
             script_type,
-            command: command.clone(),
             risk_level: audit_tool::classify(&command),
-        });
-    }
+            command,
+        })
+    }));
 
-    Ok(result)
+    result
 }

--- a/crates/dustfril-core/src/audit_tool/lifecycle_tests.rs
+++ b/crates/dustfril-core/src/audit_tool/lifecycle_tests.rs
@@ -2,6 +2,7 @@ use tempfile::TempDir;
 
 use crate::{
     audit_tool::audit_scan,
+    error::DustError,
     models::{PackageManager, RiskLevel, ScriptType},
 };
 
@@ -106,5 +107,17 @@ fn security_scan_detects_required_warning_patterns_and_ignores_normal_scripts() 
         !warnings
             .iter()
             .any(|warning| warning.script_type == "prepare")
+    );
+}
+
+#[test]
+fn audit_scan_reports_malformed_package_json() {
+    let temp_dir = TempDir::new().unwrap();
+    std::fs::write(temp_dir.path().join("package.json"), "{invalid json").unwrap();
+
+    let result = audit_scan(temp_dir.path());
+
+    assert!(
+        matches!(result, Err(DustError::Manifest(message)) if message.contains("package.json"))
     );
 }

--- a/crates/dustfril-core/src/cleaner/executor.rs
+++ b/crates/dustfril-core/src/cleaner/executor.rs
@@ -1,5 +1,7 @@
 use std::{fs, io, path::Path};
 
+use directories::BaseDirs;
+
 use crate::{
     error::DustResult,
     models::{
@@ -40,7 +42,7 @@ pub fn execute_cleanup(plan: &CleanupPlan, mode: DeleteMode) -> DustResult<Clean
     Ok(result)
 }
 
-pub fn delete_path(path: &Path, mode: DeleteMode) -> io::Result<()> {
+fn delete_path(path: &Path, mode: DeleteMode) -> io::Result<()> {
     match mode {
         DeleteMode::Trash => move_to_trash(path),
         DeleteMode::Permanent => permanently_delete(path),
@@ -48,22 +50,35 @@ pub fn delete_path(path: &Path, mode: DeleteMode) -> io::Result<()> {
 }
 
 fn permanently_delete(path: &Path) -> io::Result<()> {
-    let metadata = fs::metadata(path)?;
+    let metadata = fs::symlink_metadata(path)?;
 
-    if metadata.is_dir() {
-        fs::remove_dir_all(path)
-    } else {
-        fs::remove_file(path)
+    if metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "refusing to delete a symbolic link",
+        ));
     }
+
+    if !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "refusing to delete a non-directory artifact",
+        ));
+    }
+
+    fs::remove_dir_all(path)
 }
 
 fn move_to_trash(path: &Path) -> io::Result<()> {
-    // TODO: Revisit trash behavior per platform and replace this fallback with
-    // a stricter capability check once audit/cleanup UX is finalized.
-    match trash::delete(path) {
-        Ok(()) if !path.exists() => Ok(()),
-        Ok(()) | Err(_) => permanently_delete(path),
+    trash::delete(path).map_err(|error| io::Error::other(error.to_string()))?;
+
+    if path.exists() {
+        return Err(io::Error::other(
+            "trash operation completed but the artifact is still present",
+        ));
     }
+
+    Ok(())
 }
 
 fn failure_reason(error: &io::Error) -> CleanupFailureReason {
@@ -78,6 +93,10 @@ fn validate_candidate(candidate: &CleanupCandidate) -> Result<(), CleanupFailure
     let metadata = fs::symlink_metadata(&candidate.path).map_err(|e| failure_reason(&e))?;
     if metadata.file_type().is_symlink() {
         return Err(CleanupFailureReason::SymbolicLink);
+    }
+
+    if !metadata.is_dir() {
+        return Err(CleanupFailureReason::UnsafePath);
     }
 
     if !is_safe_cleanup_candidate(candidate) {
@@ -96,5 +115,33 @@ fn is_safe_cleanup_candidate(candidate: &CleanupCandidate) -> bool {
         return false;
     };
 
-    detector.artifact_paths().contains(&name)
+    if !detector.artifact_paths().contains(&name) {
+        return false;
+    }
+
+    let Ok(canonical_path) = fs::canonicalize(&candidate.path) else {
+        return false;
+    };
+
+    // Never remove a directory directly below a filesystem root, the current
+    // working directory, or the user's home directory. The plan does not carry
+    // a project root, so these checks provide a conservative final boundary at
+    // execution time.
+    if is_protected_path(&canonical_path) {
+        return false;
+    }
+
+    true
+}
+
+pub(super) fn is_protected_path(path: &Path) -> bool {
+    path.parent()
+        .map(|parent| parent.parent().is_none())
+        .unwrap_or(true)
+        || std::env::current_dir()
+            .map(|current_dir| path == current_dir)
+            .unwrap_or(false)
+        || BaseDirs::new()
+            .map(|base_dirs| path == base_dirs.home_dir())
+            .unwrap_or(false)
 }

--- a/crates/dustfril-core/src/cleaner/tests.rs
+++ b/crates/dustfril-core/src/cleaner/tests.rs
@@ -152,7 +152,7 @@ fn execute_cleanup_removes_target_directory() {
         candidates: vec![candidate],
     };
 
-    let result = execute_cleanup(&plan, DeleteMode::default()).unwrap();
+    let result = execute_cleanup(&plan, DeleteMode::Permanent).unwrap();
 
     assert!(!target_dir.exists());
     assert_eq!(result.deleted_paths.len(), 1);
@@ -253,4 +253,66 @@ fn execute_cleanup_rejects_unsafe_path() {
         result.failed_paths[0].reason,
         CleanupFailureReason::UnsafePath
     );
+}
+
+#[test]
+fn execute_cleanup_rejects_a_regular_file_with_an_artifact_name() {
+    let temp = TempDir::new().unwrap();
+    let target = temp.path().join("target");
+    fs::write(&target, "not a directory").unwrap();
+
+    let plan = CleanupPlan {
+        candidates: vec![CleanupCandidate {
+            path: target.clone(),
+            ecosystem: Ecosystem::Rust,
+            size_bytes: 0,
+            age_days: None,
+        }],
+    };
+
+    let result = execute_cleanup(&plan, DeleteMode::Permanent).unwrap();
+
+    assert!(target.exists());
+    assert_eq!(
+        result.failed_paths[0].reason,
+        CleanupFailureReason::UnsafePath
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn execute_cleanup_rejects_symbolic_link_candidates() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let real_target = temp.path().join("real-target");
+    let link = temp.path().join("target");
+    fs::create_dir(&real_target).unwrap();
+    symlink(&real_target, &link).unwrap();
+
+    let plan = CleanupPlan {
+        candidates: vec![CleanupCandidate {
+            path: link.clone(),
+            ecosystem: Ecosystem::Rust,
+            size_bytes: 0,
+            age_days: None,
+        }],
+    };
+
+    let result = execute_cleanup(&plan, DeleteMode::Permanent).unwrap();
+
+    assert!(link.exists());
+    assert!(real_target.exists());
+    assert_eq!(
+        result.failed_paths[0].reason,
+        CleanupFailureReason::SymbolicLink
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn protected_path_check_rejects_direct_children_of_filesystem_root() {
+    assert!(super::executor::is_protected_path(&PathBuf::from(
+        "/target"
+    )));
 }

--- a/crates/dustfril-core/src/error.rs
+++ b/crates/dustfril-core/src/error.rs
@@ -50,7 +50,14 @@ impl fmt::Display for DustError {
     }
 }
 
-impl std::error::Error for DustError {}
+impl std::error::Error for DustError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl From<std::io::Error> for DustError {
     fn from(error: std::io::Error) -> Self {
@@ -70,6 +77,13 @@ mod tests {
         let error = DustError::from(io::Error::other("boom"));
 
         assert!(matches!(error, DustError::Io(_)));
+    }
+
+    #[test]
+    fn io_errors_expose_their_source() {
+        let error = DustError::from(io::Error::other("boom"));
+
+        assert!(std::error::Error::source(&error).is_some());
     }
 
     #[test]

--- a/crates/dustfril-core/src/fs/walk.rs
+++ b/crates/dustfril-core/src/fs/walk.rs
@@ -1,14 +1,38 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
 use walkdir::WalkDir;
 
-/// Collect all directories in filesystem tree.
-/// No logic, no filtering.
-pub fn walk_dirs(root: &Path) -> Vec<PathBuf> {
+use crate::error::{DustError, DustResult};
+
+/// Collect all directories in a filesystem tree.
+///
+/// Invalid or symbolic-link roots and traversal errors are returned instead of
+/// being silently omitted from the result.
+pub fn walk_dirs(root: &Path) -> DustResult<Vec<PathBuf>> {
+    match fs::symlink_metadata(root) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(DustError::InvalidPath(root.to_path_buf()));
+        }
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => return Err(DustError::InvalidPath(root.to_path_buf())),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Err(DustError::InvalidPath(root.to_path_buf()));
+        }
+        Err(error) => return Err(DustError::Io(error)),
+    }
+
     WalkDir::new(root)
         .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().is_dir())
-        .map(|e| e.path().to_path_buf())
+        .map(|entry| {
+            let entry = entry.map_err(|error| DustError::Io(io::Error::other(error)))?;
+            Ok(entry
+                .file_type()
+                .is_dir()
+                .then(|| entry.path().to_path_buf()))
+        })
+        .filter_map(|entry| entry.transpose())
         .collect()
 }
 
@@ -24,10 +48,50 @@ mod tests {
         let nested = temp_dir.path().join("a").join("b");
         std::fs::create_dir_all(&nested).unwrap();
 
-        let dirs = walk_dirs(temp_dir.path());
+        let dirs = walk_dirs(temp_dir.path()).unwrap();
 
         assert!(dirs.iter().any(|path| path == temp_dir.path()));
         assert!(dirs.iter().any(|path| path == &temp_dir.path().join("a")));
         assert!(dirs.iter().any(|path| path == &nested));
+    }
+
+    #[test]
+    fn walk_dirs_rejects_missing_roots() {
+        let temp_dir = TempDir::new().unwrap();
+        let missing = temp_dir.path().join("missing");
+
+        assert!(matches!(
+            walk_dirs(&missing),
+            Err(DustError::InvalidPath(path)) if path == missing
+        ));
+    }
+
+    #[test]
+    fn walk_dirs_rejects_file_roots() {
+        let temp_dir = TempDir::new().unwrap();
+        let file = temp_dir.path().join("file");
+        std::fs::write(&file, "not a directory").unwrap();
+
+        assert!(matches!(
+            walk_dirs(&file),
+            Err(DustError::InvalidPath(path)) if path == file
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_dirs_rejects_symlink_roots() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = TempDir::new().unwrap();
+        let real_root = temp_dir.path().join("real-root");
+        let link = temp_dir.path().join("link");
+        std::fs::create_dir(&real_root).unwrap();
+        symlink(&real_root, &link).unwrap();
+
+        assert!(matches!(
+            walk_dirs(&link),
+            Err(DustError::InvalidPath(path)) if path == link
+        ));
     }
 }

--- a/crates/dustfril-core/src/history/mod.rs
+++ b/crates/dustfril-core/src/history/mod.rs
@@ -1,5 +1,6 @@
 use std::{
-    fs, io,
+    fs::{self, OpenOptions},
+    io::{self, Write},
     path::{Path, PathBuf},
     sync::{Mutex, OnceLock},
 };
@@ -14,6 +15,8 @@ use crate::{
 };
 
 const HISTORY_VERSION: u32 = 1;
+
+static NEXT_TEMP_FILE_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ActivityHistoryFile {
@@ -118,10 +121,37 @@ fn save(path: &Path, records: &[ActivityRecord]) -> DustResult<()> {
         records: records.to_vec(),
     };
     let json = serde_json::to_string_pretty(&history).map_err(json_error)?;
+    let temporary_path = temporary_path(path);
 
-    fs::write(path, json)?;
+    let write_result = (|| -> io::Result<()> {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary_path)?;
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+        fs::rename(&temporary_path, path)
+    })();
+
+    if let Err(error) = write_result {
+        // The original history remains untouched when serialization or the
+        // replacement fails. Best-effort cleanup avoids leaving stale files
+        // beside the history file without hiding the actual write error.
+        let _ = fs::remove_file(&temporary_path);
+        return Err(error.into());
+    }
 
     Ok(())
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("history.json");
+    let id = NEXT_TEMP_FILE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+    path.with_file_name(format!(".{file_name}.{}.{}.tmp", std::process::id(), id))
 }
 
 fn json_error(error: serde_json::Error) -> DustError {
@@ -225,6 +255,48 @@ mod tests {
         .unwrap();
 
         assert_eq!(load_unlocked(&path).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn corrupted_history_is_reported_without_overwriting_the_file() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("history.json");
+        let original = "{not valid json";
+        std::fs::write(&path, original).unwrap();
+
+        let result = load_unlocked(&path);
+
+        assert!(matches!(result, Err(DustError::Io(_))));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), original);
+    }
+
+    #[test]
+    fn unsupported_history_version_is_rejected() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("history.json");
+        std::fs::write(&path, r#"{"version":2,"records":[]}"#).unwrap();
+
+        let result = load_unlocked(&path);
+
+        assert!(
+            matches!(result, Err(DustError::Io(error)) if error.to_string().contains("Unsupported activity history version: 2"))
+        );
+    }
+
+    #[test]
+    fn save_replaces_history_without_leaving_a_temporary_file() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("history.json");
+        let activity = ActivityRecord::new(
+            ActivityKind::Scan,
+            ActivityResult::new(true, json!({"artifacts": 0})),
+        );
+
+        record_to(&path, activity).unwrap();
+
+        let files = std::fs::read_dir(temp.path()).unwrap().collect::<Vec<_>>();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].as_ref().unwrap().file_name(), "history.json");
     }
 
     #[test]

--- a/crates/dustfril-core/src/scanner/detector.rs
+++ b/crates/dustfril-core/src/scanner/detector.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{fs, path::Path};
 
 use crate::models::{Artifact, Ecosystem};
 
@@ -21,7 +21,11 @@ pub trait Detector: Sync {
         self.artifact_paths()
             .iter()
             .map(|name| root.join(name))
-            .filter(|path| path.is_dir())
+            .filter(|path| {
+                fs::symlink_metadata(path)
+                    .map(|metadata| metadata.is_dir())
+                    .unwrap_or(false)
+            })
             .map(|path| Artifact::new(path, self.ecosystem()))
             .collect()
     }

--- a/crates/dustfril-core/src/scanner/scan.rs
+++ b/crates/dustfril-core/src/scanner/scan.rs
@@ -12,7 +12,7 @@ pub fn scan(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<ScanResult> {
 
     let mut result = ScanResult::default();
 
-    for dir in walk_dirs(root) {
+    for dir in walk_dirs(root)? {
         for detector in &detectors {
             if !detector.matches(&dir) {
                 continue;

--- a/crates/dustfril-core/src/scanner/tests.rs
+++ b/crates/dustfril-core/src/scanner/tests.rs
@@ -169,3 +169,18 @@ fn rust_detector_reports_target_as_safe_artifact() {
 
     assert_eq!(detector.artifact_paths(), &["target"]);
 }
+
+#[cfg(unix)]
+#[test]
+fn scanner_does_not_return_symbolic_link_artifacts() {
+    use std::os::unix::fs::symlink;
+
+    let root = TempDir::new().unwrap();
+    let real_target = TempDir::new().unwrap();
+    std::fs::write(root.path().join("Cargo.toml"), "[package]").unwrap();
+    symlink(real_target.path(), root.path().join("target")).unwrap();
+
+    let result = scan(root.path(), &[Ecosystem::Rust]).unwrap();
+
+    assert!(result.artifacts.is_empty());
+}


### PR DESCRIPTION
## Summary
Audited and tightened the Core, CLI, and Tauri boundaries.
Propagated scanner, manifest, filesystem, and CLI failures instead of silently hiding recoverable errors.
Consolidated analyzer metadata calculation into one traversal.
Hardened cleanup validation for symlinks, non-directories, protected paths, and Trash failures; Trash no longer falls back to permanent deletion.
Made history replacement atomic and added corruption/version handling coverage.
Added Tauri DTO/history tests, stale-request state protection, CLI exit-status behavior, and focused filesystem/audit/analyzer regression tests.
Updated architecture and safety documentation.

## Coverage
Before:
65.27% regions / 65.18% lines

After:
69.79% regions / 70.42% lines

The additional coverage focuses on cleaner safety, scanner roots and symlinks, analyzer boundaries and symlink traversal, history persistence and corruption, lifecycle audit parsing, Core API errors, CLI path validation, and Tauri history conversion. Coverage is reported as a guide to important behavior, not as a standalone quality metric.

## Architectural Decisions
Reusable scanning, analysis, cleanup, audit, and history behavior remains in dustfril-core. CLI changes are limited to input validation, presentation, and process status. Tauri changes are limited to boundary validation, DTO conversion tests, and frontend request-state handling. No existing Tauri wire DTOs were changed. The shared walker now reports traversal failures, and internal deletion/walking helpers have narrower visibility.

Lifecycle manifest parsing is separated from script extraction and malformed package.json input is reported explicitly. History keeps the current versioned/legacy-compatible format while replacing the file through a synchronized adjacent temporary file.

## Tests
cargo fmt --all -- --check — passed
cargo clippy --workspace --all-targets -- -D warnings — passed
cargo test --workspace — passed (126 tests)
cargo llvm-cov --workspace --all-features --summary-only — passed
npm ci — passed
npm run build — passed
CLI missing-root smoke test — passed; returned nonzero and reported the filesystem error
git diff --check — passed

## Follow-up Findings
The Tauri bootstrap still performs scan, analysis, and plan creation as separate calls; consolidating that would require an additive command/contract change and was left out of this focused pass.
Cleanup plans do not currently carry an explicit project root, so execution uses conservative protected-path checks; a full root-boundary model would require a deliberate API change.
Cross-platform Trash success/failure integration tests need a platform harness and were not made environment-dependent.
npm ci reports three dependency audit findings; dependency remediation is outside this quality-focused scope.