### PR TITLE
Validate supply-chain scanner behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "trash",
@@ -3038,6 +3039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,6 +3264,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4287,6 +4307,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,6 +23,9 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 - 지원 lockfile의 존재 여부와 Git 상태 점검
 - CLI 정리 이력을 운영체제 앱 데이터 디렉터리에 저장
 
+공급망 보안 스캐너는 v0.0.1 이후 작업입니다. v0.0.1 릴리스 범위는
+`AGENTS.md`에 정의된 데스크톱 산출물 정리 흐름으로 유지됩니다.
+
 ## 현재 탐지 대상
 
 | 생태계 | 탐지 대상 |
@@ -31,10 +34,12 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 | Node.js | `node_modules/` |
 | Java   | `build/` |
 
-지원 lockfile은 `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`,
-`Cargo.lock`입니다. Core API는 `Missing`, `Modified`, `Untracked`, `Clean`
-상태를 반환합니다. Git worktree에서는 porcelain과 같은 상태를 사용하고,
-Git 저장소가 아니면 파일 존재 여부만 확인합니다.
+보안 스캐너가 구조적으로 분석하는 형식은 `package-lock.json`(1–3), pnpm
+YAML, Bun JSONC `bun.lock`(1–2), Cargo.lock(1–4)입니다. Yarn lockfile과
+레거시 바이너리 `bun.lockb`는 파싱하지 않으며, 이 파일들만 있는 경우 npm
+lockfile 누락으로 잘못 보고하지 않습니다. Core API는 `Missing`, `Modified`,
+`Untracked`, `Clean` 상태를 반환합니다. Git worktree에서는 porcelain과 같은
+상태를 사용하고, Git 저장소가 아니면 파일 존재 여부만 확인합니다.
 
 ## CLI 사용법
 
@@ -74,8 +79,10 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 `security scan`은 `package.json`, `Cargo.toml`, `package-lock.json`,
 `pnpm-lock.yaml`, `bun.lock`, `Cargo.lock`을 읽기 전용으로 오프라인 점검합니다.
 의심스러운 라이프사이클 스크립트, 공개 레지스트리 외부에서 가져오는 의존성,
-내장된 과거 손상 패키지 목록, 누락되거나 변경된 lockfile을 경고합니다. 탐지된
-명령을 실행하거나 프로젝트 파일을 변경하지 않습니다.
+내장된 과거 손상 패키지 목록, 누락되거나 변경된 lockfile을 경고합니다. 형식이
+잘못되었거나 지원되지 않으면 해당 파일 경로를 포함한 오류를 반환합니다. 탐지된
+명령이나 패키지 매니저를 실행하지 않고, 네트워크 및 프로젝트 파일 변경도 사용하지
+않습니다.
 
 ## 데스크톱 앱
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Check supported lockfile presence and Git status
 - Persist CLI cleanup history to the OS app data directory
 
+The supply-chain scanner is post-v0.0.1 work. The v0.0.1 release remains
+focused on the desktop artifact-cleaner workflow described in `AGENTS.md`.
+
 Scans reject missing, symbolic-link, or non-directory roots and report
 filesystem traversal errors. Cleanup only accepts real artifact directories,
 refuses symbolic links and protected paths, and reports Trash failures without
@@ -36,10 +39,14 @@ permanently deleting the candidate as a fallback.
 | Node.js   | `node_modules/`    |
 | Java      | `build/`           |
 
-Supported lockfiles are `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`,
-and `Cargo.lock`. The Core API reports `Missing`, `Modified`, `Untracked`, or
-`Clean`; Git worktrees use porcelain-equivalent status, while non-Git paths
-only validate existence.
+Supported security lockfile formats are `package-lock.json` versions 1–3,
+pnpm YAML, Bun JSONC `bun.lock` versions 1–2, and Cargo.lock versions 1–4.
+The scanner validates each format before inspecting package names and
+available source URLs. Yarn lockfiles and legacy binary `bun.lockb` files are
+not parsed; when they are the only lockfile present, they are not reported as
+missing npm lockfiles. The Core API reports `Missing`, `Modified`,
+`Untracked`, or `Clean`; Git worktrees use porcelain-equivalent status, while
+non-Git paths only validate existence.
 
 ## CLI Usage
 
@@ -80,8 +87,9 @@ Available commands:
 `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `Cargo.lock`. It reports
 suspicious lifecycle scripts, dependencies sourced outside public registries,
 package names on a built-in list of historically compromised packages, and
-missing or changed lockfiles. It never runs detected commands or modifies
-project files.
+missing or changed lockfiles. Parse and read failures identify the relevant
+manifest or lockfile and fail the scan. It never runs detected commands,
+invokes a package manager, contacts the network, or modifies project files.
 
 ## Desktop App
 

--- a/crates/dustfril-core/Cargo.toml
+++ b/crates/dustfril-core/Cargo.toml
@@ -9,6 +9,7 @@ serde = { version = "1", features = ["derive"] }
 walkdir = "2.5.0"
 trash = "5"
 serde_json = "1"
+serde_yaml = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 directories = "6"
 git2 = "0.21"

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -33,6 +33,16 @@ symbolic links, and never falls back from Trash mode to permanent deletion.
 
 The supply-chain report reads `package.json` and `Cargo.toml` plus supported
 lockfiles without executing scripts or contacting an external advisory service.
+It parses npm lockfile versions 1–3, pnpm YAML, Bun JSONC lockfile versions
+1–2, and Cargo.lock versions 1–4. Yarn lockfiles and legacy binary `bun.lockb`
+are intentionally opaque; no npm-missing result is inferred from either when
+it is the only Node lockfile present.
+
+Malformed or unsupported manifests and lockfiles are returned as explicit
+errors. Lifecycle scanning honors an explicit `packageManager` declaration;
+otherwise it uses the nearest applicable lockfile. All security behavior is
+offline and read-only, and belongs to this Core crate; CLI and Tauri only
+invoke the public API and format its results.
 
 Lockfile checks report `Missing`, `Modified`, `Untracked`, or `Clean`. Git
 worktrees use libgit2 status information equivalent to

--- a/crates/dustfril-core/src/audit_tool/lifecycle.rs
+++ b/crates/dustfril-core/src/audit_tool/lifecycle.rs
@@ -22,11 +22,19 @@ pub fn audit_scan(root: &Path) -> DustResult<Vec<LifecycleScript>> {
     for dir in walk_dirs(root)? {
         let package_json = dir.join("package.json");
 
-        if !package_json.is_file() {
-            continue;
+        match fs::symlink_metadata(&package_json) {
+            Ok(metadata) if metadata.is_file() => {}
+            Ok(_) => {
+                return Err(DustError::Manifest(format!(
+                    "{}: expected a regular file",
+                    package_json.display()
+                )));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(DustError::Io(error)),
         }
 
-        let package_manager = package_manager::detect_for_package(&package_json, root);
+        let package_manager = package_manager::detect_for_package(&package_json, root)?;
         scripts.extend(audit_scan_package(&package_json, package_manager)?);
     }
 

--- a/crates/dustfril-core/src/audit_tool/package_manager.rs
+++ b/crates/dustfril-core/src/audit_tool/package_manager.rs
@@ -1,6 +1,9 @@
-use std::path::Path;
+use std::{fs, path::Path};
 
-use crate::models::PackageManager;
+use crate::{
+    error::{DustError, DustResult},
+    models::PackageManager,
+};
 
 /// Detects the package manager used by a Node project from lockfiles in a directory.
 pub fn detect_in_dir(dir: &Path) -> Option<PackageManager> {
@@ -23,14 +26,31 @@ pub fn detect_in_dir(dir: &Path) -> Option<PackageManager> {
     None
 }
 
-/// Resolves the package manager for a package.json path by checking the package
-/// directory and walking up toward the scan root.
-pub fn detect_for_package(package_json: &Path, scan_root: &Path) -> PackageManager {
+/// Resolves the package manager for a package.json path.
+///
+/// An explicit `packageManager` declaration takes precedence over lockfiles.
+/// This keeps lifecycle audit results aligned with the project's own package
+/// manager selection instead of inventing npm when a different manager is
+/// declared.
+pub fn detect_for_package(package_json: &Path, scan_root: &Path) -> DustResult<PackageManager> {
+    if let Some(package_manager) = declared_manager(package_json)? {
+        return Ok(package_manager);
+    }
+
     let mut current = package_json.parent();
 
     while let Some(dir) = current {
+        if Some(dir) != package_json.parent() {
+            let parent_manifest = dir.join("package.json");
+            if parent_manifest.is_file()
+                && let Some(package_manager) = declared_manager(&parent_manifest)?
+            {
+                return Ok(package_manager);
+            }
+        }
+
         if let Some(package_manager) = detect_in_dir(dir) {
-            return package_manager;
+            return Ok(package_manager);
         }
 
         if dir == scan_root {
@@ -52,7 +72,38 @@ pub fn detect_for_package(package_json: &Path, scan_root: &Path) -> PackageManag
         };
     }
 
-    PackageManager::Unknown
+    Ok(PackageManager::Unknown)
+}
+
+fn declared_manager(package_json: &Path) -> DustResult<Option<PackageManager>> {
+    let content = fs::read_to_string(package_json)?;
+    let manifest: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|error| DustError::Manifest(format!("{}: {error}", package_json.display())))?;
+
+    let Some(value) = manifest.get("packageManager") else {
+        return Ok(None);
+    };
+
+    let value = value.as_str().ok_or_else(|| {
+        DustError::Manifest(format!(
+            "{}: packageManager must be a string",
+            package_json.display()
+        ))
+    })?;
+
+    Ok(Some(manager_from_declaration(value)))
+}
+
+fn manager_from_declaration(value: &str) -> PackageManager {
+    let manager = value.split_once('@').map_or(value, |(manager, _)| manager);
+
+    match manager {
+        "npm" => PackageManager::Npm,
+        "pnpm" => PackageManager::Pnpm,
+        "yarn" => PackageManager::Yarn,
+        "bun" => PackageManager::Bun,
+        _ => PackageManager::Unknown,
+    }
 }
 
 #[cfg(test)]
@@ -99,8 +150,36 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            detect_for_package(&dependency_dir.join("package.json"), temp_dir.path()),
+            detect_for_package(&dependency_dir.join("package.json"), temp_dir.path()).unwrap(),
             PackageManager::Pnpm
         );
+    }
+
+    #[test]
+    fn explicit_package_manager_takes_precedence_over_lockfiles() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"pnpm@9.0.0"}"#,
+        )
+        .unwrap();
+        std::fs::write(temp_dir.path().join("package-lock.json"), "{}").unwrap();
+
+        assert_eq!(
+            detect_for_package(&temp_dir.path().join("package.json"), temp_dir.path()).unwrap(),
+            PackageManager::Pnpm
+        );
+    }
+
+    #[test]
+    fn malformed_package_manager_manifest_is_not_silently_ignored() {
+        let temp_dir = TempDir::new().unwrap();
+        let package_json = temp_dir.path().join("package.json");
+        std::fs::write(&package_json, "{invalid json").unwrap();
+
+        assert!(matches!(
+            detect_for_package(&package_json, temp_dir.path()),
+            Err(DustError::Manifest(message)) if message.contains("package.json")
+        ));
     }
 }

--- a/crates/dustfril-core/src/audit_tool/rule.rs
+++ b/crates/dustfril-core/src/audit_tool/rule.rs
@@ -212,4 +212,23 @@ mod tests {
             "destructive-delete"
         );
     }
+
+    #[test]
+    fn rules_cover_remote_shell_variants() {
+        for command in [
+            "curl URL | bash",
+            "curl URL | sh",
+            "wget URL | bash",
+            "wget URL | sh",
+        ] {
+            assert_eq!(find(command).unwrap().id, "remote-script-pipe", "{command}");
+        }
+    }
+
+    #[test]
+    fn powershell_keywords_in_arguments_are_not_execution_context() {
+        for command in ["echo invoke-webrequest", "echo iex", "node -e iex"] {
+            assert!(find(command).is_none(), "{command}");
+        }
+    }
 }

--- a/crates/dustfril-core/src/lockfile/check.rs
+++ b/crates/dustfril-core/src/lockfile/check.rs
@@ -108,7 +108,9 @@ fn infer_expected_lockfiles(root: &Path) -> DustResult<Vec<LockfileKind>> {
         match package_manager_lockfile(&root.join("package.json"))? {
             Some(NodeLockfileSelection::Supported(kind)) => expected.push(kind),
             Some(NodeLockfileSelection::Unsupported) => {}
-            None if node_lockfiles.is_empty() => expected.push(LockfileKind::PackageLockJson),
+            None if node_lockfiles.is_empty() && !has_unsupported_node_lockfile(root) => {
+                expected.push(LockfileKind::PackageLockJson)
+            }
             None => expected.extend(node_lockfiles),
         }
     }
@@ -120,6 +122,14 @@ fn infer_expected_lockfiles(root: &Path) -> DustResult<Vec<LockfileKind>> {
     deduplicate(&mut expected);
 
     Ok(expected)
+}
+
+fn has_unsupported_node_lockfile(root: &Path) -> bool {
+    // Yarn lockfiles and Bun's legacy binary lockfile are recognized by the
+    // lifecycle audit, but are intentionally outside the structured lockfile
+    // formats inspected by the security scanner. Do not turn either into a
+    // false npm-missing finding when no packageManager field is present.
+    root.join("yarn.lock").is_file() || root.join("bun.lockb").is_file()
 }
 
 fn package_manager_lockfile(path: &Path) -> DustResult<Option<NodeLockfileSelection>> {
@@ -136,11 +146,15 @@ fn package_manager_lockfile(path: &Path) -> DustResult<Option<NodeLockfileSelect
         ))
     })?;
 
-    let selection = if package_manager.starts_with("pnpm@") {
+    let manager = package_manager
+        .split_once('@')
+        .map_or(package_manager, |(manager, _)| manager);
+
+    let selection = if manager == "pnpm" {
         NodeLockfileSelection::Supported(LockfileKind::PnpmLockYaml)
-    } else if package_manager.starts_with("bun@") {
+    } else if manager == "bun" {
         NodeLockfileSelection::Supported(LockfileKind::BunLock)
-    } else if package_manager.starts_with("npm@") {
+    } else if manager == "npm" {
         NodeLockfileSelection::Supported(LockfileKind::PackageLockJson)
     } else {
         NodeLockfileSelection::Unsupported
@@ -271,6 +285,17 @@ mod tests {
         )
         .unwrap();
         fs::write(temp_dir.path().join("yarn.lock"), "__metadata:\n").unwrap();
+
+        let checks = check_lockfile_integrity(temp_dir.path()).unwrap();
+
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn yarn_lockfile_without_a_declaration_does_not_become_missing_npm() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("package.json"), r#"{"name":"demo"}"#).unwrap();
+        fs::write(temp_dir.path().join("yarn.lock"), "# yarn lockfile v1\n").unwrap();
 
         let checks = check_lockfile_integrity(temp_dir.path()).unwrap();
 

--- a/crates/dustfril-core/src/security.rs
+++ b/crates/dustfril-core/src/security.rs
@@ -7,6 +7,7 @@
 use std::{fs, path::Path};
 
 use serde_json::Value;
+use serde_yaml::Value as YamlValue;
 use url::Url;
 
 use crate::{
@@ -47,6 +48,7 @@ pub fn scan(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<SecurityReport>
     let scan_rust = ecosystems.is_empty() || ecosystems.contains(&Ecosystem::Rust);
 
     if !scan_node && !scan_rust {
+        validate_root(root)?;
         return Ok(SecurityReport::default());
     }
 
@@ -302,31 +304,80 @@ fn scan_package_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()>
     let content = fs::read_to_string(path)?;
     let lockfile: Value =
         serde_json::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+    let lockfile_object = lockfile.as_object().ok_or_else(|| {
+        manifest_error(
+            path,
+            "package-lock.json must contain a JSON object".to_owned(),
+        )
+    })?;
+    let version = lockfile_object
+        .get("lockfileVersion")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| {
+            manifest_error(
+                path,
+                "package-lock.json must declare a numeric lockfileVersion".to_owned(),
+            )
+        })?;
+    if !(1..=3).contains(&version) {
+        return Err(manifest_error(
+            path,
+            format!("unsupported package-lock.json lockfileVersion {version}"),
+        ));
+    }
 
-    if let Some(packages) = lockfile.get("packages").and_then(Value::as_object) {
+    if version >= 2 && !lockfile_object.contains_key("packages") {
+        return Err(manifest_error(
+            path,
+            format!("package-lock.json lockfileVersion {version} is missing packages"),
+        ));
+    }
+    if version == 1 && !lockfile_object.contains_key("dependencies") {
+        return Err(manifest_error(
+            path,
+            "package-lock.json lockfileVersion 1 is missing dependencies".to_owned(),
+        ));
+    }
+
+    if let Some(packages) = lockfile_object.get("packages") {
+        let packages = packages.as_object().ok_or_else(|| {
+            manifest_error(
+                path,
+                "package-lock.json packages must be an object".to_owned(),
+            )
+        })?;
         for (key, package) in packages {
-            let Some(package) = package.as_object() else {
+            let package = package.as_object().ok_or_else(|| {
+                manifest_error(
+                    path,
+                    format!("package-lock.json package entry {key:?} must be an object"),
+                )
+            })?;
+            if key.is_empty() {
                 continue;
-            };
+            }
             let name = package
                 .get("name")
                 .and_then(Value::as_str)
                 .or_else(|| package_name_from_selector(key));
             let Some(name) = name else { continue };
-            if key.is_empty() && package.get("version").is_none() {
-                continue;
-            }
 
-            let source = package
-                .get("resolved")
-                .or_else(|| package.get("resolvedUrl"))
-                .and_then(Value::as_str);
+            let source = match string_field(package, "resolved", path)? {
+                Some(source) => Some(source),
+                None => string_field(package, "resolvedUrl", path)?,
+            };
             inspect_node_lock_dependency(path, name, source, report);
         }
     }
 
-    if let Some(dependencies) = lockfile.get("dependencies").and_then(Value::as_object) {
-        inspect_npm_dependency_tree(path, dependencies, report);
+    if let Some(dependencies) = lockfile_object.get("dependencies") {
+        let dependencies = dependencies.as_object().ok_or_else(|| {
+            manifest_error(
+                path,
+                "package-lock.json dependencies must be an object".to_owned(),
+            )
+        })?;
+        inspect_npm_dependency_tree(path, dependencies, report)?;
     }
 
     Ok(())
@@ -336,18 +387,32 @@ fn inspect_npm_dependency_tree(
     path: &Path,
     dependencies: &serde_json::Map<String, Value>,
     report: &mut SecurityReport,
-) {
+) -> DustResult<()> {
     for (name, dependency) in dependencies {
-        let source = dependency
-            .get("resolved")
-            .or_else(|| dependency.get("resolvedUrl"))
-            .and_then(Value::as_str);
+        let dependency = dependency.as_object().ok_or_else(|| {
+            manifest_error(
+                path,
+                format!("package-lock.json dependency entry {name:?} must be an object"),
+            )
+        })?;
+        let source = match string_field(dependency, "resolved", path)? {
+            Some(source) => Some(source),
+            None => string_field(dependency, "resolvedUrl", path)?,
+        };
         inspect_node_lock_dependency(path, name, source, report);
 
-        if let Some(nested) = dependency.get("dependencies").and_then(Value::as_object) {
-            inspect_npm_dependency_tree(path, nested, report);
+        if let Some(nested) = dependency.get("dependencies") {
+            let nested = nested.as_object().ok_or_else(|| {
+                manifest_error(
+                    path,
+                    format!("package-lock.json nested dependencies for {name:?} must be an object"),
+                )
+            })?;
+            inspect_npm_dependency_tree(path, nested, report)?;
         }
     }
+
+    Ok(())
 }
 
 fn inspect_node_lock_dependency(
@@ -373,69 +438,116 @@ fn inspect_node_lock_dependency(
 
 fn scan_pnpm_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
     let content = fs::read_to_string(path)?;
-    let mut in_packages = false;
-    let mut current_package: Option<String> = None;
+    let lockfile: YamlValue =
+        serde_yaml::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+    let lockfile_object = lockfile.as_mapping().ok_or_else(|| {
+        manifest_error(
+            path,
+            "pnpm-lock.yaml must contain a YAML mapping".to_owned(),
+        )
+    })?;
+    let version =
+        yaml_scalar_field(lockfile_object, "lockfileVersion", path)?.ok_or_else(|| {
+            manifest_error(
+                path,
+                "pnpm-lock.yaml must declare lockfileVersion".to_owned(),
+            )
+        })?;
+    if version
+        .split('.')
+        .next()
+        .and_then(|major| major.parse::<u64>().ok())
+        .is_none()
+    {
+        return Err(manifest_error(
+            path,
+            format!("unsupported pnpm lockfileVersion {version:?}"),
+        ));
+    }
 
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed == "packages:" {
-            in_packages = true;
-            current_package = None;
-            continue;
-        }
-
-        if in_packages && !line.starts_with(' ') && !line.starts_with('\t') {
-            in_packages = false;
-            current_package = None;
-        }
-
-        if !in_packages {
-            continue;
-        }
-
-        let indentation = line
-            .chars()
-            .take_while(|character| character.is_whitespace())
-            .count();
-        if indentation == 2 && trimmed.ends_with(':') {
-            let selector = trimmed[..trimmed.len() - 1]
-                .trim_matches(['\'', '"'])
-                .trim_start_matches('/');
-            current_package = package_name_from_selector(selector).map(str::to_owned);
-
-            if let Some(name) = current_package.as_deref() {
-                report_known_package(path, name, report);
-                if let Some(source) = untrusted_node_source(selector) {
-                    report.finding(
-                        path,
-                        SecurityFindingKind::UntrustedDependency,
-                        Some(name.to_owned()),
-                        RiskLevel::Medium,
-                        Some(selector.to_owned()),
-                        format!(
-                            "pnpm lock entry uses a non-registry source ({source}); review the resolved package."
-                        ),
-                    );
-                }
-            }
-            continue;
-        }
-
-        let Some(name) = current_package.as_deref() else {
+    for section in ["packages", "snapshots"] {
+        let Some(value) = yaml_value_field(lockfile_object, section) else {
             continue;
         };
-        if let Some(source) = yaml_value_after(trimmed, "tarball:")
-            && !is_trusted_node_registry(source)
-        {
-            report.finding(
-                path,
-                SecurityFindingKind::UntrustedDependency,
-                Some(name.to_owned()),
-                RiskLevel::Medium,
-                Some(source.to_owned()),
-                "pnpm lock entry downloads from outside the supported public npm registries; review the artifact source.",
-            );
+        let entries = value.as_mapping().ok_or_else(|| {
+            manifest_error(path, format!("pnpm-lock.yaml {section} must be a mapping"))
+        })?;
+
+        for (selector, package) in entries {
+            let selector = selector.as_str().ok_or_else(|| {
+                manifest_error(
+                    path,
+                    format!("pnpm-lock.yaml {section} keys must be strings"),
+                )
+            })?;
+            inspect_pnpm_entry(path, selector, package, report)?;
         }
+    }
+
+    Ok(())
+}
+
+fn inspect_pnpm_entry(
+    path: &Path,
+    selector: &str,
+    package: &YamlValue,
+    report: &mut SecurityReport,
+) -> DustResult<()> {
+    let name = package_name_from_selector(selector);
+    if let Some(name) = name {
+        report_known_package(path, name, report);
+    }
+    let source_selector = selector
+        .trim()
+        .trim_matches(['\'', '"'])
+        .trim_start_matches('/');
+    if let Some(source) = untrusted_node_source(source_selector) {
+        report.finding(
+            path,
+            SecurityFindingKind::UntrustedDependency,
+            name.map(str::to_owned),
+            RiskLevel::Medium,
+            Some(selector.to_owned()),
+            format!(
+                "pnpm lock entry uses a non-registry source ({source}); review the resolved package."
+            ),
+        );
+    }
+
+    let package_object = package.as_mapping().ok_or_else(|| {
+        manifest_error(
+            path,
+            format!("pnpm-lock.yaml entry {selector:?} must be a mapping"),
+        )
+    })?;
+    let Some(name) = name else {
+        return Ok(());
+    };
+    let Some(resolution) = yaml_value_field(package_object, "resolution") else {
+        return Ok(());
+    };
+    let resolution = resolution.as_mapping().ok_or_else(|| {
+        manifest_error(
+            path,
+            format!("pnpm-lock.yaml resolution for {selector:?} must be a mapping"),
+        )
+    })?;
+
+    for key in ["tarball", "repo", "url"] {
+        let Some(source) = yaml_string_field(resolution, key, path)? else {
+            continue;
+        };
+        if is_trusted_node_registry(source) {
+            continue;
+        }
+        report.finding(
+            path,
+            SecurityFindingKind::UntrustedDependency,
+            Some(name.to_owned()),
+            RiskLevel::Medium,
+            Some(source.to_owned()),
+            "pnpm lock entry downloads from outside the supported public npm registries; review the artifact source.",
+        );
     }
 
     Ok(())
@@ -444,12 +556,104 @@ fn scan_pnpm_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
 fn scan_bun_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
     let content = fs::read_to_string(path)?;
     let lockfile = parse_jsonc(&content).map_err(|error| manifest_error(path, error))?;
-
-    if let Some(packages) = lockfile.get("packages") {
-        inspect_bun_value(path, packages, None, report);
+    let lockfile_object = lockfile
+        .as_object()
+        .ok_or_else(|| manifest_error(path, "bun.lock must contain a JSON object".to_owned()))?;
+    let version = lockfile_object
+        .get("lockfileVersion")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| {
+            manifest_error(
+                path,
+                "bun.lock must declare a numeric lockfileVersion".to_owned(),
+            )
+        })?;
+    if !(1..=2).contains(&version) {
+        return Err(manifest_error(
+            path,
+            format!("unsupported bun.lock lockfileVersion {version}"),
+        ));
     }
-    if let Some(workspaces) = lockfile.get("workspaces") {
+
+    if let Some(packages) = lockfile_object.get("packages") {
+        let packages = packages.as_object().ok_or_else(|| {
+            manifest_error(path, "bun.lock packages must be an object".to_owned())
+        })?;
+        for (selector, package) in packages {
+            inspect_bun_package(path, selector, package, report)?;
+        }
+    }
+    if let Some(workspaces) = lockfile_object.get("workspaces") {
+        if !workspaces.is_object() {
+            return Err(manifest_error(
+                path,
+                "bun.lock workspaces must be an object".to_owned(),
+            ));
+        }
         inspect_bun_value(path, workspaces, None, report);
+    }
+
+    Ok(())
+}
+
+fn inspect_bun_package(
+    path: &Path,
+    selector: &str,
+    package: &Value,
+    report: &mut SecurityReport,
+) -> DustResult<()> {
+    let name = package_name_from_selector(selector).ok_or_else(|| {
+        manifest_error(
+            path,
+            format!("bun.lock package key {selector:?} is not a package selector"),
+        )
+    })?;
+    report_known_package(path, name, report);
+
+    match package {
+        Value::Array(entries) => inspect_bun_package_array(path, name, entries, report),
+        Value::Object(_) => {
+            inspect_bun_value(path, package, Some(name), report);
+            Ok(())
+        }
+        _ => Err(manifest_error(
+            path,
+            format!("bun.lock package entry {selector:?} must be an array or object"),
+        )),
+    }
+}
+
+fn inspect_bun_package_array(
+    path: &Path,
+    name: &str,
+    entries: &[Value],
+    report: &mut SecurityReport,
+) -> DustResult<()> {
+    if let Some(version_selector) = entries.first().and_then(Value::as_str) {
+        report_known_package(path, name, report);
+        if let Some(source) = untrusted_node_source(version_selector) {
+            report.finding(
+                path,
+                SecurityFindingKind::UntrustedDependency,
+                Some(name.to_owned()),
+                RiskLevel::Medium,
+                Some(version_selector.to_owned()),
+                format!(
+                    "Bun lock entry uses a non-registry source ({source}); review the resolved package."
+                ),
+            );
+        }
+    }
+
+    for (index, entry) in entries.iter().enumerate().skip(1) {
+        if index == 1
+            && let Some(source) = entry.as_str().filter(|source| !source.is_empty())
+        {
+            inspect_node_lock_dependency(path, name, Some(source), report);
+            continue;
+        }
+
+        inspect_bun_value(path, entry, Some(name), report);
     }
 
     Ok(())
@@ -645,20 +849,46 @@ fn scan_cargo_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
     let content = fs::read_to_string(path)?;
     let lockfile: toml::Value =
         toml::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+    let lockfile_table = lockfile
+        .as_table()
+        .ok_or_else(|| manifest_error(path, "Cargo.lock must contain a TOML table".to_owned()))?;
+    let version = lockfile_table
+        .get("version")
+        .and_then(toml::Value::as_integer)
+        .ok_or_else(|| manifest_error(path, "Cargo.lock must declare version".to_owned()))?;
+    if !(1..=4).contains(&version) {
+        return Err(manifest_error(
+            path,
+            format!("unsupported Cargo.lock version {version}"),
+        ));
+    }
 
-    let Some(packages) = lockfile.get("package").and_then(toml::Value::as_array) else {
+    let Some(packages) = lockfile_table.get("package") else {
         return Ok(());
     };
+    let packages = packages
+        .as_array()
+        .ok_or_else(|| manifest_error(path, "Cargo.lock package must be an array".to_owned()))?;
 
     for package in packages {
-        let Some(name) = package.get("name").and_then(toml::Value::as_str) else {
-            continue;
-        };
+        let package = package.as_table().ok_or_else(|| {
+            manifest_error(path, "Cargo.lock package entries must be tables".to_owned())
+        })?;
+        let name = package
+            .get("name")
+            .and_then(toml::Value::as_str)
+            .ok_or_else(|| manifest_error(path, "Cargo.lock package is missing name".to_owned()))?;
         report_known_package(path, name, report);
 
-        let Some(source) = package.get("source").and_then(toml::Value::as_str) else {
+        let Some(source) = package.get("source") else {
             continue;
         };
+        let source = source.as_str().ok_or_else(|| {
+            manifest_error(
+                path,
+                format!("Cargo.lock source for {name:?} must be a string"),
+            )
+        })?;
         if !is_trusted_cargo_registry(source) {
             report.finding(
                 path,
@@ -724,12 +954,16 @@ fn untrusted_node_source(specification: &str) -> Option<&'static str> {
     if value.starts_with("file:")
         || value.starts_with("link:")
         || value.starts_with("workspace:")
+        || value.starts_with('/')
         || value.starts_with("./")
         || value.starts_with("../")
     {
         return Some("local or workspace source");
     }
-    if value.split('/').count() == 2 && !value.chars().any(char::is_whitespace) {
+    if !value.starts_with('@')
+        && value.split('/').count() == 2
+        && !value.chars().any(char::is_whitespace)
+    {
         return Some("repository shorthand");
     }
 
@@ -775,6 +1009,10 @@ fn is_trusted_node_registry(source: &str) -> bool {
 
     url.scheme() == "https"
         && url.port().is_none()
+        && url.username().is_empty()
+        && url.password().is_none()
+        && url.query().is_none()
+        && url.fragment().is_none()
         && matches!(
             url.host_str(),
             Some("registry.npmjs.org" | "registry.yarnpkg.com")
@@ -789,7 +1027,13 @@ fn is_trusted_cargo_registry(source: &str) -> bool {
         return false;
     };
 
-    if url.scheme() != "https" || url.port().is_some() || url.query().is_some() {
+    if url.scheme() != "https"
+        || url.port().is_some()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
         return false;
     }
 
@@ -811,23 +1055,51 @@ fn package_name_from_selector(selector: &str) -> Option<&str> {
         .trim_matches(['\'', '"'])
         .trim_start_matches("node_modules/")
         .trim_start_matches('/');
-    if selector.is_empty() || is_lock_metadata_key(selector) {
+    let selector = selector.split('(').next().unwrap_or(selector).trim();
+    if selector.is_empty()
+        || is_lock_metadata_key(selector)
+        || selector.contains("://")
+        || selector.starts_with("file:")
+        || selector.starts_with("link:")
+        || selector.starts_with("workspace:")
+    {
         return None;
     }
 
-    let at = if let Some(stripped) = selector.strip_prefix('@') {
-        stripped.find('@').map(|index| index + 1)
+    let name = if let Some(stripped) = selector.strip_prefix('@') {
+        if let Some(index) = stripped.find('@') {
+            &selector[..index + 1]
+        } else {
+            let mut parts = selector.split('/');
+            match (parts.next(), parts.next(), parts.next()) {
+                (Some(scope), Some(package), Some(_version)) => {
+                    &selector[..scope.len() + 1 + package.len()]
+                }
+                _ => selector,
+            }
+        }
+    } else if let Some(index) = selector.find('@') {
+        &selector[..index]
     } else {
-        selector.find('@')
+        let mut parts = selector.split('/');
+        match (parts.next(), parts.next()) {
+            (Some(name), Some(version)) if looks_like_version(version) => name,
+            _ => selector,
+        }
     };
-
-    let name = at.map(|index| &selector[..index]).unwrap_or(selector);
-    let name = name.split('(').next().unwrap_or(name).trim_end_matches(':');
+    let name = name.trim_end_matches(':');
     (!name.is_empty()
         && name
             .chars()
             .any(|character| character.is_ascii_alphabetic()))
     .then_some(name)
+}
+
+fn looks_like_version(value: &str) -> bool {
+    value
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_digit() || character == 'v')
 }
 
 fn is_lock_metadata_key(value: &str) -> bool {
@@ -845,10 +1117,57 @@ fn is_lock_metadata_key(value: &str) -> bool {
     )
 }
 
-fn yaml_value_after<'a>(line: &'a str, key: &str) -> Option<&'a str> {
-    line.strip_prefix(key)
-        .map(str::trim)
-        .map(|value| value.trim_matches(['\'', '"']))
+fn string_field<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    key: &str,
+    path: &Path,
+) -> DustResult<Option<&'a str>> {
+    let Some(value) = object.get(key) else {
+        return Ok(None);
+    };
+
+    value
+        .as_str()
+        .map(Some)
+        .ok_or_else(|| manifest_error(path, format!("{key} field in JSON object must be a string")))
+}
+
+fn yaml_value_field<'a>(object: &'a serde_yaml::Mapping, key: &str) -> Option<&'a YamlValue> {
+    object.get(YamlValue::String(key.to_owned()))
+}
+
+fn yaml_scalar_field(
+    object: &serde_yaml::Mapping,
+    key: &str,
+    path: &Path,
+) -> DustResult<Option<String>> {
+    let Some(value) = yaml_value_field(object, key) else {
+        return Ok(None);
+    };
+
+    match value {
+        YamlValue::String(value) => Ok(Some(value.clone())),
+        YamlValue::Number(value) => Ok(Some(value.to_string())),
+        _ => Err(manifest_error(
+            path,
+            format!("{key} field in YAML must be a scalar string or number"),
+        )),
+    }
+}
+
+fn yaml_string_field<'a>(
+    object: &'a serde_yaml::Mapping,
+    key: &str,
+    path: &Path,
+) -> DustResult<Option<&'a str>> {
+    let Some(value) = yaml_value_field(object, key) else {
+        return Ok(None);
+    };
+
+    value
+        .as_str()
+        .map(Some)
+        .ok_or_else(|| manifest_error(path, format!("{key} field in YAML must be a string")))
 }
 
 fn manifest_error(path: &Path, message: String) -> DustError {
@@ -939,6 +1258,17 @@ mod tests {
 
         assert!(report.findings.is_empty());
         assert!(report.manifests.is_empty());
+    }
+
+    #[test]
+    fn selected_unknown_ecosystem_still_validates_the_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let missing = temp_dir.path().join("missing");
+
+        assert!(matches!(
+            scan(&missing, &[Ecosystem::Java]),
+            Err(DustError::InvalidPath(path)) if path == missing
+        ));
     }
 
     #[test]
@@ -1033,6 +1363,24 @@ mod tests {
             package_name_from_selector("/event-stream@3.3.6"),
             Some("event-stream")
         );
+        assert_eq!(
+            package_name_from_selector("/@scope/package/1.0.0"),
+            Some("@scope/package")
+        );
+        assert_eq!(
+            package_name_from_selector("/event-stream/3.3.6"),
+            Some("event-stream")
+        );
+    }
+
+    #[test]
+    fn scoped_registry_dependencies_are_not_repository_shorthands() {
+        assert!(untrusted_node_source("@scope/package").is_none());
+        assert!(untrusted_node_source("@scope/package@1.0.0").is_none());
+        assert_eq!(
+            untrusted_node_source("owner/repository"),
+            Some("repository shorthand")
+        );
     }
 
     #[test]
@@ -1046,6 +1394,9 @@ mod tests {
         assert!(!is_trusted_node_registry(
             "https://registry.yarnpkg.com.evil.example/package.tgz"
         ));
+        assert!(!is_trusted_node_registry(
+            "https://user@registry.npmjs.org/package.tgz"
+        ));
 
         assert!(is_trusted_cargo_registry(
             "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1404,9 @@ mod tests {
         assert!(is_trusted_cargo_registry("sparse+https://index.crates.io/"));
         assert!(!is_trusted_cargo_registry(
             "registry+https://evil.example/crates.io/index"
+        ));
+        assert!(!is_trusted_cargo_registry(
+            "registry+https://github.com/rust-lang/crates.io-index#evil"
         ));
     }
 
@@ -1071,5 +1425,145 @@ mod tests {
         assert!(
             matches!(result, Err(DustError::Manifest(message)) if message.contains("bun.lock"))
         );
+    }
+
+    #[test]
+    fn malformed_supported_lockfiles_are_reported() {
+        let package_lock_dir = TempDir::new().unwrap();
+        fs::write(
+            package_lock_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"npm@10.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            package_lock_dir.path().join("package-lock.json"),
+            r#"{"lockfileVersion":3,"packages":[]}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            scan(package_lock_dir.path(), &[Ecosystem::Node]),
+            Err(DustError::Manifest(message)) if message.contains("package-lock.json")
+        ));
+
+        let pnpm_dir = TempDir::new().unwrap();
+        fs::write(
+            pnpm_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"pnpm@9.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(pnpm_dir.path().join("pnpm-lock.yaml"), "packages: [").unwrap();
+        assert!(matches!(
+            scan(pnpm_dir.path(), &[Ecosystem::Node]),
+            Err(DustError::Manifest(message)) if message.contains("pnpm-lock.yaml")
+        ));
+
+        let cargo_dir = TempDir::new().unwrap();
+        fs::write(
+            cargo_dir.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        fs::write(cargo_dir.path().join("Cargo.lock"), "package = []\n").unwrap();
+        assert!(matches!(
+            scan(cargo_dir.path(), &[Ecosystem::Rust]),
+            Err(DustError::Manifest(message)) if message.contains("Cargo.lock")
+        ));
+    }
+
+    #[test]
+    fn actual_bun_package_tuples_keep_source_with_package_name() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"bun@1.3.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("bun.lock"),
+            r#"{
+                "lockfileVersion": 1,
+                "packages": {
+                    "@scope/package": [
+                        "@scope/package@1.0.0",
+                        "https://registry.npmjs.org/@scope/package/-/package-1.0.0.tgz",
+                        {},
+                        "sha512-example"
+                    ],
+                    "remote": [
+                        "remote@1.0.0",
+                        "https://registry.npmjs.org.evil.example/remote.tgz",
+                        {},
+                        "sha512-example"
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let report = scan(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == SecurityFindingKind::UntrustedDependency
+                && finding.package.as_deref() == Some("remote")
+                && finding.evidence.as_deref()
+                    == Some("https://registry.npmjs.org.evil.example/remote.tgz")
+        }));
+        assert!(!report.findings.iter().any(|finding| {
+            finding.kind == SecurityFindingKind::UntrustedDependency
+                && finding.package.as_deref() == Some("@scope/package")
+        }));
+    }
+
+    #[test]
+    fn pnpm_parser_handles_v9_entries_and_sources() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"pnpm@9.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("pnpm-lock.yaml"),
+            "lockfileVersion: '9.0'\npackages:\n  '@scope/package@1.0.0':\n    resolution:\n      tarball: https://registry.npmjs.org/@scope/package/-/package-1.0.0.tgz\n  remote@1.0.0:\n    resolution:\n      tarball: https://registry.npmjs.org.evil.example/remote.tgz\nsnapshots:\n  remote@1.0.0: {}\n",
+        )
+        .unwrap();
+
+        let report = scan(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == SecurityFindingKind::UntrustedDependency
+                && finding.package.as_deref() == Some("remote")
+        }));
+        assert!(!report.findings.iter().any(|finding| {
+            finding.kind == SecurityFindingKind::UntrustedDependency
+                && finding.package.as_deref() == Some("@scope/package")
+        }));
+    }
+
+    #[test]
+    fn package_lock_v1_dependency_tree_is_supported() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"npm@10.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("package-lock.json"),
+            r#"{
+                "lockfileVersion": 1,
+                "dependencies": {
+                    "@scope/package": {
+                        "version": "1.0.0",
+                        "resolved": "https://registry.npmjs.org/@scope/package/-/package-1.0.0.tgz"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let report = scan(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+        assert!(report.findings.is_empty());
+        assert!(report.lockfiles.iter().any(|check| {
+            check.kind == LockfileKind::PackageLockJson && check.status == LockfileStatus::Clean
+        }));
     }
 }

--- a/crates/dustfril-core/src/security.rs
+++ b/crates/dustfril-core/src/security.rs
@@ -852,10 +852,12 @@ fn scan_cargo_lock(path: &Path, report: &mut SecurityReport) -> DustResult<()> {
     let lockfile_table = lockfile
         .as_table()
         .ok_or_else(|| manifest_error(path, "Cargo.lock must contain a TOML table".to_owned()))?;
-    let version = lockfile_table
-        .get("version")
-        .and_then(toml::Value::as_integer)
-        .ok_or_else(|| manifest_error(path, "Cargo.lock must declare version".to_owned()))?;
+    let version = match lockfile_table.get("version") {
+        Some(value) => value.as_integer().ok_or_else(|| {
+            manifest_error(path, "Cargo.lock version must be an integer".to_owned())
+        })?,
+        None => 1,
+    };
     if !(1..=4).contains(&version) {
         return Err(manifest_error(
             path,
@@ -1354,6 +1356,28 @@ mod tests {
     }
 
     #[test]
+    fn cargo_lock_v1_without_version_is_supported() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("Cargo.lock"),
+            "[root]\nname = \"demo\"\nversion = \"0.1.0\"\ndependencies = []\n",
+        )
+        .unwrap();
+
+        let report = scan(temp_dir.path(), &[Ecosystem::Rust]).unwrap();
+
+        assert!(report.findings.is_empty());
+        assert!(report.lockfiles.iter().any(|check| {
+            check.kind == LockfileKind::CargoLock && check.status == LockfileStatus::Clean
+        }));
+    }
+
+    #[test]
     fn package_selector_supports_scoped_and_unscoped_names() {
         assert_eq!(
             package_name_from_selector("@scope/package@1.0.0"),
@@ -1463,7 +1487,11 @@ mod tests {
             "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
         )
         .unwrap();
-        fs::write(cargo_dir.path().join("Cargo.lock"), "package = []\n").unwrap();
+        fs::write(
+            cargo_dir.path().join("Cargo.lock"),
+            "package = \"not-an-array\"\n",
+        )
+        .unwrap();
         assert!(matches!(
             scan(cargo_dir.path(), &[Ecosystem::Rust]),
             Err(DustError::Manifest(message)) if message.contains("Cargo.lock")


### PR DESCRIPTION
## Summary

Closes #112.

- Harden package-manager and lockfile validation with explicit errors and supported-version checks.
- Validate canonical npm and crates.io registry sources, Bun JSONC structure, pnpm YAML structure, and scoped/local package paths.
- Preserve read-only, offline scanner behavior and prevent unrelated ecosystems from being reported as supported.
- Fix package-manager declaration precedence, lifecycle error propagation, shell-rule matching, and Yarn-only / legacy bun.lockb lockfile handling.
- Support legacy Cargo.lock v1 files that omit the top-level version, with regression coverage.
- Document the post-v0.0.1 scope and intentionally opaque lockfile formats.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 149 tests passed
- [x] `cargo llvm-cov --workspace --all-features --summary-only` — 73.60% line coverage (79.27% in `security.rs`)
- [x] `npm run build`
- [x] `git diff --check`
- [x] CLI smoke test: `cargo run -p dustfril-cli -- security scan . --java`

## Scope

The scanner remains an offline, read-only supply-chain inspection feature intended for post-v0.0.1 work. This PR does not add online advisory scanning, dependency auditing, or automatic remediation.