### PR TITLE
Add executable integrity baseline scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "trash",

--- a/README.ko.md
+++ b/README.ko.md
@@ -21,6 +21,7 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 - 스캔·정리 활동 이력을 버전 형식으로 운영체제 앱 데이터 디렉터리에 저장
 - Node 및 Rust 프로젝트의 오프라인 공급망 보안 점검
 - 지원 lockfile의 존재 여부와 Git 상태 점검
+- 대상 개발 도구를 실행하지 않고 로컬 SHA-256 baseline과 실행 파일 무결성 비교
 - CLI 정리 이력을 운영체제 앱 데이터 디렉터리에 저장
 
 공급망 보안 스캐너는 v0.0.1 이후 작업입니다. v0.0.1 릴리스 범위는
@@ -59,6 +60,7 @@ cargo run -p dustfril-cli -- clean
 cargo run -p dustfril-cli -- clean --permanent
 cargo run -p dustfril-cli -- audit --node
 cargo run -p dustfril-cli -- security scan --node
+cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 ```
 
 생태계 필터나 대상 경로를 함께 지정할 수 있습니다.
@@ -75,6 +77,7 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 - `clean [path] [--dry-run] [--permanent] [--rust] [--node] [--java]`
 - `audit [path] [--node]`
 - `security scan [path] [--node]`
+- `integrity scan [--tool <name>]...`
 
 `security scan`은 `package.json`, `Cargo.toml`, `package-lock.json`,
 `pnpm-lock.yaml`, `bun.lock`, `Cargo.lock`을 읽기 전용으로 오프라인 점검합니다.
@@ -83,6 +86,13 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 잘못되었거나 지원되지 않으면 해당 파일 경로를 포함한 오류를 반환합니다. 탐지된
 명령이나 패키지 매니저를 실행하지 않고, 네트워크 및 프로젝트 파일 변경도 사용하지
 않습니다.
+
+`integrity scan`은 PATH에서 요청한 개발 도구를 찾고 파일 메타데이터와 바이트를
+읽어 SHA-256을 스트리밍 계산합니다. 대상 실행 파일을 절대 실행하지 않으며,
+activity history와 분리된 버전 형식의 baseline을 저장합니다. 기본 대상은 `node`,
+`bun`, `cargo`, `rustc`, `git`, `java`, `gradle`이고, `--tool`을 반복해 일부만
+선택할 수 있습니다. 경로 또는 해시 변경은 무결성 변경으로 보고하며 악성 코드의
+증거라고 단정하지 않습니다.
 
 ## 데스크톱 앱
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Persist versioned local activity history for scans, cleanup, and explicit security scans (including legacy cleanup history migration)
 - Run an offline supply-chain security scan for Node and Rust projects
 - Check supported lockfile presence and Git status
+- Compare selected development-tool executables with local SHA-256 baselines without launching them
 - Persist CLI cleanup history to the OS app data directory
 
 The supply-chain scanner is post-v0.0.1 work. The v0.0.1 release remains
@@ -66,6 +67,7 @@ cargo run -p dustfril-cli -- clean
 cargo run -p dustfril-cli -- clean --permanent
 cargo run -p dustfril-cli -- audit --node
 cargo run -p dustfril-cli -- security scan --node
+cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 cargo run -p dustfril-cli -- history
 ```
 
@@ -83,6 +85,7 @@ Available commands:
 - `clean [path] [--dry-run] [--permanent] [--rust] [--node] [--java]`
 - `audit [path] [--node]`
 - `security scan [path] [--node]`
+- `integrity scan [--tool <name>]...`
 - `history`
 
 `security scan` is a read-only, offline check of `package.json`, `Cargo.toml`,
@@ -92,6 +95,13 @@ package names on a built-in list of historically compromised packages, and
 missing or changed lockfiles. Parse and read failures identify the relevant
 manifest or lockfile and fail the scan. It never runs detected commands,
 invokes a package manager, contacts the network, or modifies project files.
+
+`integrity scan` resolves the requested development tools through PATH, reads
+filesystem metadata, streams each target through SHA-256, and stores its
+versioned baseline separately from activity history. It never launches the
+target executable. Default tools are `node`, `bun`, `cargo`, `rustc`, `git`,
+`java`, and `gradle`; use repeated `--tool` flags to select a subset. A changed
+path or hash is reported as an integrity change, not as proof of malware.
 
 ## Desktop App
 

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -11,6 +11,7 @@ This package exposes the `dfr` binary and wraps the shared logic from `dustfril-
 - `clean`: preview or execute cleanup
 - `audit`: inspect Node lifecycle scripts
 - `security scan`: inspect Node and Rust manifests and lockfiles for supply-chain risks
+- `integrity scan`: inspect selected development-tool executables without launching them
 - `history`: load the unified local activity history as JSON
 
 ## Run
@@ -23,6 +24,7 @@ cargo run -p dustfril-cli -- analyze
 cargo run -p dustfril-cli -- clean --dry-run
 cargo run -p dustfril-cli -- audit --node
 cargo run -p dustfril-cli -- security scan --node
+cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 cargo run -p dustfril-cli -- history
 ```
 
@@ -39,6 +41,8 @@ cargo build -p dustfril-cli
 - `clean --dry-run` previews without appending a cleanup activity
 - command failures return a non-zero process exit status
 - security scans are read-only and use deterministic offline checks
+- executable-integrity scans read metadata and bytes only; they never invoke a target tool
+- executable-integrity baselines are stored separately from activity history in the OS app data directory
 - activity-history write failures are reported without discarding a completed operation result
 - Activity history is stored in the OS app data directory as a versioned `history.json`.
   Existing cleanup-history arrays are migrated when the file is read or appended to.

--- a/apps/dustfril-cli/src/cli.rs
+++ b/apps/dustfril-cli/src/cli.rs
@@ -35,6 +35,9 @@ pub enum Commands {
 
     /// Scan lifecycle scripts for suspicious commands
     Security(SecurityArgs),
+
+    /// Compare selected development-tool executables with local baselines
+    Integrity(IntegrityArgs),
 }
 
 #[derive(Args)]
@@ -47,6 +50,35 @@ pub struct SecurityArgs {
 pub enum SecurityCommands {
     /// Scan Node lifecycle scripts for suspicious commands
     Scan(PathArgs),
+}
+
+#[derive(Args)]
+pub struct IntegrityArgs {
+    #[command(subcommand)]
+    pub command: IntegrityCommands,
+}
+
+#[derive(Subcommand)]
+pub enum IntegrityCommands {
+    /// Inspect development-tool executables without launching them
+    Scan(IntegrityScanArgs),
+}
+
+#[derive(Args)]
+pub struct IntegrityScanArgs {
+    /// Tool name to inspect; repeat for multiple tools. Defaults to the initial tool set.
+    #[arg(long = "tool", value_name = "NAME")]
+    pub tools: Vec<String>,
+}
+
+impl IntegrityScanArgs {
+    pub fn tools(&self) -> Vec<dustfril_core::models::ToolSpec> {
+        if self.tools.is_empty() {
+            return dustfril_core::api::integrity::default_tools();
+        }
+
+        self.tools.iter().cloned().map(Into::into).collect()
+    }
 }
 
 #[derive(Args)]
@@ -170,5 +202,32 @@ mod tests {
         let cli = Cli::try_parse_from(["dfr", "history"]).unwrap();
 
         assert!(matches!(cli.command, Commands::History));
+    }
+
+    #[test]
+    fn cli_parses_integrity_scan_and_selected_tools() {
+        let cli = Cli::try_parse_from([
+            "dfr",
+            "integrity",
+            "scan",
+            "--tool",
+            "node",
+            "--tool",
+            "git",
+        ])
+        .unwrap();
+
+        let Commands::Integrity(args) = cli.command else {
+            panic!("expected integrity command");
+        };
+        let IntegrityCommands::Scan(args) = args.command;
+        assert_eq!(args.tools(), vec!["node".into(), "git".into()]);
+    }
+
+    #[test]
+    fn integrity_scan_defaults_to_core_tool_selection() {
+        let args = IntegrityScanArgs { tools: Vec::new() };
+
+        assert_eq!(args.tools(), dustfril_core::api::integrity::default_tools());
     }
 }

--- a/apps/dustfril-cli/src/commands/integrity.rs
+++ b/apps/dustfril-cli/src/commands/integrity.rs
@@ -1,0 +1,25 @@
+use dustfril_core::api;
+
+use crate::{cli::IntegrityScanArgs, format};
+
+pub fn scan(args: &IntegrityScanArgs) -> bool {
+    let state_path = match api::integrity::state_path() {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("Failed to determine executable-integrity state path: {error}");
+            return false;
+        }
+    };
+
+    let tools = args.tools();
+    let report = match api::integrity::scan(&tools, &state_path) {
+        Ok(report) => report,
+        Err(error) => {
+            eprintln!("Executable integrity scan failed: {error}");
+            return false;
+        }
+    };
+
+    format::print_integrity_report(&report);
+    true
+}

--- a/apps/dustfril-cli/src/commands/mod.rs
+++ b/apps/dustfril-cli/src/commands/mod.rs
@@ -2,5 +2,6 @@ pub mod analyze;
 pub mod audit;
 pub mod clean;
 pub mod history;
+pub mod integrity;
 pub mod scan;
 pub mod security;

--- a/apps/dustfril-cli/src/format/integrity_format.rs
+++ b/apps/dustfril-cli/src/format/integrity_format.rs
@@ -1,0 +1,43 @@
+use dustfril_core::models::{IntegrityReport, IntegrityStatus};
+
+/// Prints non-executing executable-integrity facts and comparison states.
+pub fn print_integrity_report(report: &IntegrityReport) {
+    println!("Executable integrity scan\n");
+
+    for check in &report.checks {
+        println!("{}: {}", check.requested_tool, check.status);
+
+        if let Some(observation) = &check.observation {
+            println!("  Path:           {}", observation.resolved_path.display());
+            println!("  Canonical:      {}", observation.canonical_path.display());
+            println!("  Size:           {} bytes", observation.size_bytes);
+            println!("  SHA-256:        {}", observation.sha256);
+            println!("  Observed:       {}", observation.observed_at);
+            if let Some(target) = &observation.symlink_target {
+                println!("  Symlink target:  {}", target.display());
+            }
+        }
+
+        if let Some(previous) = &check.previous_observation
+            && matches!(
+                check.status,
+                IntegrityStatus::ContentChanged | IntegrityStatus::ResolvedPathChanged
+            )
+        {
+            println!("  Previous SHA-256: {}", previous.sha256);
+        }
+
+        if let Some(failure) = &check.failure {
+            println!("  Reason:         {} ({})", failure.kind, failure.message);
+        }
+
+        if matches!(
+            check.status,
+            IntegrityStatus::ContentChanged | IntegrityStatus::ResolvedPathChanged
+        ) {
+            println!("  Note:           A changed executable is not proof of malware.");
+        }
+
+        println!();
+    }
+}

--- a/apps/dustfril-cli/src/format/mod.rs
+++ b/apps/dustfril-cli/src/format/mod.rs
@@ -1,9 +1,11 @@
 pub mod audit_format;
+pub mod integrity_format;
 pub mod security_format;
 pub mod size_format;
 pub mod time_format;
 
 pub use audit_format::*;
+pub use integrity_format::*;
 pub use security_format::*;
 pub use size_format::*;
 pub use time_format::*;

--- a/apps/dustfril-cli/src/main.rs
+++ b/apps/dustfril-cli/src/main.rs
@@ -32,6 +32,10 @@ fn main() -> ExitCode {
         Commands::Security(args) => match args.command {
             cli::SecurityCommands::Scan(args) => commands::security::scan(&args),
         },
+
+        Commands::Integrity(args) => match args.command {
+            cli::IntegrityCommands::Scan(args) => commands::integrity::scan(&args),
+        },
     };
 
     if succeeded {

--- a/crates/dustfril-core/Cargo.toml
+++ b/crates/dustfril-core/Cargo.toml
@@ -15,6 +15,7 @@ directories = "6"
 git2 = "0.21"
 toml = "0.9.12"
 url = "2.5.8"
+sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -15,6 +15,7 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - `api::history`: record and load versioned activity history, including cleanup-history migration and security scan summaries
 - `api::security_scan`: preserve the lifecycle-only security warnings API
 - `api::security_scan_report`: run the complete offline supply-chain scan
+- `api::integrity`: resolve selected development tools without executing them, hash their bytes, and compare local baselines
 - `api::check_lockfile_integrity`: check supported lockfile presence and Git status
 - `api::history`: record and load cleanup history using atomic replacement;
   corrupted or unsupported history files are returned as errors
@@ -30,6 +31,12 @@ symbolic links, and never falls back from Trash mode to permanent deletion.
 - Audit: Node lifecycle scripts for npm, pnpm, yarn, and bun
 - Security rules: suspicious lifecycle commands, non-registry dependency sources, historically compromised package names, and lockfile issues
 - Lockfile integrity: `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `Cargo.lock`
+
+Executable-integrity scans support `node`, `bun`, `cargo`, `rustc`, `git`,
+`java`, and `gradle` by default. They resolve PATH entries, canonicalize
+symlinks, stream SHA-256 hashing, and persist a separate versioned
+`integrity-baseline.json`. Missing or unreadable tools are returned as
+structured results; a changed hash is an observation, not a malware claim.
 
 The supply-chain report reads `package.json` and `Cargo.toml` plus supported
 lockfiles without executing scripts or contacting an external advisory service.

--- a/crates/dustfril-core/src/api/integrity.rs
+++ b/crates/dustfril-core/src/api/integrity.rs
@@ -1,0 +1,56 @@
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
+
+use crate::{
+    error::DustResult,
+    integrity,
+    models::{ExecutableObservation, IntegrityFailure, IntegrityReport, ToolSpec},
+};
+
+pub use crate::integrity::{BaselineStore, ResolvedExecutable, ToolResolver};
+
+/// Returns the representative development-tool selection used by the CLI.
+pub fn default_tools() -> Vec<ToolSpec> {
+    integrity::default_tools()
+}
+
+/// Returns the OS-specific local path used for executable-integrity state.
+pub fn state_path() -> std::io::Result<PathBuf> {
+    integrity::state_path()
+}
+
+/// Resolves and compares selected tools against a local baseline using PATH.
+pub fn scan(tools: &[ToolSpec], baseline_path: &Path) -> DustResult<IntegrityReport> {
+    integrity::scan(tools, baseline_path)
+}
+
+/// Resolves and compares selected tools with deterministic caller-provided PATH entries.
+pub fn scan_with_paths(
+    tools: &[ToolSpec],
+    paths: impl IntoIterator<Item = PathBuf>,
+    baseline_path: &Path,
+) -> DustResult<IntegrityReport> {
+    let resolver = integrity::ToolResolver::from_paths(paths);
+    integrity::scan_with_resolver(tools, &resolver, baseline_path)
+}
+
+/// Resolves and compares selected tools using a PATH-shaped value.
+pub fn scan_with_path_value(
+    tools: &[ToolSpec],
+    path: Option<OsString>,
+    baseline_path: &Path,
+) -> DustResult<IntegrityReport> {
+    let resolver = integrity::ToolResolver::from_path(path);
+    integrity::scan_with_resolver(tools, &resolver, baseline_path)
+}
+
+/// Inspects one tool without comparing or persisting it.
+pub fn inspect_tool(
+    tool: &ToolSpec,
+    paths: impl IntoIterator<Item = PathBuf>,
+) -> Result<ExecutableObservation, IntegrityFailure> {
+    let resolver = integrity::ToolResolver::from_paths(paths);
+    integrity::inspect_tool(tool, &resolver)
+}

--- a/crates/dustfril-core/src/api/mod.rs
+++ b/crates/dustfril-core/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod analyze;
 pub mod audit;
 pub mod clean;
 pub mod history;
+pub mod integrity;
 pub mod lockfile;
 pub mod scan;
 

--- a/crates/dustfril-core/src/error.rs
+++ b/crates/dustfril-core/src/error.rs
@@ -17,6 +17,8 @@ pub enum DustError {
     Git(String),
     /// Indicates that a project manifest could not be parsed for an integrity check.
     Manifest(String),
+    /// Indicates that the persisted executable-integrity state is invalid.
+    IntegrityState(String),
 }
 
 /// Standard result type used by the core crate.
@@ -45,6 +47,9 @@ impl fmt::Display for DustError {
             }
             DustError::Manifest(message) => {
                 write!(f, "Manifest error: {message}")
+            }
+            DustError::IntegrityState(message) => {
+                write!(f, "Executable integrity state error: {message}")
             }
         }
     }

--- a/crates/dustfril-core/src/integrity/baseline.rs
+++ b/crates/dustfril-core/src/integrity/baseline.rs
@@ -1,0 +1,147 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
+};
+
+use directories::ProjectDirs;
+use serde_json::Value;
+
+use crate::{
+    error::{DustError, DustResult},
+    models::{INTEGRITY_STATE_VERSION, IntegrityBaseline},
+};
+
+static BASELINE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static NEXT_TEMP_FILE_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Access to the versioned local executable-integrity baseline file.
+#[derive(Debug, Clone)]
+pub struct BaselineStore {
+    path: PathBuf,
+}
+
+impl BaselineStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Loads the baseline, returning an explicit error for malformed or old
+    /// state instead of silently starting over.
+    pub fn load(&self) -> DustResult<IntegrityBaseline> {
+        let _guard = baseline_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        load_unlocked(&self.path)
+    }
+
+    /// Atomically replaces the baseline file with a validated v1 state.
+    pub fn save(&self, baseline: &IntegrityBaseline) -> DustResult<()> {
+        let _guard = baseline_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        save_unlocked(&self.path, baseline)
+    }
+
+    pub(crate) fn update<F, T>(&self, update: F) -> DustResult<T>
+    where
+        F: FnOnce(&mut IntegrityBaseline) -> DustResult<T>,
+    {
+        let _guard = baseline_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let mut baseline = load_unlocked(&self.path)?;
+        let original = baseline.clone();
+        let result = update(&mut baseline)?;
+
+        if baseline != original {
+            save_unlocked(&self.path, &baseline)?;
+        }
+
+        Ok(result)
+    }
+}
+
+pub fn default_state_path() -> io::Result<PathBuf> {
+    let dirs = ProjectDirs::from("dev", "FrilLab", "DustFril")
+        .ok_or_else(|| io::Error::other("Failed to determine data directory"))?;
+    let data_dir = dirs.data_dir();
+    fs::create_dir_all(data_dir)?;
+    Ok(data_dir.join("integrity-baseline.json"))
+}
+
+fn load_unlocked(path: &Path) -> DustResult<IntegrityBaseline> {
+    if !path.exists() {
+        return Ok(IntegrityBaseline::default());
+    }
+
+    let json = fs::read_to_string(path)?;
+    let value: Value = serde_json::from_str(&json).map_err(state_error)?;
+    let baseline: IntegrityBaseline = serde_json::from_value(value).map_err(state_error)?;
+
+    if baseline.version != INTEGRITY_STATE_VERSION {
+        return Err(DustError::IntegrityState(format!(
+            "unsupported executable-integrity state version: {}",
+            baseline.version
+        )));
+    }
+
+    Ok(baseline)
+}
+
+fn save_unlocked(path: &Path, baseline: &IntegrityBaseline) -> DustResult<()> {
+    if baseline.version != INTEGRITY_STATE_VERSION {
+        return Err(DustError::IntegrityState(format!(
+            "unsupported executable-integrity state version: {}",
+            baseline.version
+        )));
+    }
+
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    let json = serde_json::to_string_pretty(baseline).map_err(state_error)?;
+    let temporary_path = temporary_path(path);
+    let write_result = (|| -> io::Result<()> {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary_path)?;
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+        fs::rename(&temporary_path, path)
+    })();
+
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temporary_path);
+        return Err(error.into());
+    }
+
+    Ok(())
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("integrity-baseline.json");
+    let id = NEXT_TEMP_FILE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    path.with_file_name(format!(".{file_name}.{}.{}.tmp", std::process::id(), id))
+}
+
+fn state_error(error: serde_json::Error) -> DustError {
+    DustError::IntegrityState(error.to_string())
+}
+
+fn baseline_lock() -> &'static Mutex<()> {
+    BASELINE_LOCK.get_or_init(|| Mutex::new(()))
+}

--- a/crates/dustfril-core/src/integrity/comparator.rs
+++ b/crates/dustfril-core/src/integrity/comparator.rs
@@ -1,0 +1,19 @@
+use crate::models::{ExecutableObservation, IntegrityStatus};
+
+pub fn compare(
+    previous: &ExecutableObservation,
+    current: &ExecutableObservation,
+) -> IntegrityStatus {
+    if previous.resolved_path != current.resolved_path
+        || previous.canonical_path != current.canonical_path
+        || previous.symlink_target != current.symlink_target
+    {
+        return IntegrityStatus::ResolvedPathChanged;
+    }
+
+    if previous.sha256 != current.sha256 {
+        return IntegrityStatus::ContentChanged;
+    }
+
+    IntegrityStatus::Unchanged
+}

--- a/crates/dustfril-core/src/integrity/hasher.rs
+++ b/crates/dustfril-core/src/integrity/hasher.rs
@@ -1,0 +1,83 @@
+use std::{fs::File, io::Read};
+
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+
+use crate::models::{ExecutableObservation, IntegrityFailure, IntegrityFailureKind};
+
+use super::resolver::ResolvedExecutable;
+
+const HASH_BUFFER_SIZE: usize = 64 * 1024;
+
+/// Hashes a resolved executable and builds an observation without executing it.
+pub fn observe(resolved: ResolvedExecutable) -> Result<ExecutableObservation, IntegrityFailure> {
+    let mut file = File::open(&resolved.canonical_path).map_err(|error| {
+        IntegrityFailure::new(
+            IntegrityFailureKind::Unreadable,
+            format!("{}: {error}", resolved.canonical_path.display()),
+        )
+    })?;
+    let metadata = file.metadata().map_err(|error| {
+        IntegrityFailure::new(
+            IntegrityFailureKind::Unreadable,
+            format!("{}: {error}", resolved.canonical_path.display()),
+        )
+    })?;
+
+    let sha256 = hash_reader(&mut file, &resolved.canonical_path)?;
+    let observed_at = Utc::now();
+
+    Ok(ExecutableObservation {
+        requested_tool: resolved.requested_tool,
+        resolved_path: resolved.resolved_path,
+        canonical_path: resolved.canonical_path,
+        symlink_target: resolved.symlink_target,
+        size_bytes: metadata.len(),
+        sha256,
+        observed_at,
+        version_metadata: None,
+    })
+}
+
+fn hash_reader(reader: &mut impl Read, path: &std::path::Path) -> Result<String, IntegrityFailure> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; HASH_BUFFER_SIZE];
+
+    loop {
+        let bytes_read = reader.read(&mut buffer).map_err(|error| {
+            IntegrityFailure::new(
+                IntegrityFailureKind::HashFailed,
+                format!("{}: {error}", path.display()),
+            )
+        })?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+
+    struct FailingReader;
+
+    impl Read for FailingReader {
+        fn read(&mut self, _buffer: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("fixture read failure"))
+        }
+    }
+
+    #[test]
+    fn hash_reader_returns_a_structured_hash_failure() {
+        let failure = hash_reader(&mut FailingReader, std::path::Path::new("fixture")).unwrap_err();
+
+        assert_eq!(failure.kind, IntegrityFailureKind::HashFailed);
+        assert!(failure.message.contains("fixture read failure"));
+    }
+}

--- a/crates/dustfril-core/src/integrity/mod.rs
+++ b/crates/dustfril-core/src/integrity/mod.rs
@@ -133,8 +133,21 @@ mod tests {
     fn write_tool(directory: &Path, name: &str, bytes: &[u8]) -> std::path::PathBuf {
         let path = directory.join(name);
         fs::write(&path, bytes).unwrap();
+        make_executable(&path);
         path
     }
+
+    #[cfg(unix)]
+    fn make_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(not(unix))]
+    fn make_executable(_path: &Path) {}
 
     fn scan_one(tool_name: &str, resolver: &ToolResolver, baseline_path: &Path) -> IntegrityCheck {
         scan_with_resolver(&[tool(tool_name)], resolver, baseline_path)
@@ -167,7 +180,9 @@ mod tests {
         let state_path = temp.path().join("integrity.json");
         let resolver = ToolResolver::from_paths([temp.path().to_path_buf()]);
 
-        let first = scan_one("node", &resolver, &state_path);
+        let first_report = scan_with_resolver(&[tool("node")], &resolver, &state_path).unwrap();
+        assert!(!first_report.has_changes());
+        let first = first_report.checks.into_iter().next().unwrap();
         assert_eq!(first.status, IntegrityStatus::NewBaseline);
         assert_eq!(first.observation.as_ref().unwrap().size_bytes, 13);
         assert_eq!(
@@ -218,6 +233,31 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn path_lookup_skips_a_non_executable_shadow_candidate() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let shadow_directory = temp.path().join("shadow");
+        let executable_directory = temp.path().join("executable");
+        fs::create_dir(&shadow_directory).unwrap();
+        fs::create_dir(&executable_directory).unwrap();
+        let shadow = write_tool(&shadow_directory, "node", b"not runnable");
+        write_tool(&executable_directory, "node", b"runnable");
+        let mut permissions = fs::metadata(&shadow).unwrap().permissions();
+        permissions.set_mode(0o644);
+        fs::set_permissions(&shadow, permissions).unwrap();
+        let resolver = ToolResolver::from_paths([shadow_directory, executable_directory.clone()]);
+
+        let observation = inspect_tool(&tool("node"), &resolver).unwrap();
+
+        assert_eq!(
+            observation.canonical_path,
+            fs::canonicalize(executable_directory.join("node")).unwrap()
+        );
+    }
+
     #[test]
     fn missing_tool_is_reported_without_erasing_previous_baseline() {
         let temp = TempDir::new().unwrap();
@@ -233,7 +273,9 @@ mod tests {
         );
         fs::remove_file(directory.join("node")).unwrap();
 
-        let missing = scan_one("node", &resolver, &state_path);
+        let missing_report = scan_with_resolver(&[tool("node")], &resolver, &state_path).unwrap();
+        assert!(missing_report.has_changes());
+        let missing = missing_report.checks.into_iter().next().unwrap();
         assert_eq!(missing.status, IntegrityStatus::Missing);
         assert_eq!(
             missing.failure.unwrap().kind,

--- a/crates/dustfril-core/src/integrity/mod.rs
+++ b/crates/dustfril-core/src/integrity/mod.rs
@@ -1,0 +1,448 @@
+//! Non-executing executable-integrity inspection and baseline comparison.
+//!
+//! This module only reads filesystem metadata and executable bytes. It never
+//! launches a requested tool, asks it for a version, or changes the inspected
+//! path.
+
+mod baseline;
+mod comparator;
+mod hasher;
+mod resolver;
+
+pub use baseline::BaselineStore;
+pub use resolver::{ResolvedExecutable, ToolResolver};
+
+use std::path::Path;
+
+use crate::{
+    error::{DustError, DustResult},
+    models::{
+        ExecutableObservation, IntegrityBaseline, IntegrityCheck, IntegrityFailureKind,
+        IntegrityReport, IntegrityStatus, ToolSpec,
+    },
+};
+
+/// The initial set of representative development tools.
+pub fn default_tools() -> Vec<ToolSpec> {
+    ["node", "bun", "cargo", "rustc", "git", "java", "gradle"]
+        .into_iter()
+        .map(ToolSpec::from)
+        .collect()
+}
+
+/// Returns the default local state path and creates its parent data directory.
+pub fn state_path() -> std::io::Result<std::path::PathBuf> {
+    baseline::default_state_path()
+}
+
+/// Inspects one selected tool without comparing or persisting a baseline.
+pub fn inspect_tool(
+    tool: &ToolSpec,
+    resolver: &ToolResolver,
+) -> Result<ExecutableObservation, crate::models::IntegrityFailure> {
+    let resolved = resolver.resolve(tool)?;
+    hasher::observe(resolved)
+}
+
+/// Resolves and compares selected tools using the process environment's PATH.
+pub fn scan(tools: &[ToolSpec], baseline_path: &Path) -> DustResult<IntegrityReport> {
+    let resolver = ToolResolver::from_environment().map_err(DustError::Io)?;
+    scan_with_resolver(tools, &resolver, baseline_path)
+}
+
+/// Resolves and compares selected tools using an explicit resolver.
+pub fn scan_with_resolver(
+    tools: &[ToolSpec],
+    resolver: &ToolResolver,
+    baseline_path: &Path,
+) -> DustResult<IntegrityReport> {
+    let store = BaselineStore::new(baseline_path);
+
+    store.update(|baseline| {
+        let checks = tools
+            .iter()
+            .map(|tool| check_tool(tool, resolver, baseline))
+            .collect();
+
+        Ok(IntegrityReport { checks })
+    })
+}
+
+fn check_tool(
+    tool: &ToolSpec,
+    resolver: &ToolResolver,
+    baseline: &mut IntegrityBaseline,
+) -> IntegrityCheck {
+    let previous_observation = baseline.observations.get(&tool.name).cloned();
+
+    match inspect_tool(tool, resolver) {
+        Ok(observation) => {
+            let status = previous_observation
+                .as_ref()
+                .map_or(IntegrityStatus::NewBaseline, |previous| {
+                    comparator::compare(previous, &observation)
+                });
+
+            // A successful observation becomes the next comparison point. A
+            // failed observation never removes or overwrites the last good
+            // record, so missing/unreadable tools remain diagnosable.
+            baseline
+                .observations
+                .insert(tool.name.clone(), observation.clone());
+
+            IntegrityCheck {
+                requested_tool: tool.name.clone(),
+                status,
+                observation: Some(observation),
+                previous_observation,
+                failure: None,
+            }
+        }
+        Err(failure) => {
+            let status = if failure.kind == IntegrityFailureKind::NotFound {
+                IntegrityStatus::Missing
+            } else {
+                IntegrityStatus::InspectionFailed
+            };
+
+            IntegrityCheck {
+                requested_tool: tool.name.clone(),
+                status,
+                observation: None,
+                previous_observation,
+                failure: Some(failure),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use sha2::{Digest, Sha256};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::models::{IntegrityFailureKind, IntegrityStatus};
+
+    fn tool(name: &str) -> ToolSpec {
+        ToolSpec::from(name)
+    }
+
+    fn write_tool(directory: &Path, name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let path = directory.join(name);
+        fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    fn scan_one(tool_name: &str, resolver: &ToolResolver, baseline_path: &Path) -> IntegrityCheck {
+        scan_with_resolver(&[tool(tool_name)], resolver, baseline_path)
+            .unwrap()
+            .checks
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+
+    fn sha256(bytes: &[u8]) -> String {
+        format!("{:x}", Sha256::digest(bytes))
+    }
+
+    #[test]
+    fn default_tools_include_the_initial_developer_tool_set() {
+        assert_eq!(
+            default_tools()
+                .into_iter()
+                .map(|tool| tool.name)
+                .collect::<Vec<_>>(),
+            ["node", "bun", "cargo", "rustc", "git", "java", "gradle"]
+        );
+    }
+
+    #[test]
+    fn first_observation_is_baseline_then_bytes_are_compared() {
+        let temp = TempDir::new().unwrap();
+        let tool_path = write_tool(temp.path(), "node", b"first version");
+        let state_path = temp.path().join("integrity.json");
+        let resolver = ToolResolver::from_paths([temp.path().to_path_buf()]);
+
+        let first = scan_one("node", &resolver, &state_path);
+        assert_eq!(first.status, IntegrityStatus::NewBaseline);
+        assert_eq!(first.observation.as_ref().unwrap().size_bytes, 13);
+        assert_eq!(
+            first.observation.as_ref().unwrap().sha256,
+            sha256(b"first version")
+        );
+        assert!(first.failure.is_none());
+
+        let unchanged = scan_one("node", &resolver, &state_path);
+        assert_eq!(unchanged.status, IntegrityStatus::Unchanged);
+
+        fs::write(&tool_path, b"replacement version").unwrap();
+        let changed = scan_one("node", &resolver, &state_path);
+        assert_eq!(changed.status, IntegrityStatus::ContentChanged);
+        assert_eq!(
+            changed.previous_observation.unwrap().sha256,
+            sha256(b"first version")
+        );
+        assert_eq!(
+            changed.observation.unwrap().sha256,
+            sha256(b"replacement version")
+        );
+    }
+
+    #[test]
+    fn path_resolution_change_is_distinguished_from_content_change() {
+        let temp = TempDir::new().unwrap();
+        let first_directory = temp.path().join("first");
+        let second_directory = temp.path().join("second");
+        fs::create_dir(&first_directory).unwrap();
+        fs::create_dir(&second_directory).unwrap();
+        write_tool(&first_directory, "node", b"same bytes");
+        write_tool(&second_directory, "node", b"same bytes");
+        let state_path = temp.path().join("integrity.json");
+
+        let first_resolver = ToolResolver::from_paths([first_directory.clone()]);
+        assert_eq!(
+            scan_one("node", &first_resolver, &state_path).status,
+            IntegrityStatus::NewBaseline
+        );
+
+        let second_resolver = ToolResolver::from_paths([second_directory.clone()]);
+        let changed = scan_one("node", &second_resolver, &state_path);
+        assert_eq!(changed.status, IntegrityStatus::ResolvedPathChanged);
+        assert_eq!(
+            changed.observation.unwrap().resolved_path,
+            second_directory.join("node")
+        );
+    }
+
+    #[test]
+    fn missing_tool_is_reported_without_erasing_previous_baseline() {
+        let temp = TempDir::new().unwrap();
+        let state_path = temp.path().join("integrity.json");
+        let directory = temp.path().join("tools");
+        fs::create_dir(&directory).unwrap();
+        write_tool(&directory, "node", b"node");
+        let resolver = ToolResolver::from_paths([directory.clone()]);
+
+        assert_eq!(
+            scan_one("node", &resolver, &state_path).status,
+            IntegrityStatus::NewBaseline
+        );
+        fs::remove_file(directory.join("node")).unwrap();
+
+        let missing = scan_one("node", &resolver, &state_path);
+        assert_eq!(missing.status, IntegrityStatus::Missing);
+        assert_eq!(
+            missing.failure.unwrap().kind,
+            IntegrityFailureKind::NotFound
+        );
+        assert_eq!(
+            BaselineStore::new(&state_path)
+                .load()
+                .unwrap()
+                .observations
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn non_regular_target_is_an_inspection_failure() {
+        let temp = TempDir::new().unwrap();
+        let directory = temp.path().join("tools");
+        fs::create_dir(&directory).unwrap();
+        fs::create_dir(directory.join("node")).unwrap();
+        let resolver = ToolResolver::from_paths([directory]);
+
+        let check = scan_one("node", &resolver, &temp.path().join("integrity.json"));
+        assert_eq!(check.status, IntegrityStatus::InspectionFailed);
+        assert_eq!(
+            check.failure.unwrap().kind,
+            IntegrityFailureKind::NonRegularFile
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_observation_records_target_and_detects_target_change() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let directory = temp.path().join("tools");
+        fs::create_dir(&directory).unwrap();
+        let first_target = write_tool(&directory, "node-v1", b"v1");
+        let second_target = write_tool(&directory, "node-v2", b"v2");
+        let link = directory.join("node");
+        symlink(&first_target, &link).unwrap();
+        let resolver = ToolResolver::from_paths([directory.clone()]);
+        let state_path = temp.path().join("integrity.json");
+
+        let first = scan_one("node", &resolver, &state_path);
+        assert_eq!(first.status, IntegrityStatus::NewBaseline);
+        let observation = first.observation.unwrap();
+        assert_eq!(
+            observation.canonical_path,
+            fs::canonicalize(&first_target).unwrap()
+        );
+        assert_eq!(observation.symlink_target, Some(first_target.clone()));
+
+        fs::remove_file(&link).unwrap();
+        symlink(&second_target, &link).unwrap();
+        let changed = scan_one("node", &resolver, &state_path);
+        assert_eq!(changed.status, IntegrityStatus::ResolvedPathChanged);
+        assert_eq!(
+            changed.observation.unwrap().canonical_path,
+            fs::canonicalize(second_target).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn broken_symlink_is_not_silently_skipped() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let directory = temp.path().join("tools");
+        fs::create_dir(&directory).unwrap();
+        symlink(directory.join("missing-target"), directory.join("node")).unwrap();
+        let resolver = ToolResolver::from_paths([directory]);
+
+        let check = scan_one("node", &resolver, &temp.path().join("integrity.json"));
+        assert_eq!(check.status, IntegrityStatus::InspectionFailed);
+        assert_eq!(
+            check.failure.unwrap().kind,
+            IntegrityFailureKind::BrokenSymlink
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_loop_is_reported_as_an_inspection_failure() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let directory = temp.path().join("tools");
+        fs::create_dir(&directory).unwrap();
+        symlink(directory.join("loop-b"), directory.join("loop-a")).unwrap();
+        symlink(directory.join("loop-a"), directory.join("loop-b")).unwrap();
+        let resolver = ToolResolver::from_paths([directory]);
+
+        let check = scan_one("loop-a", &resolver, &temp.path().join("integrity.json"));
+        assert_eq!(check.status, IntegrityStatus::InspectionFailed);
+        assert_eq!(
+            check.failure.unwrap().kind,
+            IntegrityFailureKind::SymlinkLoop
+        );
+    }
+
+    #[test]
+    fn large_fixture_is_hashed_to_the_expected_sha256() {
+        let temp = TempDir::new().unwrap();
+        let bytes = (0..(2 * 1024 * 1024))
+            .map(|index| (index % 251) as u8)
+            .collect::<Vec<_>>();
+        write_tool(temp.path(), "node", &bytes);
+        let resolver = ToolResolver::from_paths([temp.path().to_path_buf()]);
+
+        let observation = inspect_tool(&tool("node"), &resolver).unwrap();
+        assert_eq!(observation.size_bytes, bytes.len() as u64);
+        assert_eq!(observation.sha256, sha256(&bytes));
+    }
+
+    #[test]
+    fn baseline_reload_preserves_multiple_tools_when_one_is_updated() {
+        let temp = TempDir::new().unwrap();
+        let first_directory = temp.path().join("first");
+        let second_directory = temp.path().join("second");
+        fs::create_dir(&first_directory).unwrap();
+        fs::create_dir(&second_directory).unwrap();
+        let node_path = write_tool(&first_directory, "node", b"node");
+        write_tool(&second_directory, "git", b"git");
+        let state_path = temp.path().join("integrity.json");
+        let resolver = ToolResolver::from_paths([first_directory, second_directory]);
+
+        let report =
+            scan_with_resolver(&[tool("node"), tool("git")], &resolver, &state_path).unwrap();
+        assert!(
+            report
+                .checks
+                .iter()
+                .all(|check| { check.status == IntegrityStatus::NewBaseline })
+        );
+
+        fs::write(node_path, b"node replacement").unwrap();
+        let report = scan_with_resolver(&[tool("node")], &resolver, &state_path).unwrap();
+        assert_eq!(report.checks[0].status, IntegrityStatus::ContentChanged);
+
+        let baseline = BaselineStore::new(&state_path).load().unwrap();
+        assert_eq!(baseline.observations.len(), 2);
+        assert!(baseline.observations.contains_key("git"));
+        assert_eq!(baseline.version, crate::models::INTEGRITY_STATE_VERSION);
+    }
+
+    #[test]
+    fn malformed_and_unsupported_state_are_explicit_errors() {
+        let temp = TempDir::new().unwrap();
+        let state_path = temp.path().join("integrity.json");
+        let store = BaselineStore::new(&state_path);
+
+        fs::write(&state_path, "not json").unwrap();
+        assert!(matches!(
+            store.load(),
+            Err(crate::error::DustError::IntegrityState(_))
+        ));
+
+        fs::write(&state_path, r#"{"version":2,"observations":{}}"#).unwrap();
+        assert!(matches!(
+            store.load(),
+            Err(crate::error::DustError::IntegrityState(message))
+                if message.contains("unsupported executable-integrity state version: 2")
+        ));
+    }
+
+    #[test]
+    fn failed_atomic_save_keeps_the_existing_destination_untouched() {
+        let temp = TempDir::new().unwrap();
+        let destination = temp.path().join("state-directory");
+        fs::create_dir(&destination).unwrap();
+
+        let result = BaselineStore::new(&destination).save(&IntegrityBaseline::default());
+
+        assert!(result.is_err());
+        assert!(destination.is_dir());
+        assert_eq!(
+            fs::read_dir(temp.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn inspecting_a_fake_executable_never_launches_it() {
+        let temp = TempDir::new().unwrap();
+        let marker = temp.path().join("launched");
+        let fake = format!("#!/bin/sh\ntouch {}\n", marker.display());
+        write_tool(temp.path(), "node", fake.as_bytes());
+        let resolver = ToolResolver::from_paths([temp.path().to_path_buf()]);
+
+        inspect_tool(&tool("node"), &resolver).unwrap();
+
+        assert!(!marker.exists());
+    }
+
+    #[test]
+    fn invalid_tool_name_is_reported_without_filesystem_access() {
+        let temp = TempDir::new().unwrap();
+        let resolver = ToolResolver::from_paths(Vec::<std::path::PathBuf>::new());
+
+        let failure = inspect_tool(&tool("  "), &resolver).unwrap_err();
+        assert_eq!(failure.kind, IntegrityFailureKind::InvalidToolName);
+        assert!(!temp.path().join("integrity.json").exists());
+    }
+}

--- a/crates/dustfril-core/src/integrity/resolver.rs
+++ b/crates/dustfril-core/src/integrity/resolver.rs
@@ -1,0 +1,216 @@
+use std::{
+    env,
+    ffi::OsString,
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use crate::models::{IntegrityFailure, IntegrityFailureKind, ToolSpec};
+
+/// PATH-based executable resolver that does not execute candidates.
+#[derive(Debug, Clone)]
+pub struct ToolResolver {
+    search_paths: Vec<PathBuf>,
+}
+
+impl ToolResolver {
+    /// Builds a resolver from the current process PATH.
+    pub fn from_environment() -> io::Result<Self> {
+        Ok(Self::from_path(env::var_os("PATH")))
+    }
+
+    /// Builds a resolver from a PATH-shaped value.
+    pub fn from_path(path: Option<OsString>) -> Self {
+        let search_paths = path
+            .as_deref()
+            .map(env::split_paths)
+            .map(Iterator::collect)
+            .unwrap_or_default();
+
+        Self { search_paths }
+    }
+
+    /// Builds a resolver from explicit search directories, useful for callers
+    /// that need deterministic resolution or tests with temporary fixtures.
+    pub fn from_paths(paths: impl IntoIterator<Item = PathBuf>) -> Self {
+        Self {
+            search_paths: paths.into_iter().collect(),
+        }
+    }
+
+    /// Resolves a command name or explicit path and inspects only its identity.
+    pub fn resolve(&self, tool: &ToolSpec) -> Result<ResolvedExecutable, IntegrityFailure> {
+        if tool.name.trim().is_empty() || tool.name.contains('\0') {
+            return Err(IntegrityFailure::new(
+                IntegrityFailureKind::InvalidToolName,
+                "requested tool name is empty or contains a NUL byte",
+            ));
+        }
+
+        let requested = Path::new(&tool.name);
+        if is_explicit_path(requested) {
+            return self.inspect_candidate(tool, make_absolute(requested));
+        }
+
+        for search_path in &self.search_paths {
+            let directory = if search_path.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                search_path.as_path()
+            };
+
+            for candidate_name in candidate_names(&tool.name) {
+                let candidate = make_absolute(&directory.join(candidate_name));
+                match fs::symlink_metadata(&candidate) {
+                    Ok(_) => return self.inspect_candidate(tool, candidate),
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                    Err(error) => {
+                        return Err(io_failure(
+                            IntegrityFailureKind::Unreadable,
+                            &candidate,
+                            error,
+                        ));
+                    }
+                }
+            }
+        }
+
+        Err(IntegrityFailure::new(
+            IntegrityFailureKind::NotFound,
+            format!("no PATH candidate found for {}", tool.name),
+        ))
+    }
+
+    fn inspect_candidate(
+        &self,
+        tool: &ToolSpec,
+        resolved_path: PathBuf,
+    ) -> Result<ResolvedExecutable, IntegrityFailure> {
+        let link_metadata = fs::symlink_metadata(&resolved_path).map_err(|error| {
+            let kind = if error.kind() == io::ErrorKind::NotFound {
+                IntegrityFailureKind::NotFound
+            } else {
+                IntegrityFailureKind::Unreadable
+            };
+            io_failure(kind, &resolved_path, error)
+        })?;
+        let is_symlink = link_metadata.file_type().is_symlink();
+        let symlink_target = if is_symlink {
+            Some(fs::read_link(&resolved_path).map_err(|error| {
+                io_failure(IntegrityFailureKind::Unreadable, &resolved_path, error)
+            })?)
+        } else {
+            None
+        };
+
+        let canonical_path = fs::canonicalize(&resolved_path).map_err(|error| {
+            let kind = if is_symlink && error.kind() == io::ErrorKind::NotFound {
+                IntegrityFailureKind::BrokenSymlink
+            } else if is_symlink && is_symlink_loop(&error) {
+                IntegrityFailureKind::SymlinkLoop
+            } else {
+                IntegrityFailureKind::Unreadable
+            };
+            io_failure(kind, &resolved_path, error)
+        })?;
+        let target_metadata = fs::metadata(&canonical_path).map_err(|error| {
+            io_failure(IntegrityFailureKind::Unreadable, &canonical_path, error)
+        })?;
+
+        if !target_metadata.is_file() {
+            return Err(IntegrityFailure::new(
+                IntegrityFailureKind::NonRegularFile,
+                format!(
+                    "resolved target for {} is not a regular file: {}",
+                    tool.name,
+                    canonical_path.display()
+                ),
+            ));
+        }
+
+        Ok(ResolvedExecutable {
+            requested_tool: tool.name.clone(),
+            resolved_path,
+            canonical_path,
+            symlink_target,
+        })
+    }
+}
+
+/// The selected PATH identity and the canonical regular file to hash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedExecutable {
+    pub requested_tool: String,
+    pub resolved_path: PathBuf,
+    pub canonical_path: PathBuf,
+    pub symlink_target: Option<PathBuf>,
+}
+
+fn is_explicit_path(path: &Path) -> bool {
+    path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+        || path.to_string_lossy().contains(['/', '\\'])
+}
+
+fn make_absolute(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+
+    env::current_dir()
+        .map(|current| current.join(path))
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(windows)]
+fn candidate_names(name: &str) -> Vec<PathBuf> {
+    let path = Path::new(name);
+    if path.extension().is_some() {
+        return vec![path.to_path_buf()];
+    }
+
+    let extensions = env::var_os("PATHEXT")
+        .map(|value| {
+            value
+                .to_string_lossy()
+                .split(';')
+                .filter(|extension| !extension.is_empty())
+                .map(PathBuf::from)
+                .collect::<Vec<_>>()
+        })
+        .filter(|extensions| !extensions.is_empty())
+        .unwrap_or_else(|| {
+            [".COM", ".EXE", ".BAT", ".CMD"]
+                .into_iter()
+                .map(PathBuf::from)
+                .collect()
+        });
+
+    extensions
+        .into_iter()
+        .map(|extension| PathBuf::from(format!("{name}{}", extension.display())))
+        .collect()
+}
+
+#[cfg(not(windows))]
+fn candidate_names(name: &str) -> Vec<PathBuf> {
+    vec![PathBuf::from(name)]
+}
+
+fn io_failure(kind: IntegrityFailureKind, path: &Path, error: io::Error) -> IntegrityFailure {
+    IntegrityFailure::new(kind, format!("{}: {error}", path.display()))
+}
+
+fn is_symlink_loop(error: &io::Error) -> bool {
+    #[cfg(unix)]
+    if error.raw_os_error() == Some(40) {
+        return true;
+    }
+
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("too many levels of symbolic links")
+        || message.contains("symbolic link loop")
+        || message.contains("symlink loop")
+}

--- a/crates/dustfril-core/src/integrity/resolver.rs
+++ b/crates/dustfril-core/src/integrity/resolver.rs
@@ -62,7 +62,12 @@ impl ToolResolver {
             for candidate_name in candidate_names(&tool.name) {
                 let candidate = make_absolute(&directory.join(candidate_name));
                 match fs::symlink_metadata(&candidate) {
-                    Ok(_) => return self.inspect_candidate(tool, candidate),
+                    Ok(_) => match self.inspect_candidate(tool, candidate) {
+                        Err(failure) if failure.kind == IntegrityFailureKind::NonExecutable => {
+                            continue;
+                        }
+                        result => return result,
+                    },
                     Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
                     Err(error) => {
                         return Err(io_failure(
@@ -128,6 +133,17 @@ impl ToolResolver {
             ));
         }
 
+        if !is_executable(&canonical_path, &target_metadata) {
+            return Err(IntegrityFailure::new(
+                IntegrityFailureKind::NonExecutable,
+                format!(
+                    "resolved target for {} is not executable: {}",
+                    tool.name,
+                    canonical_path.display()
+                ),
+            ));
+        }
+
         Ok(ResolvedExecutable {
             requested_tool: tool.name.clone(),
             resolved_path,
@@ -135,6 +151,33 @@ impl ToolResolver {
             symlink_target,
         })
     }
+}
+
+#[cfg(unix)]
+fn is_executable(_path: &Path, metadata: &fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    metadata.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(windows)]
+fn is_executable(path: &Path, _metadata: &fs::Metadata) -> bool {
+    let Some(extension) = path.extension().and_then(|extension| extension.to_str()) else {
+        return false;
+    };
+    let extension = format!(".{extension}");
+    let path_extensions =
+        env::var_os("PATHEXT").unwrap_or_else(|| OsString::from(".COM;.EXE;.BAT;.CMD"));
+
+    path_extensions
+        .to_string_lossy()
+        .split(';')
+        .any(|candidate| candidate.eq_ignore_ascii_case(&extension))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn is_executable(_path: &Path, _metadata: &fs::Metadata) -> bool {
+    true
 }
 
 /// The selected PATH identity and the canonical regular file to hash.

--- a/crates/dustfril-core/src/lib.rs
+++ b/crates/dustfril-core/src/lib.rs
@@ -7,6 +7,7 @@ mod audit_tool;
 mod cleaner;
 mod fs;
 mod history;
+mod integrity;
 mod lockfile;
 mod scanner;
 mod security;

--- a/crates/dustfril-core/src/models/integrity.rs
+++ b/crates/dustfril-core/src/models/integrity.rs
@@ -77,6 +77,8 @@ pub enum IntegrityFailureKind {
     NotFound,
     /// The resolved target is not a regular file.
     NonRegularFile,
+    /// The resolved regular file is not executable for the current platform.
+    NonExecutable,
     /// Metadata, opening, or reading the target was denied or unavailable.
     Unreadable,
     /// A symlink target does not exist.
@@ -93,6 +95,7 @@ impl fmt::Display for IntegrityFailureKind {
             Self::InvalidToolName => "Invalid tool name",
             Self::NotFound => "Tool not found",
             Self::NonRegularFile => "Resolved target is not a regular file",
+            Self::NonExecutable => "Resolved target is not executable",
             Self::Unreadable => "Target is unreadable",
             Self::BrokenSymlink => "Broken symlink",
             Self::SymlinkLoop => "Symlink loop",
@@ -162,7 +165,7 @@ impl IntegrityReport {
             matches!(
                 check.status,
                 IntegrityStatus::ContentChanged | IntegrityStatus::ResolvedPathChanged
-            )
+            ) || (check.status == IntegrityStatus::Missing && check.previous_observation.is_some())
         })
     }
 }

--- a/crates/dustfril-core/src/models/integrity.rs
+++ b/crates/dustfril-core/src/models/integrity.rs
@@ -1,0 +1,184 @@
+//! Models for local executable-integrity observations and comparisons.
+
+use std::{collections::BTreeMap, fmt, path::PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Version of the on-disk executable-integrity baseline format.
+pub const INTEGRITY_STATE_VERSION: u32 = 1;
+
+/// A caller-selected development tool to inspect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolSpec {
+    /// The command name or explicit filesystem path requested by the caller.
+    pub name: String,
+}
+
+impl ToolSpec {
+    /// Creates a tool selection without resolving or executing it.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+impl From<&str> for ToolSpec {
+    fn from(name: &str) -> Self {
+        Self::new(name)
+    }
+}
+
+impl From<String> for ToolSpec {
+    fn from(name: String) -> Self {
+        Self::new(name)
+    }
+}
+
+/// The result of comparing a current observation with the previous baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum IntegrityStatus {
+    /// No prior successful observation exists for this tool.
+    NewBaseline,
+    /// The selected identity and content hash are unchanged.
+    Unchanged,
+    /// The resolved file content hash differs from the previous observation.
+    ContentChanged,
+    /// PATH resolution, canonical target, or symlink relationship changed.
+    ResolvedPathChanged,
+    /// No candidate could be found for the requested tool.
+    Missing,
+    /// The candidate existed but could not be safely inspected.
+    InspectionFailed,
+}
+
+impl fmt::Display for IntegrityStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::NewBaseline => "New baseline",
+            Self::Unchanged => "Unchanged",
+            Self::ContentChanged => "Content changed",
+            Self::ResolvedPathChanged => "Resolved path changed",
+            Self::Missing => "Missing",
+            Self::InspectionFailed => "Inspection failed",
+        };
+
+        f.write_str(label)
+    }
+}
+
+/// The reason a requested executable could not be inspected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum IntegrityFailureKind {
+    /// The requested tool name was empty or otherwise invalid.
+    InvalidToolName,
+    /// No PATH candidate or explicit path exists.
+    NotFound,
+    /// The resolved target is not a regular file.
+    NonRegularFile,
+    /// Metadata, opening, or reading the target was denied or unavailable.
+    Unreadable,
+    /// A symlink target does not exist.
+    BrokenSymlink,
+    /// Symlink resolution exceeded the platform's loop limit.
+    SymlinkLoop,
+    /// Reading the target failed after hashing began.
+    HashFailed,
+}
+
+impl fmt::Display for IntegrityFailureKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::InvalidToolName => "Invalid tool name",
+            Self::NotFound => "Tool not found",
+            Self::NonRegularFile => "Resolved target is not a regular file",
+            Self::Unreadable => "Target is unreadable",
+            Self::BrokenSymlink => "Broken symlink",
+            Self::SymlinkLoop => "Symlink loop",
+            Self::HashFailed => "Hashing failed",
+        };
+
+        f.write_str(label)
+    }
+}
+
+/// Structured details for an inspection failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IntegrityFailure {
+    pub kind: IntegrityFailureKind,
+    pub message: String,
+}
+
+impl IntegrityFailure {
+    pub(crate) fn new(kind: IntegrityFailureKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+/// A successful, non-executing observation of a requested executable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutableObservation {
+    pub requested_tool: String,
+    /// The PATH entry or explicit path selected before canonicalization.
+    pub resolved_path: PathBuf,
+    /// The regular file whose bytes were hashed.
+    pub canonical_path: PathBuf,
+    /// The direct symlink target, when the selected path is a symlink.
+    pub symlink_target: Option<PathBuf>,
+    pub size_bytes: u64,
+    /// Lowercase hexadecimal SHA-256 of the canonical target's bytes.
+    pub sha256: String,
+    pub observed_at: DateTime<Utc>,
+    /// Reserved for safe metadata sources; inspection never invokes the tool.
+    pub version_metadata: Option<String>,
+}
+
+/// One tool's current integrity result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IntegrityCheck {
+    pub requested_tool: String,
+    pub status: IntegrityStatus,
+    pub observation: Option<ExecutableObservation>,
+    pub previous_observation: Option<ExecutableObservation>,
+    pub failure: Option<IntegrityFailure>,
+}
+
+/// Structured results for an executable-integrity scan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct IntegrityReport {
+    pub checks: Vec<IntegrityCheck>,
+}
+
+impl IntegrityReport {
+    /// Returns whether any tool differed from its previous successful state.
+    pub fn has_changes(&self) -> bool {
+        self.checks.iter().any(|check| {
+            matches!(
+                check.status,
+                IntegrityStatus::ContentChanged | IntegrityStatus::ResolvedPathChanged
+            )
+        })
+    }
+}
+
+/// Versioned local state containing the last successful observation per tool.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IntegrityBaseline {
+    pub version: u32,
+    pub observations: BTreeMap<String, ExecutableObservation>,
+}
+
+impl Default for IntegrityBaseline {
+    fn default() -> Self {
+        Self {
+            version: INTEGRITY_STATE_VERSION,
+            observations: BTreeMap::new(),
+        }
+    }
+}

--- a/crates/dustfril-core/src/models/mod.rs
+++ b/crates/dustfril-core/src/models/mod.rs
@@ -3,6 +3,7 @@ mod analysis;
 mod audit;
 mod cleanup;
 mod history;
+mod integrity;
 mod lockfile;
 mod scan;
 
@@ -10,6 +11,7 @@ pub use analysis::*;
 pub use audit::*;
 pub use cleanup::*;
 pub use history::*;
+pub use integrity::*;
 pub use lockfile::*;
 pub(crate) use scan::effective_security_ecosystems;
 pub use scan::*;


### PR DESCRIPTION
## Summary

Implements #62 with a reusable `dustfril-core` executable-integrity scanner and a thin CLI command.

- Resolve selected developer tools through PATH or explicit paths without executing them.
- Record resolved path, canonical target, symlink relationship, size, SHA-256, and observation time.
- Compare observations as `NewBaseline`, `Unchanged`, `ContentChanged`, `ResolvedPathChanged`, `Missing`, or `InspectionFailed`.
- Persist versioned baselines separately from activity history using atomic replacement.
- Keep multiple tool records and preserve the last successful observation when inspection fails.
- Add `dfr integrity scan --tool <name>` with default tools: node, bun, cargo, rustc, git, java, gradle.
- Add temporary-fixture coverage for hashing, PATH changes, symlinks, missing/non-regular targets, malformed state, persistence, large files, and the no-execution regression.

A changed executable is reported as an integrity change and is never presented as proof of malware. Platform signature verification remains outside this change for #63.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo llvm-cov --workspace --all-features --summary-only`
