### PR TITLE
Validate unified activity audit semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ cargo run -p dustfril-cli -- clean
 cargo run -p dustfril-cli -- clean --permanent
 cargo run -p dustfril-cli -- audit --node
 cargo run -p dustfril-cli -- security scan --node
+cargo run -p dustfril-cli -- history
 ```
 
 Filter by ecosystem or pass a target path:
@@ -82,6 +83,7 @@ Available commands:
 - `clean [path] [--dry-run] [--permanent] [--rust] [--node] [--java]`
 - `audit [path] [--node]`
 - `security scan [path] [--node]`
+- `history`
 
 `security scan` is a read-only, offline check of `package.json`, `Cargo.toml`,
 `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `Cargo.lock`. It reports
@@ -100,6 +102,7 @@ The desktop app currently exposes the same core workflows in a workspace browser
 - cleanup plan
 - cleanup execution
 - lifecycle script audit
+- unified activity history
 
 Start the frontend app from `apps/dustfril-tauri`:
 

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -11,6 +11,7 @@ This package exposes the `dfr` binary and wraps the shared logic from `dustfril-
 - `clean`: preview or execute cleanup
 - `audit`: inspect Node lifecycle scripts
 - `security scan`: inspect Node and Rust manifests and lockfiles for supply-chain risks
+- `history`: load the unified local activity history as JSON
 
 ## Run
 
@@ -22,6 +23,7 @@ cargo run -p dustfril-cli -- analyze
 cargo run -p dustfril-cli -- clean --dry-run
 cargo run -p dustfril-cli -- audit --node
 cargo run -p dustfril-cli -- security scan --node
+cargo run -p dustfril-cli -- history
 ```
 
 Direct package build:
@@ -34,8 +36,10 @@ cargo build -p dustfril-cli
 
 - Supported ecosystem filters: `--rust`, `--node`, `--java`
 - `clean` asks for confirmation before deletion
+- `clean --dry-run` previews without appending a cleanup activity
 - command failures return a non-zero process exit status
 - security scans are read-only and use deterministic offline checks
+- activity-history write failures are reported without discarding a completed operation result
 - Activity history is stored in the OS app data directory as a versioned `history.json`.
   Existing cleanup-history arrays are migrated when the file is read or appended to.
 - Each explicit `security scan` appends one Security activity with its result

--- a/apps/dustfril-cli/src/cli.rs
+++ b/apps/dustfril-cli/src/cli.rs
@@ -27,6 +27,9 @@ pub enum Commands {
     /// Clean detected artifacts
     Clean(CleanArgs),
 
+    /// Show the unified local activity history
+    History,
+
     /// Audit lifecycle scripts
     Audit(PathArgs),
 
@@ -160,5 +163,12 @@ mod tests {
                 command: SecurityCommands::Scan(PathArgs { node: true, .. })
             })
         ));
+    }
+
+    #[test]
+    fn cli_parses_history_command() {
+        let cli = Cli::try_parse_from(["dfr", "history"]).unwrap();
+
+        assert!(matches!(cli.command, Commands::History));
     }
 }

--- a/apps/dustfril-cli/src/commands/analyze.rs
+++ b/apps/dustfril-cli/src/commands/analyze.rs
@@ -2,8 +2,8 @@ use dustfril_core::api;
 use dustfril_core::models::{AnalysisResult, CleanupRecommendation};
 
 use crate::cli::PathArgs;
-use crate::format;
 use crate::shared::path::{resolve_path, validate_path};
+use crate::{format, history};
 
 fn print_summary(analysis: &AnalysisResult) {
     let mut keep = 0;
@@ -74,6 +74,9 @@ pub fn execute(args: PathArgs) -> bool {
     let scan_result = match api::scan(&path, &ecosystems) {
         Ok(res) => res,
         Err(e) => {
+            if let Err(history_error) = history::record_scan_failure(&path, &e.to_string()) {
+                eprintln!("Failed to record scan failure history: {history_error}");
+            }
             eprintln!("Scan failed: {}", e);
             return false;
         }

--- a/apps/dustfril-cli/src/commands/clean.rs
+++ b/apps/dustfril-cli/src/commands/clean.rs
@@ -33,15 +33,27 @@ pub fn dry_run(args: &CleanArgs) -> bool {
 }
 
 pub fn execute(args: &CleanArgs) -> bool {
+    let mode = if args.permanent {
+        DeleteMode::Permanent
+    } else {
+        DeleteMode::default()
+    };
+
     let plan = match build_cleanup_plan(args) {
         Ok(plan) => plan,
         Err(e) => {
+            if let Err(history_error) = history::record_cleanup_failure(mode, &e.to_string()) {
+                eprintln!("Failed to record cleanup failure history: {history_error}");
+            }
             eprintln!("Cleanup preparation failed: {}", e);
             return false;
         }
     };
 
     if plan.candidates.is_empty() {
+        let result = CleanupResult::default();
+        history::record(mode, &result)
+            .unwrap_or_else(|e| eprintln!("Failed to record cleanup history: {e}"));
         println!("No cleanup candidates found.");
         return true;
     }
@@ -60,15 +72,12 @@ pub fn execute(args: &CleanArgs) -> bool {
         }
     }
 
-    let mode = if args.permanent {
-        DeleteMode::Permanent
-    } else {
-        DeleteMode::default()
-    };
-
     let result = match api::clean::execute(&plan, mode) {
         Ok(res) => res,
         Err(e) => {
+            if let Err(history_error) = history::record_cleanup_failure(mode, &e.to_string()) {
+                eprintln!("Failed to record cleanup failure history: {history_error}");
+            }
             eprintln!("Cleanup failed: {}", e);
             return false;
         }
@@ -95,10 +104,7 @@ fn build_cleanup_plan(args: &CleanArgs) -> Result<CleanupPlan, DustError> {
     let ecosystems = args.ecosystems();
 
     let scan = api::scan(&path, &ecosystems)?;
-    let analysis = api::analyze(scan.clone())?;
-    if let Err(error) = api::history::record_scan(&path, &scan, analysis.total_size_bytes) {
-        eprintln!("Failed to record scan history: {error}");
-    }
+    let analysis = api::analyze(scan)?;
     let plan = api::clean::build_plan_from_analysis(analysis)?;
 
     Ok(plan)

--- a/apps/dustfril-cli/src/commands/history.rs
+++ b/apps/dustfril-cli/src/commands/history.rs
@@ -1,0 +1,23 @@
+use dustfril_core::api;
+
+/// Loads and prints the same unified activity records used by the desktop app.
+pub fn execute() -> bool {
+    let records = match api::history::load_all() {
+        Ok(records) => records,
+        Err(error) => {
+            eprintln!("Failed to load activity history: {error}");
+            return false;
+        }
+    };
+
+    match serde_json::to_string_pretty(&records) {
+        Ok(json) => {
+            println!("{json}");
+            true
+        }
+        Err(error) => {
+            eprintln!("Failed to format activity history: {error}");
+            false
+        }
+    }
+}

--- a/apps/dustfril-cli/src/commands/mod.rs
+++ b/apps/dustfril-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod analyze;
 pub mod audit;
 pub mod clean;
+pub mod history;
 pub mod scan;
 pub mod security;

--- a/apps/dustfril-cli/src/commands/scan.rs
+++ b/apps/dustfril-cli/src/commands/scan.rs
@@ -2,6 +2,7 @@ use dustfril_core::api;
 
 use crate::{
     cli::PathArgs,
+    history,
     shared::path::{resolve_path, validate_path},
 };
 
@@ -23,6 +24,9 @@ pub fn execute(args: PathArgs) -> bool {
     let result = match api::scan(&path, &ecosystems) {
         Ok(res) => res,
         Err(e) => {
+            if let Err(history_error) = history::record_scan_failure(&path, &e.to_string()) {
+                eprintln!("Failed to record scan failure history: {history_error}");
+            }
             eprintln!("Scan failed: {}", e);
             return false;
         }

--- a/apps/dustfril-cli/src/history.rs
+++ b/apps/dustfril-cli/src/history.rs
@@ -6,3 +6,16 @@ pub fn record(
 ) -> std::io::Result<()> {
     api::history::record(mode, result).map_err(|error| std::io::Error::other(error.to_string()))
 }
+
+pub fn record_scan_failure(target_path: &std::path::Path, reason: &str) -> std::io::Result<()> {
+    api::history::record_scan_failure(target_path, reason)
+        .map_err(|error| std::io::Error::other(error.to_string()))
+}
+
+pub fn record_cleanup_failure(
+    mode: dustfril_core::models::DeleteMode,
+    reason: &str,
+) -> std::io::Result<()> {
+    api::history::record_cleanup_failure(mode, reason)
+        .map_err(|error| std::io::Error::other(error.to_string()))
+}

--- a/apps/dustfril-cli/src/main.rs
+++ b/apps/dustfril-cli/src/main.rs
@@ -25,6 +25,8 @@ fn main() -> ExitCode {
             }
         }
 
+        Commands::History => commands::history::execute(),
+
         Commands::Audit(args) => commands::audit::execute(&args),
 
         Commands::Security(args) => match args.command {

--- a/apps/dustfril-tauri/README.md
+++ b/apps/dustfril-tauri/README.md
@@ -28,12 +28,13 @@ case-sensitive.
 | Command | Request | Response |
 | --- | --- | --- |
 | `default_root` | none | path string |
-| `scan` | `{ options: RunOptions }` | `ScanResponse` |
+| `scan` | `{ options: RunOptions }` | `ScanResponse` (may include additive `historyWarning`) |
 | `analyze` | `{ options: RunOptions }` | `AnalysisResponse` |
 | `build_cleanup_plan` | `{ options: RunOptions }` | `CleanupPlanResponse` |
 | `audit` | `{ options: RunOptions }` | `LifecycleScript[]` |
-| `security_scan` | `{ options: RunOptions }` | `SecurityScanResponse` |
-| `execute_cleanup` | `{ request: { candidates, mode } }` | `CleanupResultResponse` |
+| `security_scan` | `{ options: RunOptions }` | `SecurityScanResponse` (may include additive `historyWarning`) |
+| `execute_cleanup` | `{ request: { candidates, mode } }` | `CleanupResultResponse` (may include additive `historyWarning`) |
+| `load_activity_history` | none | `ActivityRecord[]` |
 | `load_cleanup_history` | none | `CleanupHistoryEntry[]` |
 
 Contract changes must preserve existing command names, field names, nullability,
@@ -47,6 +48,10 @@ boundary and matching Rust serialization tests and TypeScript updates.
 - Scan, analyze, review, and cleanup workflow
 - Safe cleanup with Trash or permanent delete confirmation
 - Activity history viewer backed by shared, versioned core history storage
+
+Activity persistence is auxiliary to scan, cleanup, and security results. If a
+history write fails, the operation response remains available and includes an
+additive `historyWarning` for the desktop status surface.
 
 ## UI Components
 

--- a/apps/dustfril-tauri/src-tauri/src/contract.rs
+++ b/apps/dustfril-tauri/src-tauri/src/contract.rs
@@ -34,6 +34,8 @@ pub(crate) struct CleanupCandidateInput {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ScanResponse {
     pub(crate) artifacts: Vec<ArtifactDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) history_warning: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -83,6 +85,8 @@ pub(crate) struct CleanupResultResponse {
     pub(crate) deleted_paths: Vec<String>,
     pub(crate) failed_paths: Vec<CleanupFailureDto>,
     pub(crate) freed_size_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) history_warning: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -119,6 +123,8 @@ pub(crate) struct SecurityScanResponse {
     pub(crate) lifecycle_warnings: Vec<SecurityWarningDto>,
     pub(crate) lockfiles: Vec<LockfileCheckDto>,
     pub(crate) manifests: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) history_warning: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -341,6 +347,7 @@ impl From<SecurityReport> for SecurityScanResponse {
                 .into_iter()
                 .map(|path| path.display().to_string())
                 .collect(),
+            history_warning: None,
         }
     }
 }
@@ -532,6 +539,7 @@ mod tests {
                 reason: "PermissionDenied".to_string(),
             }],
             freed_size_bytes: 42,
+            history_warning: None,
         };
 
         assert_eq!(
@@ -566,6 +574,7 @@ mod tests {
                 path: "/workspace/node_modules".to_string(),
                 ecosystem: EcosystemDto::Node,
             }],
+            history_warning: None,
         };
         let history = CleanupHistoryEntryDto {
             executed_at_ms: 1_750_000_000_000,
@@ -620,6 +629,34 @@ mod tests {
                 "riskLevel": "High",
                 "evidence": "curl payload | bash",
                 "reason": "Remote script is piped to a shell."
+            })
+        );
+    }
+
+    #[test]
+    fn history_warning_is_additive_and_omitted_for_healthy_operations() {
+        let scan = ScanResponse {
+            artifacts: Vec::new(),
+            history_warning: None,
+        };
+        let cleanup = CleanupResultResponse {
+            deleted_paths: Vec::new(),
+            failed_paths: Vec::new(),
+            freed_size_bytes: 0,
+            history_warning: Some("history is unavailable".to_owned()),
+        };
+
+        assert_eq!(
+            serde_json::to_value(scan).unwrap(),
+            json!({"artifacts": []})
+        );
+        assert_eq!(
+            serde_json::to_value(cleanup).unwrap(),
+            json!({
+                "deletedPaths": [],
+                "failedPaths": [],
+                "freedSizeBytes": 0,
+                "historyWarning": "history is unavailable"
             })
         );
     }

--- a/apps/dustfril-tauri/src-tauri/src/history.rs
+++ b/apps/dustfril-tauri/src-tauri/src/history.rs
@@ -35,6 +35,16 @@ pub fn record_scan(
         .map_err(|error| error.to_string())
 }
 
+/// Records a scan that failed before producing a scan result.
+pub fn record_scan_failure(target_path: &Path, reason: &str) -> Result<(), String> {
+    api::history::record_scan_failure(target_path, reason).map_err(|error| error.to_string())
+}
+
+/// Records a cleanup that failed before producing a cleanup result.
+pub fn record_cleanup_failure(mode: DeleteMode, reason: &str) -> Result<(), String> {
+    api::history::record_cleanup_failure(mode, reason).map_err(|error| error.to_string())
+}
+
 /// Records one explicit security scan for the desktop activity log.
 pub fn record_security_scan(
     target_path: &Path,

--- a/apps/dustfril-tauri/src-tauri/src/lib.rs
+++ b/apps/dustfril-tauri/src-tauri/src/lib.rs
@@ -2,7 +2,9 @@ mod contract;
 mod history;
 
 use std::{
-    env, fs,
+    env,
+    fmt::Display,
+    fs,
     io::ErrorKind,
     path::{Path, PathBuf},
     time::UNIX_EPOCH,
@@ -59,6 +61,16 @@ fn system_time_to_ms(value: std::time::SystemTime) -> Option<u64> {
         .and_then(|duration| u64::try_from(duration.as_millis()).ok())
 }
 
+fn format_history_warning(operation: &str, error: impl Display) -> String {
+    let warning = format!("Failed to record {operation} activity history: {error}");
+    eprintln!("{warning}");
+    warning
+}
+
+fn report_failed_activity_record(operation: &str, error: impl Display) {
+    let _ = format_history_warning(operation, error);
+}
+
 #[tauri::command]
 async fn default_root() -> Result<String, String> {
     tokio::task::spawn_blocking(|| default_root_path().map(|path| path.display().to_string()))
@@ -72,13 +84,33 @@ async fn scan(options: RunOptions) -> Result<ScanResponse, String> {
     let ecosystems: Vec<_> = options.ecosystems.into_iter().map(Into::into).collect();
 
     tokio::task::spawn_blocking(move || {
-        let result = api::scan(&root, &ecosystems).map_err(|error| error.to_string())?;
-        let total_size_bytes = api::analyze(result.clone())
-            .map_err(|error| error.to_string())?
-            .total_size_bytes;
+        let result = match api::scan(&root, &ecosystems) {
+            Ok(result) => result,
+            Err(error) => {
+                if let Err(history_error) = history::record_scan_failure(&root, &error.to_string())
+                {
+                    report_failed_activity_record("scan", history_error);
+                }
+                return Err(error.to_string());
+            }
+        };
+        let mut history_warning = None;
+        let total_size_bytes = match api::analyze(result.clone()) {
+            Ok(analysis) => Some(analysis.total_size_bytes),
+            Err(error) => {
+                let warning = format!(
+                    "Failed to calculate scan size; scan activity history was not recorded: {error}"
+                );
+                eprintln!("{warning}");
+                history_warning = Some(warning);
+                None
+            }
+        };
 
-        if let Err(error) = history::record_scan(&root, &result, total_size_bytes) {
-            eprintln!("Failed to record scan history: {error}");
+        if let Some(total_size_bytes) = total_size_bytes {
+            if let Err(error) = history::record_scan(&root, &result, total_size_bytes) {
+                history_warning = Some(format_history_warning("scan", error));
+            }
         }
 
         Ok(ScanResponse {
@@ -90,6 +122,7 @@ async fn scan(options: RunOptions) -> Result<ScanResponse, String> {
                     ecosystem: artifact.ecosystem.into(),
                 })
                 .collect(),
+            history_warning,
         })
     })
     .await
@@ -170,8 +203,21 @@ async fn execute_cleanup(request: ExecuteCleanupRequest) -> Result<CleanupResult
 
     tokio::task::spawn_blocking(move || {
         let plan = CleanupPlan { candidates };
-        let result = api::clean::execute(&plan, mode).map_err(|error| error.to_string())?;
-        history::record(mode, &result).map_err(|error| error.to_string())?;
+        let result = match api::clean::execute(&plan, mode) {
+            Ok(result) => result,
+            Err(error) => {
+                if let Err(history_error) =
+                    history::record_cleanup_failure(mode, &error.to_string())
+                {
+                    report_failed_activity_record("cleanup", history_error);
+                }
+                return Err(error.to_string());
+            }
+        };
+        let history_warning = match history::record(mode, &result) {
+            Ok(()) => None,
+            Err(error) => Some(format_history_warning("cleanup", error)),
+        };
 
         Ok(CleanupResultResponse {
             deleted_paths: result
@@ -188,6 +234,7 @@ async fn execute_cleanup(request: ExecuteCleanupRequest) -> Result<CleanupResult
                 })
                 .collect(),
             freed_size_bytes: result.freed_size_bytes,
+            history_warning,
         })
     })
     .await
@@ -231,13 +278,7 @@ async fn security_scan(options: RunOptions) -> Result<SecurityScanResponse, Stri
 
     tokio::task::spawn_blocking(move || {
         let report = match api::security_scan_report(&root, &ecosystems) {
-            Ok(report) => {
-                if let Err(error) = history::record_security_scan(&root, &ecosystems, &report) {
-                    eprintln!("Failed to record security scan history: {error}");
-                }
-
-                report
-            }
+            Ok(report) => report,
             Err(error) => {
                 if let Err(history_error) =
                     history::record_security_failure(&root, &ecosystems, &error.to_string())
@@ -248,7 +289,14 @@ async fn security_scan(options: RunOptions) -> Result<SecurityScanResponse, Stri
             }
         };
 
-        Ok(report.into())
+        let mut response: SecurityScanResponse = report.clone().into();
+        response.history_warning = match history::record_security_scan(&root, &ecosystems, &report)
+        {
+            Ok(()) => None,
+            Err(error) => Some(format_history_warning("security scan", error)),
+        };
+
+        Ok(response)
     })
     .await
     .map_err(|error| error.to_string())?

--- a/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
+++ b/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
@@ -8,7 +8,7 @@ type HistoryListProps = {
 
 export function HistoryList(props: HistoryListProps) {
   if (!props.entries.length) {
-    return <EmptyState message="No activity history yet. Completed operations will appear here." />;
+    return <EmptyState message="No activity history yet. Operations will appear here." />;
   }
 
   return (
@@ -51,11 +51,14 @@ function ScanDetails({ entry }: { entry: ActivityRecord }) {
   const details = entry.result.details;
 
   return (
-    <div className="mt-4 grid gap-2 text-sm text-slate-300 sm:grid-cols-3">
-      <Detail label="Target" value={details.path ?? 'Unknown'} />
-      <Detail label="Artifacts" value={String(details.artifacts ?? 0)} />
-      <Detail label="Total Size" value={formatBytes(details.size ?? 0)} />
-    </div>
+    <>
+      <div className="mt-4 grid gap-2 text-sm text-slate-300 sm:grid-cols-3">
+        <Detail label="Target" value={details.path ?? 'Unknown'} />
+        <Detail label="Artifacts" value={String(details.artifacts ?? 0)} />
+        <Detail label="Total Size" value={formatBytes(details.size ?? 0)} />
+      </div>
+      {details.reason ? <p className="mt-4 text-sm text-rose-200">{details.reason}</p> : null}
+    </>
   );
 }
 
@@ -88,6 +91,8 @@ function CleanupDetails({ entry }: { entry: ActivityRecord }) {
           </ul>
         </div>
       ) : null}
+
+      {details.reason ? <p className="mt-4 text-sm text-rose-200">{details.reason}</p> : null}
     </>
   );
 }

--- a/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
@@ -264,6 +264,7 @@ export function useAppState() {
     setCleanupPlan(plan);
     setSelectedCleanupPaths(plan.candidates.map((candidate) => candidate.path));
     setLastScanAtMs(Date.now());
+    setError(scan.historyWarning ?? null);
     setHistoryEntries(await loadActivityHistory());
   }
 
@@ -339,7 +340,9 @@ export function useAppState() {
 
       setCleanupResult(result);
       if (result.failedPaths.length) {
-        setError(formatCleanupFailure(result));
+        setError(formatCleanupFailure(result, result.historyWarning));
+      } else {
+        setError(result.historyWarning ?? null);
       }
       setCleanupPlan((current) =>
         current
@@ -408,10 +411,11 @@ export function useAppState() {
   };
 }
 
-function formatCleanupFailure(result: CleanupResultResponse): string {
+function formatCleanupFailure(result: CleanupResultResponse, historyWarning?: string): string {
   const failures = result.failedPaths
     .map((failure) => `${failure.path} (${failure.reason})`)
     .join('; ');
+  const historyMessage = historyWarning ? ` ${historyWarning}` : '';
 
-  return `Cleanup completed with ${result.failedPaths.length} failure(s). Freed ${formatBytes(result.freedSizeBytes)}. Failed: ${failures}`;
+  return `Cleanup completed with ${result.failedPaths.length} failure(s). Freed ${formatBytes(result.freedSizeBytes)}. Failed: ${failures}.${historyMessage}`;
 }

--- a/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
@@ -239,6 +239,13 @@ export function useAppState() {
     } catch (invokeError) {
       if (requestId === actionRequestRef.current) {
         setError(String(invokeError));
+
+        // Failed operations can still leave an activity record behind. Refresh
+        // it without allowing a history-read failure to hide the primary error.
+        const refreshedHistory = await loadActivityHistory().catch(() => null);
+        if (requestId === actionRequestRef.current && refreshedHistory) {
+          setHistoryEntries(refreshedHistory);
+        }
       }
     } finally {
       if (requestId === actionRequestRef.current) {

--- a/apps/dustfril-tauri/src/types/workflow.ts
+++ b/apps/dustfril-tauri/src/types/workflow.ts
@@ -18,6 +18,7 @@ export type Artifact = {
 
 export type ScanResponse = {
   artifacts: Artifact[];
+  historyWarning?: string;
 };
 
 export type ArtifactAnalysis = {
@@ -55,6 +56,7 @@ export type CleanupResultResponse = {
   deletedPaths: string[];
   failedPaths: CleanupFailure[];
   freedSizeBytes: number;
+  historyWarning?: string;
 };
 
 export type LifecycleScript = {
@@ -92,6 +94,7 @@ export type SecurityScanResponse = {
   lifecycleWarnings: SecurityWarning[];
   lockfiles: LockfileCheck[];
   manifests: string[];
+  historyWarning?: string;
 };
 
 export type ActivityKind = 'Scan' | 'Cleanup' | 'Security';

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -43,6 +43,13 @@ through `api::history`. The event stores finding counts, highest severity,
 stable rule IDs, relative source locations, and sanitised reasons; command or
 dependency-source evidence is not persisted.
 
+Top-level scan, cleanup, and security operations each record at most one
+activity. Internal analysis and cleanup-plan helpers do not write history.
+Completed operation results remain distinguishable from execution failures and
+partial cleanup failures. History writes use a process-wide append lock and
+atomic replacement; callers should report history errors without discarding a
+completed primary result.
+
 Malformed or unsupported manifests and lockfiles are returned as explicit
 errors. Lifecycle scanning honors an explicit `packageManager` declaration;
 otherwise it uses the nearest applicable lockfile. All security behavior is

--- a/crates/dustfril-core/src/api/history.rs
+++ b/crates/dustfril-core/src/api/history.rs
@@ -33,6 +33,16 @@ pub fn record_scan(
     history::record_scan(target_path, result, total_size_bytes)
 }
 
+/// Records a scan that failed before producing a scan result.
+pub fn record_scan_failure(target_path: &Path, reason: &str) -> DustResult<()> {
+    history::record_scan_failure(target_path, reason)
+}
+
+/// Records a cleanup that failed before producing a cleanup result.
+pub fn record_cleanup_failure(mode: DeleteMode, reason: &str) -> DustResult<()> {
+    history::record_cleanup_failure(mode, reason)
+}
+
 /// Records one explicit security scan in the unified activity history.
 pub fn record_security_scan(
     target_path: &Path,

--- a/crates/dustfril-core/src/history/mod.rs
+++ b/crates/dustfril-core/src/history/mod.rs
@@ -55,6 +55,16 @@ pub fn record_scan(
     record(ActivityRecord::scan(target_path, result, total_size_bytes))
 }
 
+/// Records a scan that failed before producing a scan result.
+pub fn record_scan_failure(target_path: &Path, reason: &str) -> DustResult<()> {
+    record(ActivityRecord::scan_failure(target_path, reason))
+}
+
+/// Records a cleanup that failed before producing a cleanup result.
+pub fn record_cleanup_failure(mode: DeleteMode, reason: &str) -> DustResult<()> {
+    record(ActivityRecord::cleanup_failure(mode, reason))
+}
+
 /// Records one explicit security scan in the unified activity history.
 pub fn record_security_scan(
     target_path: &Path,
@@ -155,7 +165,7 @@ fn save(path: &Path, records: &[ActivityRecord]) -> DustResult<()> {
             .open(&temporary_path)?;
         file.write_all(json.as_bytes())?;
         file.sync_all()?;
-        fs::rename(&temporary_path, path)
+        replace_file(&temporary_path, path)
     })();
 
     if let Err(error) = write_result {
@@ -167,6 +177,10 @@ fn save(path: &Path, records: &[ActivityRecord]) -> DustResult<()> {
     }
 
     Ok(())
+}
+
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    fs::rename(source, destination)
 }
 
 fn temporary_path(path: &Path) -> PathBuf {
@@ -248,6 +262,9 @@ mod tests {
         assert_eq!(history[0].kind, crate::models::ActivityKind::Cleanup);
         assert!(!history[0].result.success);
         assert_eq!(history[0].result.details["freed"], 2048);
+        assert_eq!(history[0].result.details["mode"], "permanent");
+        assert_eq!(history[0].result.details["deleted"][0], "build");
+        assert_eq!(history[0].result.details["failed"][0]["path"], "target");
 
         let migrated: Value =
             serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
@@ -346,6 +363,125 @@ mod tests {
         assert!(!activity.result.success);
         assert_eq!(activity.result.details["deleted"][0], "target");
         assert_eq!(activity.result.details["failed"][0]["path"], "node_modules");
+    }
+
+    #[test]
+    fn cleanup_activity_records_success_without_items() {
+        let activity = ActivityRecord::cleanup(DeleteMode::Trash, &CleanupResult::default());
+
+        assert!(activity.result.success);
+        assert!(
+            activity.result.details["deleted"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            activity.result.details["failed"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(activity.result.details["freed"], 0);
+    }
+
+    #[test]
+    fn failed_operations_are_reloadable_activity_records() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("history.json");
+
+        record_to(
+            &path,
+            ActivityRecord::scan_failure(Path::new("/workspace"), "scan failed"),
+        )
+        .unwrap();
+        record_to(
+            &path,
+            ActivityRecord::cleanup_failure(DeleteMode::Permanent, "cleanup failed"),
+        )
+        .unwrap();
+
+        let records = load_unlocked(&path).unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert!(!records[0].result.success);
+        assert!(!records[1].result.success);
+        assert_eq!(records[0].kind, ActivityKind::Scan);
+        assert_eq!(records[1].kind, ActivityKind::Cleanup);
+    }
+
+    #[test]
+    fn replacement_failure_keeps_existing_valid_history() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("history.json");
+        let activity = ActivityRecord::new(
+            ActivityKind::Scan,
+            ActivityResult::new(true, json!({"artifacts": 0})),
+        );
+        record_to(&path, activity.clone()).unwrap();
+        let original = std::fs::read_to_string(&path).unwrap();
+
+        let replacement_source = temp.path().join("replacement-source");
+        std::fs::create_dir(&replacement_source).unwrap();
+        let result = replace_file(&replacement_source, &path);
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_to_string(path).unwrap(), original);
+    }
+
+    #[test]
+    fn failed_save_cleans_temporary_file_without_touching_destination() {
+        let temp = TempDir::new().unwrap();
+        let destination = temp.path().join("history-directory");
+        std::fs::create_dir(&destination).unwrap();
+        let activity = ActivityRecord::new(
+            ActivityKind::Scan,
+            ActivityResult::new(true, json!({"artifacts": 0})),
+        );
+
+        let result = save(&destination, &[activity]);
+
+        assert!(result.is_err());
+        assert!(destination.is_dir());
+        assert_eq!(
+            std::fs::read_dir(temp.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn concurrent_appends_remain_parseable_and_lossless() {
+        let temp = TempDir::new().unwrap();
+        let path = std::sync::Arc::new(temp.path().join("history.json"));
+        let workers = 12;
+
+        let handles = (0..workers)
+            .map(|index| {
+                let path = std::sync::Arc::clone(&path);
+                std::thread::spawn(move || {
+                    record_to(
+                        &path,
+                        ActivityRecord::new(
+                            ActivityKind::Scan,
+                            ActivityResult::new(true, json!({"worker": index})),
+                        ),
+                    )
+                    .unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let records = load_unlocked(&path).unwrap();
+        assert_eq!(records.len(), workers);
+        assert!(records.iter().all(|record| record.result.success));
     }
 
     #[test]

--- a/crates/dustfril-core/src/models/history.rs
+++ b/crates/dustfril-core/src/models/history.rs
@@ -59,6 +59,19 @@ impl ActivityResult {
         )
     }
 
+    /// Builds the result payload for a scan that could not execute.
+    pub fn from_scan_failure(target_path: &Path, reason: &str) -> Self {
+        Self::new(
+            false,
+            json!({
+                "path": target_path.display().to_string(),
+                "artifacts": 0,
+                "size": 0,
+                "reason": sanitize_text(reason),
+            }),
+        )
+    }
+
     /// Builds the result payload for a cleanup attempt, including partial failures.
     pub fn from_cleanup(mode: DeleteMode, result: &CleanupResult) -> Self {
         let failed_paths: Vec<Value> = result
@@ -79,6 +92,21 @@ impl ActivityResult {
                 "deleted": paths_to_values(&result.deleted_paths),
                 "failed": failed_paths,
                 "freed": result.freed_size_bytes,
+            }),
+        )
+    }
+
+    /// Builds the result payload for a cleanup that failed before a result
+    /// could be produced.
+    pub fn from_cleanup_failure(mode: DeleteMode, reason: &str) -> Self {
+        Self::new(
+            false,
+            json!({
+                "mode": delete_mode_label(mode),
+                "deleted": [],
+                "failed": [],
+                "freed": 0,
+                "reason": sanitize_text(reason),
             }),
         )
     }
@@ -173,10 +201,24 @@ impl ActivityRecord {
         )
     }
 
+    pub fn scan_failure(target_path: &Path, reason: &str) -> Self {
+        Self::new(
+            ActivityKind::Scan,
+            ActivityResult::from_scan_failure(target_path, reason),
+        )
+    }
+
     pub fn cleanup(mode: DeleteMode, result: &CleanupResult) -> Self {
         Self::new(
             ActivityKind::Cleanup,
             ActivityResult::from_cleanup(mode, result),
+        )
+    }
+
+    pub fn cleanup_failure(mode: DeleteMode, reason: &str) -> Self {
+        Self::new(
+            ActivityKind::Cleanup,
+            ActivityResult::from_cleanup_failure(mode, reason),
         )
     }
 
@@ -488,5 +530,25 @@ mod tests {
         assert_eq!(result.details["findingCount"], 0);
         assert_eq!(result.details["highestRisk"], "None");
         assert_eq!(result.details["reason"], "Manifest error: token=[REDACTED]");
+    }
+
+    #[test]
+    fn operation_failures_are_distinguishable_from_completed_results() {
+        let scan = ActivityRecord::scan_failure(Path::new("/workspace"), "Scan failed");
+        let cleanup = ActivityRecord::cleanup_failure(DeleteMode::Trash, "Cleanup failed");
+
+        assert_eq!(scan.kind, ActivityKind::Scan);
+        assert!(!scan.result.success);
+        assert_eq!(scan.result.details["reason"], "Scan failed");
+
+        assert_eq!(cleanup.kind, ActivityKind::Cleanup);
+        assert!(!cleanup.result.success);
+        assert_eq!(cleanup.result.details["reason"], "Cleanup failed");
+        assert!(
+            cleanup.result.details["failed"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
     }
 }


### PR DESCRIPTION
## What

Validate and harden unified activity audit semantics across Core, CLI, and Tauri.

## Why

Closes #113

The audit found and fixed duplicate Scan records during CLI cleanup planning and a Tauri path where history-write failure incorrectly turned a completed cleanup into a failed command. The change also persists explicit execution failures, keeps empty Cleanup operations visible, exposes additive Tauri history warnings, and adds the CLI `history` reader.

## Validation report

Scan event boundary: PASS  
Cleanup event boundary: PASS  
Security event boundary: PASS  
Partial failure semantics: PASS  
Legacy migration: PASS  
Version handling: PASS  
Atomic persistence: PASS  
Auxiliary-write failure behavior: PASS  
Sensitive-data handling: PASS  
CLI/Core parity: PASS  
Tauri/Core parity: PASS  
Duplicate-growth sanity: PASS  
Coverage: 73.40% lines / 73.73% regions (`cargo llvm-cov --workspace --all-features --summary-only`)

Blocking findings: None

Follow-ups: None

Epic #61 recommendation: CLOSE

## Quality gates

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 20 CLI, 131 Core, 12 Tauri tests passed
- `cargo llvm-cov --workspace --all-features --summary-only`
- `npm run build` in `apps/dustfril-tauri`
- `git diff --check`

Frontend dependency audit still reports existing transitive advisories from the checked-in lockfile; no dependency update was included in this validation change.