### PR TITLE
Persist security scan events in unified activity history

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Build a cleanup plan before deleting anything
 - Clean artifacts with Trash or permanent deletion mode
 - Audit Node lifecycle scripts such as `preinstall` and `postinstall`
-- Persist versioned local activity history (including legacy cleanup history migration)
+- Persist versioned local activity history for scans, cleanup, and explicit security scans (including legacy cleanup history migration)
 - Run an offline supply-chain security scan for Node and Rust projects
 - Check supported lockfile presence and Git status
 - Persist CLI cleanup history to the OS app data directory

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -38,3 +38,6 @@ cargo build -p dustfril-cli
 - security scans are read-only and use deterministic offline checks
 - Activity history is stored in the OS app data directory as a versioned `history.json`.
   Existing cleanup-history arrays are migrated when the file is read or appended to.
+- Each explicit `security scan` appends one Security activity with its result
+  summary. Finding evidence and credential-shaped values are excluded or
+  sanitised before persistence.

--- a/apps/dustfril-cli/src/commands/security.rs
+++ b/apps/dustfril-cli/src/commands/security.rs
@@ -22,8 +22,19 @@ pub fn scan(args: &PathArgs) -> bool {
     let ecosystems = args.ecosystems();
 
     let report = match api::security_scan_report(&path, &ecosystems) {
-        Ok(report) => report,
+        Ok(report) => {
+            if let Err(error) = api::history::record_security_scan(&path, &ecosystems, &report) {
+                eprintln!("Failed to record security scan history: {error}");
+            }
+
+            report
+        }
         Err(error) => {
+            if let Err(history_error) =
+                api::history::record_security_failure(&path, &ecosystems, &error.to_string())
+            {
+                eprintln!("Failed to record security scan history: {history_error}");
+            }
             eprintln!("Security scan failed: {error}");
             return false;
         }

--- a/apps/dustfril-tauri/README.md
+++ b/apps/dustfril-tauri/README.md
@@ -32,6 +32,7 @@ case-sensitive.
 | `analyze` | `{ options: RunOptions }` | `AnalysisResponse` |
 | `build_cleanup_plan` | `{ options: RunOptions }` | `CleanupPlanResponse` |
 | `audit` | `{ options: RunOptions }` | `LifecycleScript[]` |
+| `security_scan` | `{ options: RunOptions }` | `SecurityScanResponse` |
 | `execute_cleanup` | `{ request: { candidates, mode } }` | `CleanupResultResponse` |
 | `load_cleanup_history` | none | `CleanupHistoryEntry[]` |
 

--- a/apps/dustfril-tauri/src-tauri/src/contract.rs
+++ b/apps/dustfril-tauri/src-tauri/src/contract.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use dustfril_core::models::{
     CleanupFailureReason, CleanupRecommendation, DeleteMode, Ecosystem, LifecycleScript,
-    PackageManager, RiskLevel, ScriptType,
+    LockfileCheck, LockfileKind, LockfileStatus, PackageManager, RiskLevel, ScriptType,
+    SecurityFinding, SecurityReport, SecurityWarning,
 };
 use serde::{Deserialize, Serialize};
 
@@ -109,6 +110,59 @@ pub(crate) struct LifecycleScriptDto {
     pub(crate) script_type: ScriptTypeDto,
     pub(crate) command: String,
     pub(crate) risk_level: RiskLevelDto,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SecurityScanResponse {
+    pub(crate) findings: Vec<SecurityFindingDto>,
+    pub(crate) lifecycle_warnings: Vec<SecurityWarningDto>,
+    pub(crate) lockfiles: Vec<LockfileCheckDto>,
+    pub(crate) manifests: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SecurityFindingDto {
+    pub(crate) path: String,
+    pub(crate) rule: String,
+    pub(crate) package: Option<String>,
+    pub(crate) risk_level: RiskLevelDto,
+    pub(crate) evidence: Option<String>,
+    pub(crate) reason: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SecurityWarningDto {
+    pub(crate) package: String,
+    pub(crate) script_type: String,
+    pub(crate) command: String,
+    pub(crate) risk_level: RiskLevelDto,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LockfileCheckDto {
+    pub(crate) path: String,
+    pub(crate) kind: LockfileKindDto,
+    pub(crate) status: LockfileStatusDto,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) enum LockfileKindDto {
+    PackageLockJson,
+    PnpmLockYaml,
+    BunLock,
+    CargoLock,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) enum LockfileStatusDto {
+    Missing,
+    Modified,
+    Untracked,
+    Clean,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
@@ -268,6 +322,81 @@ impl From<LifecycleScript> for LifecycleScriptDto {
             script_type: script.script_type.into(),
             command: script.command,
             risk_level: script.risk_level.into(),
+        }
+    }
+}
+
+impl From<SecurityReport> for SecurityScanResponse {
+    fn from(report: SecurityReport) -> Self {
+        Self {
+            findings: report.findings.into_iter().map(Into::into).collect(),
+            lifecycle_warnings: report
+                .lifecycle_warnings
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            lockfiles: report.lockfiles.into_iter().map(Into::into).collect(),
+            manifests: report
+                .manifests
+                .into_iter()
+                .map(|path| path.display().to_string())
+                .collect(),
+        }
+    }
+}
+
+impl From<SecurityFinding> for SecurityFindingDto {
+    fn from(finding: SecurityFinding) -> Self {
+        Self {
+            path: finding.path.display().to_string(),
+            rule: finding.kind.rule_id().to_owned(),
+            package: finding.package,
+            risk_level: finding.risk_level.into(),
+            evidence: finding.evidence,
+            reason: finding.reason,
+        }
+    }
+}
+
+impl From<SecurityWarning> for SecurityWarningDto {
+    fn from(warning: SecurityWarning) -> Self {
+        Self {
+            package: warning.package,
+            script_type: warning.script_type,
+            command: warning.command,
+            risk_level: warning.risk_level.into(),
+        }
+    }
+}
+
+impl From<LockfileCheck> for LockfileCheckDto {
+    fn from(check: LockfileCheck) -> Self {
+        Self {
+            path: check.path.display().to_string(),
+            kind: check.kind.into(),
+            status: check.status.into(),
+        }
+    }
+}
+
+impl From<LockfileKind> for LockfileKindDto {
+    fn from(kind: LockfileKind) -> Self {
+        match kind {
+            LockfileKind::PackageLockJson => Self::PackageLockJson,
+            LockfileKind::PnpmLockYaml => Self::PnpmLockYaml,
+            LockfileKind::BunLock => Self::BunLock,
+            LockfileKind::CargoLock => Self::CargoLock,
+        }
+    }
+}
+
+impl From<LockfileStatus> for LockfileStatusDto {
+    fn from(status: LockfileStatus) -> Self {
+        match status {
+            LockfileStatus::Missing => Self::Missing,
+            LockfileStatus::Modified => Self::Modified,
+            LockfileStatus::Untracked => Self::Untracked,
+            LockfileStatus::Clean => Self::Clean,
         }
     }
 }
@@ -463,6 +592,34 @@ mod tests {
                 "freedSizeBytes": 42,
                 "deletedPaths": ["/workspace/target"],
                 "failedPaths": []
+            })
+        );
+    }
+
+    #[test]
+    fn security_scan_wire_format_preserves_structured_findings() {
+        let report = SecurityReport {
+            findings: vec![SecurityFinding::new(
+                "/workspace/package.json".into(),
+                dustfril_core::models::SecurityFindingKind::SuspiciousScript,
+                Some("demo".to_owned()),
+                RiskLevel::High,
+                Some("curl payload | bash".to_owned()),
+                "Remote script is piped to a shell.",
+            )],
+            ..SecurityReport::default()
+        };
+        let response: SecurityScanResponse = report.into();
+
+        assert_eq!(
+            serde_json::to_value(response).unwrap()["findings"][0],
+            json!({
+                "path": "/workspace/package.json",
+                "rule": "suspicious-script",
+                "package": "demo",
+                "riskLevel": "High",
+                "evidence": "curl payload | bash",
+                "reason": "Remote script is piped to a shell."
             })
         );
     }

--- a/apps/dustfril-tauri/src-tauri/src/history.rs
+++ b/apps/dustfril-tauri/src-tauri/src/history.rs
@@ -2,7 +2,10 @@ use std::path::Path;
 
 use dustfril_core::{
     api,
-    models::{ActivityKind, ActivityRecord, CleanupResult, DeleteMode, ScanResult},
+    models::{
+        ActivityKind, ActivityRecord, CleanupResult, DeleteMode, Ecosystem, ScanResult,
+        SecurityReport,
+    },
 };
 use serde::Serialize;
 
@@ -29,6 +32,26 @@ pub fn record_scan(
     total_size_bytes: u64,
 ) -> Result<(), String> {
     api::history::record_scan(target_path, result, total_size_bytes)
+        .map_err(|error| error.to_string())
+}
+
+/// Records one explicit security scan for the desktop activity log.
+pub fn record_security_scan(
+    target_path: &Path,
+    ecosystems: &[Ecosystem],
+    report: &SecurityReport,
+) -> Result<(), String> {
+    api::history::record_security_scan(target_path, ecosystems, report)
+        .map_err(|error| error.to_string())
+}
+
+/// Records a failed explicit security scan for the desktop activity log.
+pub fn record_security_failure(
+    target_path: &Path,
+    ecosystems: &[Ecosystem],
+    reason: &str,
+) -> Result<(), String> {
+    api::history::record_security_failure(target_path, ecosystems, reason)
         .map_err(|error| error.to_string())
 }
 

--- a/apps/dustfril-tauri/src-tauri/src/lib.rs
+++ b/apps/dustfril-tauri/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ use contract::{
     artifact_path, cleanup_failure_reason, AnalysisResponse, ArtifactAnalysisDto, ArtifactDto,
     CleanupCandidateDto, CleanupFailureDto, CleanupHistoryEntryDto, CleanupPlanResponse,
     CleanupResultResponse, ExecuteCleanupRequest, LifecycleScriptDto, RunOptions, ScanResponse,
+    SecurityScanResponse,
 };
 use dustfril_core::{
     api,
@@ -223,6 +224,36 @@ async fn audit(options: RunOptions) -> Result<Vec<LifecycleScriptDto>, String> {
     .map_err(|error| error.to_string())?
 }
 
+#[tauri::command]
+async fn security_scan(options: RunOptions) -> Result<SecurityScanResponse, String> {
+    let root = resolve_root(options.root)?;
+    let ecosystems: Vec<_> = options.ecosystems.into_iter().map(Into::into).collect();
+
+    tokio::task::spawn_blocking(move || {
+        let report = match api::security_scan_report(&root, &ecosystems) {
+            Ok(report) => {
+                if let Err(error) = history::record_security_scan(&root, &ecosystems, &report) {
+                    eprintln!("Failed to record security scan history: {error}");
+                }
+
+                report
+            }
+            Err(error) => {
+                if let Err(history_error) =
+                    history::record_security_failure(&root, &ecosystems, &error.to_string())
+                {
+                    eprintln!("Failed to record security scan history: {history_error}");
+                }
+                return Err(error.to_string());
+            }
+        };
+
+        Ok(report.into())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -235,7 +266,8 @@ pub fn run() {
             execute_cleanup,
             load_activity_history,
             load_cleanup_history,
-            audit
+            audit,
+            security_scan
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
+++ b/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
@@ -40,14 +40,7 @@ export function HistoryList(props: HistoryListProps) {
 
           {entry.kind === 'Scan' ? <ScanDetails entry={entry} /> : null}
           {entry.kind === 'Cleanup' ? <CleanupDetails entry={entry} /> : null}
-          {entry.kind === 'Security' ? (
-            <div className="mt-4">
-              <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Details</p>
-              <pre className="mt-2 overflow-x-auto text-xs text-slate-300">
-                {JSON.stringify(entry.result.details, null, 2)}
-              </pre>
-            </div>
-          ) : null}
+          {entry.kind === 'Security' ? <SecurityDetails entry={entry} /> : null}
         </article>
       ))}
     </div>
@@ -90,6 +83,46 @@ function CleanupDetails({ entry }: { entry: ActivityRecord }) {
               <li key={`${failure.path}-${failure.reason ?? ''}`} className="truncate">
                 - {failure.path}
                 {failure.reason ? ` (${failure.reason})` : ''}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function SecurityDetails({ entry }: { entry: ActivityRecord }) {
+  const details = entry.result.details;
+  const findings = details.findings ?? [];
+
+  return (
+    <>
+      <div className="mt-4 grid gap-2 text-sm text-slate-300 sm:grid-cols-4">
+        <Detail label="Target" value={details.path ?? 'Unknown'} />
+        <Detail label="Ecosystems" value={details.ecosystems?.join(', ') ?? 'All'} />
+        <Detail label="Findings" value={String(details.findingCount ?? findings.length)} />
+        <Detail label="Highest Risk" value={details.highestRisk ?? 'None'} />
+      </div>
+
+      {details.reason ? (
+        <p className="mt-4 text-sm text-rose-200">{details.reason}</p>
+      ) : null}
+
+      {findings.length ? (
+        <div className="mt-4">
+          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Findings</p>
+          <ul className="mt-2 space-y-2 text-sm text-slate-300">
+            {findings.map((finding, index) => (
+              <li
+                key={`${finding.rule}-${finding.source}-${index}`}
+                className="rounded-2xl border border-white/6 bg-white/4 px-3 py-2"
+              >
+                <p className="font-medium text-slate-200">
+                  {finding.rule} · {finding.risk}
+                </p>
+                <p className="mt-1 truncate text-xs text-slate-400">{finding.source}</p>
+                <p className="mt-1 text-xs text-slate-300">{finding.reason}</p>
               </li>
             ))}
           </ul>

--- a/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
+++ b/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
@@ -100,7 +100,16 @@ function SecurityDetails({ entry }: { entry: ActivityRecord }) {
     <>
       <div className="mt-4 grid gap-2 text-sm text-slate-300 sm:grid-cols-4">
         <Detail label="Target" value={details.path ?? 'Unknown'} />
-        <Detail label="Ecosystems" value={details.ecosystems?.join(', ') ?? 'All'} />
+        <Detail
+          label="Ecosystems"
+          value={
+            details.ecosystems
+              ? details.ecosystems.length
+                ? details.ecosystems.join(', ')
+                : 'None'
+              : 'All'
+          }
+        />
         <Detail label="Findings" value={String(details.findingCount ?? findings.length)} />
         <Detail label="Highest Risk" value={details.highestRisk ?? 'None'} />
       </div>

--- a/apps/dustfril-tauri/src/lib/tauri.ts
+++ b/apps/dustfril-tauri/src/lib/tauri.ts
@@ -9,6 +9,7 @@ import type {
   LifecycleScript,
   RunOptions,
   ScanResponse,
+  SecurityScanResponse,
 } from '../types/workflow';
 
 const commands = {
@@ -17,6 +18,7 @@ const commands = {
   analyze: 'analyze',
   buildCleanupPlan: 'build_cleanup_plan',
   audit: 'audit',
+  securityScan: 'security_scan',
   executeCleanup: 'execute_cleanup',
   loadActivityHistory: 'load_activity_history',
   loadCleanupHistory: 'load_cleanup_history',
@@ -40,6 +42,10 @@ export function buildCleanupPlan(options: RunOptions) {
 
 export function auditScripts(options: RunOptions) {
   return invoke<LifecycleScript[]>(commands.audit, { options });
+}
+
+export function securityScan(options: RunOptions) {
+  return invoke<SecurityScanResponse>(commands.securityScan, { options });
 }
 
 export function executeCleanup(candidates: CleanupCandidate[], mode: DeleteMode) {

--- a/apps/dustfril-tauri/src/types/workflow.ts
+++ b/apps/dustfril-tauri/src/types/workflow.ts
@@ -65,6 +65,35 @@ export type LifecycleScript = {
   riskLevel: RiskLevel;
 };
 
+export type SecurityFinding = {
+  path: string;
+  rule: string;
+  package: string | null;
+  riskLevel: RiskLevel;
+  evidence: string | null;
+  reason: string;
+};
+
+export type SecurityWarning = {
+  package: string;
+  scriptType: string;
+  command: string;
+  riskLevel: RiskLevel;
+};
+
+export type LockfileCheck = {
+  path: string;
+  kind: 'PackageLockJson' | 'PnpmLockYaml' | 'BunLock' | 'CargoLock';
+  status: 'Missing' | 'Modified' | 'Untracked' | 'Clean';
+};
+
+export type SecurityScanResponse = {
+  findings: SecurityFinding[];
+  lifecycleWarnings: SecurityWarning[];
+  lockfiles: LockfileCheck[];
+  manifests: string[];
+};
+
 export type ActivityKind = 'Scan' | 'Cleanup' | 'Security';
 
 export type ActivityFailure = {
@@ -80,7 +109,22 @@ export type ActivityDetails = {
   deleted?: string[];
   failed?: ActivityFailure[];
   freed?: number;
+  ecosystems?: Ecosystem[];
+  findingCount?: number;
+  highestRisk?: RiskLevel;
+  findings?: SecurityActivityFinding[];
+  manifests?: number;
+  lockfiles?: number;
+  reason?: string;
   [key: string]: unknown;
+};
+
+export type SecurityActivityFinding = {
+  rule: string;
+  risk: RiskLevel;
+  source: string;
+  package?: string | null;
+  reason: string;
 };
 
 export type ActivityResult = {

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -12,7 +12,7 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - `api::clean::execute`: execute cleanup in Trash or permanent mode
 - `api::audit`: inspect supported lifecycle scripts; malformed manifests are
   returned as errors instead of being silently ignored
-- `api::history`: record and load versioned activity history, including cleanup-history migration
+- `api::history`: record and load versioned activity history, including cleanup-history migration and security scan summaries
 - `api::security_scan`: preserve the lifecycle-only security warnings API
 - `api::security_scan_report`: run the complete offline supply-chain scan
 - `api::check_lockfile_integrity`: check supported lockfile presence and Git status
@@ -37,6 +37,11 @@ It parses npm lockfile versions 1–3, pnpm YAML, Bun JSONC lockfile versions
 1–2, and Cargo.lock versions 1–4. Yarn lockfiles and legacy binary `bun.lockb`
 are intentionally opaque; no npm-missing result is inferred from either when
 it is the only Node lockfile present.
+
+Explicit security scans can be recorded as one `ActivityKind::Security` event
+through `api::history`. The event stores finding counts, highest severity,
+stable rule IDs, relative source locations, and sanitised reasons; command or
+dependency-source evidence is not persisted.
 
 Malformed or unsupported manifests and lockfiles are returned as explicit
 errors. Lifecycle scanning honors an explicit `packageManager` declaration;

--- a/crates/dustfril-core/src/api/history.rs
+++ b/crates/dustfril-core/src/api/history.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 use crate::{
     error::DustResult,
     history,
-    models::{ActivityRecord, CleanupHistoryEntry, CleanupResult, DeleteMode, ScanResult},
+    models::{
+        ActivityRecord, CleanupHistoryEntry, CleanupResult, DeleteMode, Ecosystem, ScanResult,
+        SecurityReport,
+    },
 };
 
 /// Backwards-compatible cleanup history entry point.
@@ -28,6 +31,24 @@ pub fn record_scan(
     total_size_bytes: u64,
 ) -> DustResult<()> {
     history::record_scan(target_path, result, total_size_bytes)
+}
+
+/// Records one explicit security scan in the unified activity history.
+pub fn record_security_scan(
+    target_path: &Path,
+    ecosystems: &[Ecosystem],
+    report: &SecurityReport,
+) -> DustResult<()> {
+    history::record_security_scan(target_path, ecosystems, report)
+}
+
+/// Records a failed explicit security scan in the unified activity history.
+pub fn record_security_failure(
+    target_path: &Path,
+    ecosystems: &[Ecosystem],
+    reason: &str,
+) -> DustResult<()> {
+    history::record_security_failure(target_path, ecosystems, reason)
 }
 
 pub fn load_all() -> DustResult<Vec<ActivityRecord>> {

--- a/crates/dustfril-core/src/history/mod.rs
+++ b/crates/dustfril-core/src/history/mod.rs
@@ -11,7 +11,10 @@ use serde_json::Value;
 
 use crate::{
     error::{DustError, DustResult},
-    models::{ActivityRecord, CleanupHistoryEntry, CleanupResult, DeleteMode, ScanResult},
+    models::{
+        ActivityRecord, CleanupHistoryEntry, CleanupResult, DeleteMode, Ecosystem, ScanResult,
+        SecurityReport,
+    },
 };
 
 const HISTORY_VERSION: u32 = 1;
@@ -50,6 +53,28 @@ pub fn record_scan(
     total_size_bytes: u64,
 ) -> DustResult<()> {
     record(ActivityRecord::scan(target_path, result, total_size_bytes))
+}
+
+/// Records one explicit security scan in the unified activity history.
+pub fn record_security_scan(
+    target_path: &Path,
+    ecosystems: &[Ecosystem],
+    report: &SecurityReport,
+) -> DustResult<()> {
+    record(ActivityRecord::security(target_path, ecosystems, report))
+}
+
+/// Records a failed explicit security scan in the unified activity history.
+pub fn record_security_failure(
+    target_path: &Path,
+    ecosystems: &[Ecosystem],
+    reason: &str,
+) -> DustResult<()> {
+    record(ActivityRecord::security_failure(
+        target_path,
+        ecosystems,
+        reason,
+    ))
 }
 
 /// Loads all activity records, migrating a legacy cleanup history when needed.
@@ -171,6 +196,7 @@ mod tests {
     use super::*;
     use crate::models::{
         ActivityKind, ActivityResult, Artifact, CleanupFailure, CleanupFailureReason, Ecosystem,
+        RiskLevel, SecurityFinding, SecurityFindingKind, SecurityReport,
     };
 
     fn cleanup_result() -> CleanupResult {
@@ -320,6 +346,40 @@ mod tests {
         assert!(!activity.result.success);
         assert_eq!(activity.result.details["deleted"][0], "target");
         assert_eq!(activity.result.details["failed"][0]["path"], "node_modules");
+    }
+
+    #[test]
+    fn security_activity_is_persisted_as_one_reloadable_unified_record() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("history.json");
+        let report = SecurityReport {
+            findings: vec![SecurityFinding::new(
+                temp.path().join("package.json"),
+                SecurityFindingKind::MissingLockfile,
+                None,
+                RiskLevel::High,
+                None,
+                "Expected lockfile is missing.",
+            )],
+            ..SecurityReport::default()
+        };
+
+        record_to(
+            &path,
+            ActivityRecord::security(temp.path(), &[Ecosystem::Node], &report),
+        )
+        .unwrap();
+
+        let records = load_unlocked(&path).unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].kind, ActivityKind::Security);
+        assert_eq!(records[0].result.details["findingCount"], 1);
+        assert_eq!(records[0].result.details["highestRisk"], "High");
+        assert_eq!(
+            records[0].result.details["findings"][0]["source"],
+            "package.json"
+        );
     }
 
     fn record_to(path: &Path, activity: ActivityRecord) -> DustResult<()> {

--- a/crates/dustfril-core/src/models/audit.rs
+++ b/crates/dustfril-core/src/models/audit.rs
@@ -48,6 +48,20 @@ impl fmt::Display for SecurityFindingKind {
     }
 }
 
+impl SecurityFindingKind {
+    /// Returns the stable identifier persisted in activity history.
+    pub fn rule_id(self) -> &'static str {
+        match self {
+            Self::SuspiciousScript => "suspicious-script",
+            Self::UntrustedDependency => "untrusted-dependency",
+            Self::KnownMaliciousPackage => "known-malicious-package",
+            Self::MissingLockfile => "missing-lockfile",
+            Self::ModifiedLockfile => "modified-lockfile",
+            Self::UntrackedLockfile => "untracked-lockfile",
+        }
+    }
+}
+
 /// A normalized supply-chain security finding.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SecurityFinding {
@@ -181,5 +195,26 @@ impl fmt::Display for RiskLevel {
         };
 
         write!(f, "{value}")
+    }
+}
+
+impl RiskLevel {
+    /// Returns the severity ordering used when summarising a security scan.
+    pub fn highest(self, other: Self) -> Self {
+        if self.rank() >= other.rank() {
+            self
+        } else {
+            other
+        }
+    }
+
+    fn rank(self) -> u8 {
+        match self {
+            Self::None => 0,
+            Self::Low => 1,
+            Self::Medium => 2,
+            Self::High => 3,
+            Self::Critical => 4,
+        }
     }
 }

--- a/crates/dustfril-core/src/models/history.rs
+++ b/crates/dustfril-core/src/models/history.rs
@@ -4,7 +4,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::models::{CleanupResult, DeleteMode, Ecosystem, RiskLevel, ScanResult, SecurityReport};
+use crate::models::{
+    CleanupResult, DeleteMode, Ecosystem, RiskLevel, ScanResult, SecurityReport,
+    effective_security_ecosystems,
+};
 
 /// The kind of operation represented by an activity record.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -114,7 +117,7 @@ impl ActivityResult {
             true,
             json!({
                 "path": sanitize_path(target_path),
-                "ecosystems": ecosystem_labels(ecosystems),
+                "ecosystems": ecosystem_labels(&effective_security_ecosystems(ecosystems)),
                 "findingCount": report.findings.len(),
                 "highestRisk": highest_risk.to_string(),
                 "findings": findings,
@@ -134,7 +137,7 @@ impl ActivityResult {
             false,
             json!({
                 "path": sanitize_path(target_path),
-                "ecosystems": ecosystem_labels(ecosystems),
+                "ecosystems": ecosystem_labels(&effective_security_ecosystems(ecosystems)),
                 "findingCount": 0,
                 "highestRisk": RiskLevel::None.to_string(),
                 "findings": [],

--- a/crates/dustfril-core/src/models/history.rs
+++ b/crates/dustfril-core/src/models/history.rs
@@ -1,10 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::models::{CleanupResult, DeleteMode, ScanResult};
+use crate::models::{CleanupResult, DeleteMode, Ecosystem, RiskLevel, ScanResult, SecurityReport};
 
 /// The kind of operation represented by an activity record.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -79,6 +79,69 @@ impl ActivityResult {
             }),
         )
     }
+
+    /// Builds a safe, structured result payload for a completed security scan.
+    ///
+    /// Finding evidence is intentionally excluded because it can contain
+    /// commands, URLs, or other user-provided values. The remaining fields
+    /// are sanitised before they are persisted to the local activity history.
+    pub fn from_security(
+        target_path: &Path,
+        ecosystems: &[Ecosystem],
+        report: &SecurityReport,
+    ) -> Self {
+        let highest_risk = report
+            .findings
+            .iter()
+            .fold(RiskLevel::None, |highest, finding| {
+                highest.highest(finding.risk_level)
+            });
+        let findings = report
+            .findings
+            .iter()
+            .map(|finding| {
+                json!({
+                    "rule": finding.kind.rule_id(),
+                    "risk": finding.risk_level.to_string(),
+                    "source": source_path(target_path, &finding.path),
+                    "package": finding.package.as_deref().map(sanitize_text),
+                    "reason": sanitize_text(&finding.reason),
+                })
+            })
+            .collect::<Vec<_>>();
+
+        Self::new(
+            true,
+            json!({
+                "path": sanitize_path(target_path),
+                "ecosystems": ecosystem_labels(ecosystems),
+                "findingCount": report.findings.len(),
+                "highestRisk": highest_risk.to_string(),
+                "findings": findings,
+                "manifests": report.manifests.len(),
+                "lockfiles": report.lockfiles.len(),
+            }),
+        )
+    }
+
+    /// Builds a failed security result without persisting the raw error text.
+    pub fn from_security_failure(
+        target_path: &Path,
+        ecosystems: &[Ecosystem],
+        reason: &str,
+    ) -> Self {
+        Self::new(
+            false,
+            json!({
+                "path": sanitize_path(target_path),
+                "ecosystems": ecosystem_labels(ecosystems),
+                "findingCount": 0,
+                "highestRisk": RiskLevel::None.to_string(),
+                "findings": [],
+                "reason": sanitize_text(reason),
+            }),
+        )
+    }
 }
 
 /// A single operation in the local DustFril activity log.
@@ -111,6 +174,20 @@ impl ActivityRecord {
         Self::new(
             ActivityKind::Cleanup,
             ActivityResult::from_cleanup(mode, result),
+        )
+    }
+
+    pub fn security(target_path: &Path, ecosystems: &[Ecosystem], report: &SecurityReport) -> Self {
+        Self::new(
+            ActivityKind::Security,
+            ActivityResult::from_security(target_path, ecosystems, report),
+        )
+    }
+
+    pub fn security_failure(target_path: &Path, ecosystems: &[Ecosystem], reason: &str) -> Self {
+        Self::new(
+            ActivityKind::Security,
+            ActivityResult::from_security_failure(target_path, ecosystems, reason),
         )
     }
 }
@@ -168,6 +245,153 @@ fn paths_to_values(paths: &[PathBuf]) -> Vec<Value> {
         .collect()
 }
 
+fn ecosystem_labels(ecosystems: &[Ecosystem]) -> Vec<&'static str> {
+    ecosystems
+        .iter()
+        .map(|ecosystem| match ecosystem {
+            Ecosystem::Rust => "Rust",
+            Ecosystem::Node => "Node",
+            Ecosystem::Java => "Java",
+        })
+        .collect()
+}
+
+fn source_path(root: &Path, finding_path: &Path) -> String {
+    let source = finding_path
+        .strip_prefix(root)
+        .unwrap_or(finding_path)
+        .display()
+        .to_string();
+
+    sanitize_text(&source)
+}
+
+fn sanitize_path(path: &Path) -> String {
+    sanitize_text(&path.display().to_string())
+}
+
+/// Redacts common credential-shaped values while retaining useful context.
+fn sanitize_text(value: &str) -> String {
+    let value = redact_inline_assignments(value);
+    let words = value.split_whitespace().collect::<Vec<_>>();
+    let mut sanitized = Vec::with_capacity(words.len());
+    let mut redact_next = false;
+
+    for word in words {
+        if redact_next {
+            sanitized.push("[REDACTED]".to_owned());
+            redact_next = false;
+            continue;
+        }
+
+        let normalized = word
+            .trim_matches(|character: char| character == '-' || character == ':')
+            .to_ascii_lowercase();
+        if is_sensitive_key(&normalized) || normalized == "bearer" {
+            sanitized.push(word.to_owned());
+            redact_next = true;
+        } else {
+            sanitized.push(word.to_owned());
+        }
+    }
+
+    sanitized.join(" ")
+}
+
+fn redact_inline_assignments(value: &str) -> String {
+    let mut sanitized = value.to_owned();
+
+    for key in [
+        "token",
+        "password",
+        "passwd",
+        "secret",
+        "api_key",
+        "api-key",
+        "credential",
+        "authorization",
+    ] {
+        for separator in ['=', ':'] {
+            sanitized = redact_assignment(&sanitized, key, separator);
+        }
+    }
+
+    sanitized
+}
+
+fn redact_assignment(value: &str, key: &str, separator: char) -> String {
+    let lower = value.to_ascii_lowercase();
+    let mut result = String::with_capacity(value.len());
+    let mut cursor = 0;
+
+    while let Some(relative) = lower[cursor..].find(key) {
+        let start = cursor + relative;
+        let before_is_boundary = start == 0
+            || !lower.as_bytes()[start - 1].is_ascii_alphanumeric()
+                && lower.as_bytes()[start - 1] != b'_'
+                && lower.as_bytes()[start - 1] != b'-';
+        let key_end = start + key.len();
+        let key_is_complete = key_end == value.len()
+            || !lower.as_bytes()[key_end].is_ascii_alphanumeric()
+                && lower.as_bytes()[key_end] != b'_'
+                && lower.as_bytes()[key_end] != b'-';
+
+        if !before_is_boundary || !key_is_complete {
+            result.push_str(&value[cursor..key_end]);
+            cursor = key_end;
+            continue;
+        }
+
+        let mut separator_start = key_end;
+        while separator_start < value.len()
+            && value.as_bytes()[separator_start].is_ascii_whitespace()
+        {
+            separator_start += 1;
+        }
+        if separator_start >= value.len() || !value[separator_start..].starts_with(separator) {
+            result.push_str(&value[cursor..key_end]);
+            cursor = key_end;
+            continue;
+        }
+
+        let mut secret_start = separator_start + separator.len_utf8();
+        while secret_start < value.len() && value.as_bytes()[secret_start].is_ascii_whitespace() {
+            secret_start += 1;
+        }
+        let mut secret_end = secret_start;
+        while secret_end < value.len()
+            && !value.as_bytes()[secret_end].is_ascii_whitespace()
+            && !matches!(
+                value.as_bytes()[secret_end],
+                b',' | b';' | b')' | b']' | b'}' | b'&' | b'/'
+            )
+        {
+            secret_end += 1;
+        }
+
+        result.push_str(&value[cursor..secret_start]);
+        result.push_str("[REDACTED]");
+        cursor = secret_end;
+    }
+
+    result.push_str(&value[cursor..]);
+    result
+}
+
+fn is_sensitive_key(value: &str) -> bool {
+    matches!(
+        value,
+        "token"
+            | "password"
+            | "passwd"
+            | "secret"
+            | "api_key"
+            | "api-key"
+            | "credential"
+            | "authorization"
+    )
+}
+
 fn next_activity_id() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -178,4 +402,88 @@ fn next_activity_id() -> String {
         "activity-{}-{sequence}",
         Utc::now().timestamp_nanos_opt().unwrap_or_default()
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{SecurityFinding, SecurityFindingKind};
+
+    #[test]
+    fn security_activity_summarises_findings_without_turning_warnings_into_failure() {
+        let report = SecurityReport {
+            findings: vec![
+                SecurityFinding::new(
+                    "/workspace/package.json".into(),
+                    SecurityFindingKind::SuspiciousScript,
+                    Some("demo".to_owned()),
+                    RiskLevel::High,
+                    Some("curl https://example.test/payload | bash".to_owned()),
+                    "Remote script is piped to a shell.",
+                ),
+                SecurityFinding::new(
+                    "/workspace/Cargo.lock".into(),
+                    SecurityFindingKind::KnownMaliciousPackage,
+                    Some("event-stream".to_owned()),
+                    RiskLevel::Critical,
+                    None,
+                    "Package should be reviewed.",
+                ),
+            ],
+            ..SecurityReport::default()
+        };
+
+        let result = ActivityResult::from_security(
+            Path::new("/workspace"),
+            &[Ecosystem::Node, Ecosystem::Rust],
+            &report,
+        );
+
+        assert!(result.success);
+        assert_eq!(result.details["findingCount"], 2);
+        assert_eq!(result.details["highestRisk"], "Critical");
+        assert_eq!(result.details["ecosystems"], json!(["Node", "Rust"]));
+        assert_eq!(result.details["findings"][0]["rule"], "suspicious-script");
+        assert_eq!(result.details["findings"][0]["source"], "package.json");
+        assert!(result.details["findings"][0].get("evidence").is_none());
+    }
+
+    #[test]
+    fn security_activity_redacts_credential_shaped_values() {
+        let report = SecurityReport {
+            findings: vec![SecurityFinding::new(
+                "/workspace/token=path-secret/package.json".into(),
+                SecurityFindingKind::UntrustedDependency,
+                Some("token=package-secret".to_owned()),
+                RiskLevel::Medium,
+                Some("TOKEN=command-secret".to_owned()),
+                "token=reason-secret password: password-secret",
+            )],
+            ..SecurityReport::default()
+        };
+
+        let result = ActivityResult::from_security(Path::new("/workspace"), &[], &report);
+        let serialized = serde_json::to_string(&result).unwrap();
+
+        assert!(!serialized.contains("path-secret"));
+        assert!(!serialized.contains("package-secret"));
+        assert!(!serialized.contains("command-secret"));
+        assert!(!serialized.contains("reason-secret"));
+        assert!(!serialized.contains("password-secret"));
+        assert!(serialized.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn failed_security_activity_preserves_failure_status_and_safe_summary() {
+        let result = ActivityResult::from_security_failure(
+            Path::new("/workspace"),
+            &[Ecosystem::Node],
+            "Manifest error: token=scan-secret",
+        );
+
+        assert!(!result.success);
+        assert_eq!(result.details["findingCount"], 0);
+        assert_eq!(result.details["highestRisk"], "None");
+        assert_eq!(result.details["reason"], "Manifest error: token=[REDACTED]");
+    }
 }

--- a/crates/dustfril-core/src/models/mod.rs
+++ b/crates/dustfril-core/src/models/mod.rs
@@ -11,4 +11,5 @@ pub use audit::*;
 pub use cleanup::*;
 pub use history::*;
 pub use lockfile::*;
+pub(crate) use scan::effective_security_ecosystems;
 pub use scan::*;

--- a/crates/dustfril-core/src/models/scan.rs
+++ b/crates/dustfril-core/src/models/scan.rs
@@ -23,6 +23,26 @@ impl fmt::Display for Ecosystem {
     }
 }
 
+/// Returns the effective ecosystems supported by the security scanner.
+///
+/// An empty selection means the scanner's default Node and Rust scope. Other
+/// ecosystems are ignored, matching the scanner's execution semantics.
+pub(crate) fn effective_security_ecosystems(selected: &[Ecosystem]) -> Vec<Ecosystem> {
+    if selected.is_empty() {
+        return vec![Ecosystem::Node, Ecosystem::Rust];
+    }
+
+    let mut effective = Vec::new();
+    for ecosystem in selected.iter().copied() {
+        if matches!(ecosystem, Ecosystem::Node | Ecosystem::Rust) && !effective.contains(&ecosystem)
+        {
+            effective.push(ecosystem);
+        }
+    }
+
+    effective
+}
+
 /// Result of scanning a filesystem tree for removable artifacts.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ScanResult {
@@ -63,5 +83,23 @@ mod tests {
 
         assert_eq!(artifact.path, PathBuf::from("target"));
         assert_eq!(artifact.ecosystem, Ecosystem::Rust);
+    }
+
+    #[test]
+    fn security_scope_matches_scanner_defaults_and_filters_unsupported_ecosystems() {
+        assert_eq!(
+            effective_security_ecosystems(&[]),
+            vec![Ecosystem::Node, Ecosystem::Rust]
+        );
+        assert_eq!(
+            effective_security_ecosystems(&[
+                Ecosystem::Java,
+                Ecosystem::Rust,
+                Ecosystem::Node,
+                Ecosystem::Rust,
+            ]),
+            vec![Ecosystem::Rust, Ecosystem::Node]
+        );
+        assert!(effective_security_ecosystems(&[Ecosystem::Java]).is_empty());
     }
 }

--- a/crates/dustfril-core/src/security.rs
+++ b/crates/dustfril-core/src/security.rs
@@ -16,7 +16,7 @@ use crate::{
     lockfile,
     models::{
         Ecosystem, LockfileCheck, LockfileKind, LockfileStatus, RiskLevel, SecurityFinding,
-        SecurityFindingKind, SecurityReport,
+        SecurityFindingKind, SecurityReport, effective_security_ecosystems,
     },
 };
 
@@ -44,8 +44,9 @@ const KNOWN_COMPROMISED_PACKAGES: &[&str] = &[
 
 /// Runs the complete offline security scan for the selected ecosystems.
 pub fn scan(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<SecurityReport> {
-    let scan_node = ecosystems.is_empty() || ecosystems.contains(&Ecosystem::Node);
-    let scan_rust = ecosystems.is_empty() || ecosystems.contains(&Ecosystem::Rust);
+    let effective_ecosystems = effective_security_ecosystems(ecosystems);
+    let scan_node = effective_ecosystems.contains(&Ecosystem::Node);
+    let scan_rust = effective_ecosystems.contains(&Ecosystem::Rust);
 
     if !scan_node && !scan_rust {
         validate_root(root)?;


### PR DESCRIPTION
## Summary
- persist one Core-owned Security activity per explicit CLI/Tauri security scan
- record finding count, highest risk, ecosystem scope, stable rule IDs, source paths, and sanitised reasons
- record failed scans without treating findings as operational failures
- keep history writes auxiliary and surface write errors without losing completed results
- expose the Tauri security_scan command and render Security entries in the history view

## Tests
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-fail-fast
- npm run build (apps/dustfril-tauri)

Closes #60