### PR TITLE
[FEATURE] Add platform-aware executable code-signature verification

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -89,10 +89,12 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 
 `integrity scan`은 PATH에서 요청한 개발 도구를 찾고 파일 메타데이터와 바이트를
 읽어 SHA-256을 스트리밍 계산합니다. 대상 실행 파일을 절대 실행하지 않으며,
-activity history와 분리된 버전 형식의 baseline을 저장합니다. 기본 대상은 `node`,
-`bun`, `cargo`, `rustc`, `git`, `java`, `gradle`이고, `--tool`을 반복해 일부만
-선택할 수 있습니다. 경로 또는 해시 변경은 무결성 변경으로 보고하며 악성 코드의
-증거라고 단정하지 않습니다.
+activity history와 분리된 버전 형식의 baseline을 저장합니다. macOS에서는 시스템
+`codesign`으로 읽기 전용 서명 정보도 확인하고, Linux와 Windows에서는 서명 검증을
+명시적으로 `Unsupported`로 보고합니다. 기본 대상은 `node`, `bun`, `cargo`,
+`rustc`, `git`, `java`, `gradle`이고, `--tool`을 반복해 일부만 선택할 수 있습니다.
+경로 또는 해시 변경은 무결성 변경으로 보고하며 악성 코드의 증거라고 단정하지
+않습니다. 서명 결과도 소프트웨어 전체의 신뢰성 판정이 아닙니다.
 
 ## 데스크톱 앱
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,13 @@ invokes a package manager, contacts the network, or modifies project files.
 `integrity scan` resolves the requested development tools through PATH, reads
 filesystem metadata, streams each target through SHA-256, and stores its
 versioned baseline separately from activity history. It never launches the
-target executable. Default tools are `node`, `bun`, `cargo`, `rustc`, `git`,
-`java`, and `gradle`; use repeated `--tool` flags to select a subset. A changed
-path or hash is reported as an integrity change, not as proof of malware.
+target executable. On macOS it also asks the system `codesign` verifier for
+read-only signature evidence; Linux and Windows report signature verification
+as explicitly unsupported until platform-specific verifiers are added. Default
+tools are `node`, `bun`, `cargo`, `rustc`, `git`, `java`, and `gradle`; use
+repeated `--tool` flags to select a subset. A changed path or hash is reported
+as an integrity change, not as proof of malware, and a signature result is not
+a general software-trust verdict.
 
 ## Desktop App
 

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -42,6 +42,8 @@ cargo build -p dustfril-cli
 - command failures return a non-zero process exit status
 - security scans are read-only and use deterministic offline checks
 - executable-integrity scans read metadata and bytes only; they never invoke a target tool
+- executable-integrity scans report platform signature evidence separately from hash changes
+- Linux and Windows currently report executable signature verification as explicitly unsupported
 - executable-integrity baselines are stored separately from activity history in the OS app data directory
 - activity-history write failures are reported without discarding a completed operation result
 - Activity history is stored in the OS app data directory as a versioned `history.json`.

--- a/apps/dustfril-cli/src/format/integrity_format.rs
+++ b/apps/dustfril-cli/src/format/integrity_format.rs
@@ -1,4 +1,4 @@
-use dustfril_core::models::{IntegrityReport, IntegrityStatus};
+use dustfril_core::models::{IntegrityReport, IntegrityStatus, SignatureStatus};
 
 /// Prints non-executing executable-integrity facts and comparison states.
 pub fn print_integrity_report(report: &IntegrityReport) {
@@ -29,6 +29,26 @@ pub fn print_integrity_report(report: &IntegrityReport) {
 
         if let Some(failure) = &check.failure {
             println!("  Reason:         {} ({})", failure.kind, failure.message);
+        }
+
+        if let Some(signature) = &check.signature {
+            if signature.status == SignatureStatus::Unsupported {
+                println!("  Signature:      Unsupported on this platform");
+            } else {
+                println!("  Signature:      {}", signature.status);
+            }
+            if let Some(signer) = &signature.signer {
+                println!("  Signer:         {signer}");
+            }
+            if let Some(team_identifier) = &signature.team_identifier {
+                println!("  Team:           {team_identifier}");
+            }
+            if let Some(message) = &signature.verification_message {
+                println!("  Signature info: {message}");
+            }
+            if let Some(failure) = &signature.failure {
+                println!("  Signature reason: {} ({})", failure.kind, failure.message);
+            }
         }
 
         if matches!(

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -16,6 +16,7 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - `api::security_scan`: preserve the lifecycle-only security warnings API
 - `api::security_scan_report`: run the complete offline supply-chain scan
 - `api::integrity`: resolve selected development tools without executing them, hash their bytes, and compare local baselines
+- `api::integrity::verify_signature`: inspect an already resolved executable with the supported platform verifier
 - `api::check_lockfile_integrity`: check supported lockfile presence and Git status
 - `api::history`: record and load cleanup history using atomic replacement;
   corrupted or unsupported history files are returned as errors
@@ -37,6 +38,10 @@ Executable-integrity scans support `node`, `bun`, `cargo`, `rustc`, `git`,
 symlinks, stream SHA-256 hashing, and persist a separate versioned
 `integrity-baseline.json`. Missing or unreadable tools are returned as
 structured results; a changed hash is an observation, not a malware claim.
+Signature evidence is kept separate from baseline comparison: macOS uses the
+system `codesign` verifier, while Linux and Windows return `Unsupported` until
+dedicated platform verifiers are implemented. Unsigned or invalid signatures
+are evidence about the verifier result, not malware claims.
 
 The supply-chain report reads `package.json` and `Cargo.toml` plus supported
 lockfiles without executing scripts or contacting an external advisory service.

--- a/crates/dustfril-core/src/api/integrity.rs
+++ b/crates/dustfril-core/src/api/integrity.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{
     error::DustResult,
     integrity,
-    models::{ExecutableObservation, IntegrityFailure, IntegrityReport, ToolSpec},
+    models::{ExecutableObservation, IntegrityFailure, IntegrityReport, SignatureReport, ToolSpec},
 };
 
 pub use crate::integrity::{BaselineStore, ResolvedExecutable, ToolResolver};
@@ -53,4 +53,9 @@ pub fn inspect_tool(
 ) -> Result<ExecutableObservation, IntegrityFailure> {
     let resolver = integrity::ToolResolver::from_paths(paths);
     integrity::inspect_tool(tool, &resolver)
+}
+
+/// Verifies the OS-supported signature for an already resolved executable.
+pub fn verify_signature(path: &Path) -> SignatureReport {
+    integrity::verify_signature(path)
 }

--- a/crates/dustfril-core/src/integrity/macos.rs
+++ b/crates/dustfril-core/src/integrity/macos.rs
@@ -1,0 +1,230 @@
+// macOS code-signature verification through the system `codesign` verifier.
+use std::{io, path::Path, process::Command};
+
+use crate::models::{
+    SignatureFailure, SignatureFailureKind, SignaturePlatform, SignatureReport, SignatureStatus,
+};
+
+const CODESIGN_PATH: &str = "/usr/bin/codesign";
+
+pub fn verify(path: &Path) -> SignatureReport {
+    let output = Command::new(CODESIGN_PATH)
+        .arg("--verify")
+        .arg("--verbose=4")
+        // `path` is an argument to the verifier, never shell-interpolated.
+        .arg(path.as_os_str())
+        .output();
+
+    match output {
+        Ok(output) => report_from_output(output.status.code(), output.status.success(), &output),
+        Err(error) => report_for_command_error(error),
+    }
+}
+
+fn report_from_output(
+    exit_code: Option<i32>,
+    successful: bool,
+    output: &std::process::Output,
+) -> SignatureReport {
+    let details = parse_codesign_details(&combined_output(output));
+
+    if successful {
+        let mut report = SignatureReport::new(SignaturePlatform::MacOs, SignatureStatus::Valid);
+        report.signer = details.signer;
+        report.team_identifier = details.team_identifier;
+        report.verification_code = exit_code;
+        report.verification_message = Some("codesign accepted the executable signature".to_owned());
+        return report;
+    }
+
+    let status = classify_failure(&details.output);
+    let mut report = SignatureReport::new(SignaturePlatform::MacOs, status);
+    report.signer = details.signer;
+    report.team_identifier = details.team_identifier;
+    report.verification_code = exit_code;
+    report.verification_message = Some(match status {
+        SignatureStatus::Unsigned => "codesign found no supported signature".to_owned(),
+        SignatureStatus::Invalid => "codesign rejected the executable signature".to_owned(),
+        SignatureStatus::InspectionFailed => {
+            "codesign could not classify the verification result".to_owned()
+        }
+        SignatureStatus::Valid | SignatureStatus::Unsupported => {
+            "codesign returned an unexpected verification result".to_owned()
+        }
+    });
+
+    if status == SignatureStatus::InspectionFailed {
+        report.failure = Some(SignatureFailure::new(
+            SignatureFailureKind::VerifierFailed,
+            verifier_failure_message(exit_code),
+        ));
+    }
+
+    report
+}
+
+fn report_for_command_error(error: io::Error) -> SignatureReport {
+    let kind = if error.kind() == io::ErrorKind::NotFound {
+        SignatureFailureKind::VerifierUnavailable
+    } else {
+        SignatureFailureKind::VerifierFailed
+    };
+    let mut report =
+        SignatureReport::new(SignaturePlatform::MacOs, SignatureStatus::InspectionFailed);
+    report.verification_message = Some("macOS signature verifier could not be started".to_owned());
+    report.failure = Some(SignatureFailure::new(
+        kind,
+        format!("{CODESIGN_PATH}: {error}"),
+    ));
+    report
+}
+
+fn verifier_failure_message(exit_code: Option<i32>) -> String {
+    match exit_code {
+        Some(code) => {
+            format!("codesign returned an unclassified verification failure (exit code {code})")
+        }
+        None => "codesign terminated without an exit code".to_owned(),
+    }
+}
+
+struct CodesignDetails {
+    output: String,
+    signer: Option<String>,
+    team_identifier: Option<String>,
+}
+
+fn parse_codesign_details(output: &str) -> CodesignDetails {
+    let mut signer = None;
+    let mut team_identifier = None;
+
+    for line in output.lines().map(str::trim) {
+        if let Some(value) = line.strip_prefix("Authority=")
+            && !value.is_empty()
+            && signer.is_none()
+        {
+            signer = Some(value.to_owned());
+        }
+        if let Some(value) = line.strip_prefix("TeamIdentifier=")
+            && !value.is_empty()
+        {
+            team_identifier = Some(value.to_owned());
+        }
+    }
+
+    CodesignDetails {
+        output: output.to_owned(),
+        signer,
+        team_identifier,
+    }
+}
+
+fn classify_failure(output: &str) -> SignatureStatus {
+    let output = output.to_ascii_lowercase();
+
+    if output.contains("not signed")
+        || output.contains("no code signature")
+        || output.contains("code object is unsigned")
+    {
+        SignatureStatus::Unsigned
+    } else if output.contains("invalid")
+        || output.contains("sealed resource")
+        || output.contains("code object is unsealed")
+        || output.contains("code or signature modified")
+        || output.contains("invalid signature")
+        || output.contains("signature invalid")
+        || output.contains("hash mismatch")
+        || output.contains("a valid code signature")
+    {
+        SignatureStatus::Invalid
+    } else {
+        SignatureStatus::InspectionFailed
+    }
+}
+
+fn combined_output(output: &std::process::Output) -> String {
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !combined.is_empty() {
+        combined.push('\n');
+    }
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    combined
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_codesign_unsigned_output_without_treating_it_as_verifier_failure() {
+        assert_eq!(
+            classify_failure("/tmp/tool: code object is not signed at all"),
+            SignatureStatus::Unsigned
+        );
+    }
+
+    #[test]
+    fn maps_codesign_tampering_output_to_invalid() {
+        assert_eq!(
+            classify_failure("a sealed resource is missing or invalid"),
+            SignatureStatus::Invalid
+        );
+        assert_eq!(
+            classify_failure("code or signature modified"),
+            SignatureStatus::Invalid
+        );
+    }
+
+    #[test]
+    fn leaves_unknown_codesign_failures_as_inspection_failures() {
+        assert_eq!(
+            classify_failure("codesign: operation not permitted"),
+            SignatureStatus::InspectionFailed
+        );
+    }
+
+    #[test]
+    fn extracts_signer_and_team_metadata() {
+        let details = parse_codesign_details(
+            "Authority=Developer ID Application: Example (TEAM123)\nTeamIdentifier=TEAM123\n",
+        );
+
+        assert_eq!(
+            details.signer.as_deref(),
+            Some("Developer ID Application: Example (TEAM123)")
+        );
+        assert_eq!(details.team_identifier.as_deref(), Some("TEAM123"));
+    }
+
+    #[test]
+    fn unsigned_fixture_is_reported_as_unsigned() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let target = temp.path().join("unsigned-tool");
+        std::fs::write(&target, b"unsigned fixture").unwrap();
+
+        let report = verify(&target);
+
+        assert_eq!(report.status, SignatureStatus::Unsigned);
+        assert!(report.failure.is_none());
+    }
+
+    #[test]
+    fn signed_system_fixture_is_reported_as_valid() {
+        let report = verify(Path::new("/usr/bin/true"));
+
+        assert_eq!(report.status, SignatureStatus::Valid);
+        assert!(report.failure.is_none());
+    }
+
+    #[test]
+    fn special_path_is_passed_without_shell_interpolation() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let target = temp.path().join("tool with spaces;$(touch marker)");
+        std::fs::write(&target, b"unsigned fixture").unwrap();
+
+        let report = verify(&target);
+
+        assert_eq!(report.status, SignatureStatus::Unsigned);
+        assert!(target.exists());
+    }
+}

--- a/crates/dustfril-core/src/integrity/macos.rs
+++ b/crates/dustfril-core/src/integrity/macos.rs
@@ -16,12 +16,18 @@ pub fn verify(path: &Path) -> SignatureReport {
         .output();
 
     match output {
-        Ok(output) => report_from_output(output.status.code(), output.status.success(), &output),
+        Ok(output) => report_from_output(
+            path,
+            output.status.code(),
+            output.status.success(),
+            &output,
+        ),
         Err(error) => report_for_command_error(error),
     }
 }
 
 fn report_from_output(
+    path: &Path,
     exit_code: Option<i32>,
     successful: bool,
     output: &std::process::Output,
@@ -30,10 +36,17 @@ fn report_from_output(
 
     if successful {
         let mut report = SignatureReport::new(SignaturePlatform::MacOs, SignatureStatus::Valid);
-        report.signer = details.signer;
-        report.team_identifier = details.team_identifier;
         report.verification_code = exit_code;
         report.verification_message = Some("codesign accepted the executable signature".to_owned());
+        if let Some(metadata) = display_metadata(path) {
+            report.signer = metadata.signer;
+            report.team_identifier = metadata.team_identifier;
+        } else {
+            report.verification_message = Some(
+                "codesign accepted the executable signature; signer metadata is unavailable"
+                    .to_owned(),
+            );
+        }
         return report;
     }
 
@@ -61,6 +74,22 @@ fn report_from_output(
     }
 
     report
+}
+
+fn display_metadata(path: &Path) -> Option<CodesignDetails> {
+    let output = Command::new(CODESIGN_PATH)
+        .arg("-d")
+        .arg("--verbose=4")
+        // `path` is an argument to the verifier, never shell-interpolated.
+        .arg(path.as_os_str())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    Some(parse_codesign_details(&combined_output(&output)))
 }
 
 fn report_for_command_error(error: io::Error) -> SignatureReport {
@@ -107,6 +136,7 @@ fn parse_codesign_details(output: &str) -> CodesignDetails {
         }
         if let Some(value) = line.strip_prefix("TeamIdentifier=")
             && !value.is_empty()
+            && !value.eq_ignore_ascii_case("not set")
         {
             team_identifier = Some(value.to_owned());
         }
@@ -213,6 +243,8 @@ mod tests {
         let report = verify(Path::new("/usr/bin/true"));
 
         assert_eq!(report.status, SignatureStatus::Valid);
+        assert_eq!(report.signer.as_deref(), Some("Software Signing"));
+        assert!(report.team_identifier.is_none());
         assert!(report.failure.is_none());
     }
 

--- a/crates/dustfril-core/src/integrity/mod.rs
+++ b/crates/dustfril-core/src/integrity/mod.rs
@@ -85,6 +85,7 @@ fn check_tool(
 
     match inspect_tool(tool, resolver) {
         Ok(observation) => {
+            let (observation, signature) = verify_and_reinspect(tool, resolver, observation);
             let status = previous_observation
                 .as_ref()
                 .map_or(IntegrityStatus::NewBaseline, |previous| {
@@ -98,15 +99,13 @@ fn check_tool(
                 .observations
                 .insert(tool.name.clone(), observation.clone());
 
-            let signature = Some(signature::verify(&observation.canonical_path));
-
             IntegrityCheck {
                 requested_tool: tool.name.clone(),
                 status,
                 observation: Some(observation),
                 previous_observation,
                 failure: None,
-                signature,
+                signature: Some(signature),
             }
         }
         Err(failure) => {
@@ -126,6 +125,53 @@ fn check_tool(
             }
         }
     }
+}
+
+/// Re-inspects the resolved target after signature verification so a path or
+/// content replacement during the verifier call cannot be reported with a
+/// signature belonging to a different file version.
+fn verify_and_reinspect(
+    tool: &ToolSpec,
+    resolver: &ToolResolver,
+    observation: ExecutableObservation,
+) -> (ExecutableObservation, crate::models::SignatureReport) {
+    let signature = signature::verify(&observation.canonical_path);
+
+    // Unsupported platforms do not invoke an external verifier, so another
+    // hash pass would add work without closing a verifier TOCTOU window.
+    if signature.status == crate::models::SignatureStatus::Unsupported {
+        return (observation, signature);
+    }
+
+    match inspect_tool(tool, resolver) {
+        Ok(current) if observations_match(&observation, &current) => (observation, signature),
+        Ok(current) => (
+            current,
+            signature::target_changed_report(
+                &signature,
+                "resolved path, symlink relationship, size, or SHA-256 changed during verification",
+            ),
+        ),
+        Err(failure) => (
+            observation,
+            signature::target_changed_report(
+                &signature,
+                format!(
+                    "target could not be re-inspected after verification: {} ({})",
+                    failure.kind, failure.message
+                ),
+            ),
+        ),
+    }
+}
+
+fn observations_match(previous: &ExecutableObservation, current: &ExecutableObservation) -> bool {
+    previous.requested_tool == current.requested_tool
+        && previous.resolved_path == current.resolved_path
+        && previous.canonical_path == current.canonical_path
+        && previous.symlink_target == current.symlink_target
+        && previous.size_bytes == current.size_bytes
+        && previous.sha256 == current.sha256
 }
 
 #[cfg(test)]

--- a/crates/dustfril-core/src/integrity/mod.rs
+++ b/crates/dustfril-core/src/integrity/mod.rs
@@ -8,6 +8,7 @@ mod baseline;
 mod comparator;
 mod hasher;
 mod resolver;
+mod signature;
 
 pub use baseline::BaselineStore;
 pub use resolver::{ResolvedExecutable, ToolResolver};
@@ -42,6 +43,13 @@ pub fn inspect_tool(
 ) -> Result<ExecutableObservation, crate::models::IntegrityFailure> {
     let resolved = resolver.resolve(tool)?;
     hasher::observe(resolved)
+}
+
+/// Verifies the platform-supported code signature for an already resolved
+/// executable without launching the target. The caller should pass the
+/// canonical path returned by executable inspection.
+pub fn verify_signature(path: &Path) -> crate::models::SignatureReport {
+    signature::verify(path)
 }
 
 /// Resolves and compares selected tools using the process environment's PATH.
@@ -90,12 +98,15 @@ fn check_tool(
                 .observations
                 .insert(tool.name.clone(), observation.clone());
 
+            let signature = Some(signature::verify(&observation.canonical_path));
+
             IntegrityCheck {
                 requested_tool: tool.name.clone(),
                 status,
                 observation: Some(observation),
                 previous_observation,
                 failure: None,
+                signature,
             }
         }
         Err(failure) => {
@@ -111,6 +122,7 @@ fn check_tool(
                 observation: None,
                 previous_observation,
                 failure: Some(failure),
+                signature: None,
             }
         }
     }
@@ -184,6 +196,7 @@ mod tests {
         assert!(!first_report.has_changes());
         let first = first_report.checks.into_iter().next().unwrap();
         assert_eq!(first.status, IntegrityStatus::NewBaseline);
+        assert!(first.signature.is_some());
         assert_eq!(first.observation.as_ref().unwrap().size_bytes, 13);
         assert_eq!(
             first.observation.as_ref().unwrap().sha256,

--- a/crates/dustfril-core/src/integrity/signature.rs
+++ b/crates/dustfril-core/src/integrity/signature.rs
@@ -33,6 +33,21 @@ pub fn verify(path: &Path) -> SignatureReport {
     }
 }
 
+pub(crate) fn target_changed_report(
+    previous: &SignatureReport,
+    message: impl Into<String>,
+) -> SignatureReport {
+    let mut report = SignatureReport::new(previous.platform, SignatureStatus::InspectionFailed);
+    report.verification_code = previous.verification_code;
+    report.verification_message =
+        Some("The executable changed while signature verification was in progress".to_owned());
+    report.failure = Some(SignatureFailure::new(
+        SignatureFailureKind::TargetChangedDuringVerification,
+        message,
+    ));
+    report
+}
+
 fn validate_target(path: &Path) -> Result<(), SignatureFailure> {
     let metadata = fs::metadata(path).map_err(|error| {
         let kind = if error.kind() == io::ErrorKind::NotFound {
@@ -167,5 +182,17 @@ mod tests {
         let _report = verify(&target);
 
         assert!(!marker.exists());
+    }
+
+    #[test]
+    fn a_changed_target_invalidates_signature_evidence() {
+        let previous = SignatureReport::new(SignaturePlatform::MacOs, SignatureStatus::Valid);
+        let report = target_changed_report(&previous, "hash changed after verification");
+
+        assert_eq!(report.status, SignatureStatus::InspectionFailed);
+        assert_eq!(
+            report.failure.unwrap().kind,
+            SignatureFailureKind::TargetChangedDuringVerification
+        );
     }
 }

--- a/crates/dustfril-core/src/integrity/signature.rs
+++ b/crates/dustfril-core/src/integrity/signature.rs
@@ -1,0 +1,171 @@
+//! Platform-specific, read-only executable signature verification.
+
+use std::{fs, io, path::Path};
+
+use crate::models::{
+    SignatureFailure, SignatureFailureKind, SignaturePlatform, SignatureReport, SignatureStatus,
+};
+
+#[cfg(target_os = "macos")]
+mod macos {
+    include!("macos.rs");
+}
+
+/// Verifies an already resolved executable without executing it.
+pub fn verify(path: &Path) -> SignatureReport {
+    let platform = current_platform();
+
+    if let Err(failure) = validate_target(path) {
+        let mut report = SignatureReport::new(platform, SignatureStatus::InspectionFailed);
+        report.verification_message = Some("The executable could not be inspected".to_owned());
+        report.failure = Some(failure);
+        return report;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        macos::verify(path)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        unsupported_report(platform)
+    }
+}
+
+fn validate_target(path: &Path) -> Result<(), SignatureFailure> {
+    let metadata = fs::metadata(path).map_err(|error| {
+        let kind = if error.kind() == io::ErrorKind::NotFound {
+            SignatureFailureKind::TargetMissing
+        } else {
+            SignatureFailureKind::TargetUnreadable
+        };
+
+        SignatureFailure::new(kind, format!("{}: {error}", path.display()))
+    })?;
+
+    if !metadata.is_file() {
+        return Err(SignatureFailure::new(
+            SignatureFailureKind::TargetNonRegularFile,
+            format!("target is not a regular file: {}", path.display()),
+        ));
+    }
+
+    fs::File::open(path).map_err(|error| {
+        SignatureFailure::new(
+            SignatureFailureKind::TargetUnreadable,
+            format!("{}: {error}", path.display()),
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn unsupported_report(platform: SignaturePlatform) -> SignatureReport {
+    let mut report = SignatureReport::new(platform, SignatureStatus::Unsupported);
+    report.verification_message = Some(match platform {
+        SignaturePlatform::Linux => {
+            "Linux does not provide a universal executable code-signature verifier".to_owned()
+        }
+        SignaturePlatform::Windows => {
+            "Windows Authenticode verification is not implemented in this build".to_owned()
+        }
+        SignaturePlatform::Other => {
+            "No executable code-signature verifier is implemented for this platform".to_owned()
+        }
+        SignaturePlatform::MacOs => unreachable!("macOS uses its platform verifier"),
+    });
+    report.failure = Some(SignatureFailure::new(
+        SignatureFailureKind::PlatformUnsupported,
+        "no DustFril signature verifier is configured for this platform",
+    ));
+    report
+}
+
+fn current_platform() -> SignaturePlatform {
+    #[cfg(target_os = "macos")]
+    {
+        SignaturePlatform::MacOs
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        SignaturePlatform::Windows
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        SignaturePlatform::Linux
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        SignaturePlatform::Other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn missing_target_is_not_mislabeled_as_unsigned() {
+        let temp = TempDir::new().unwrap();
+        let report = verify(&temp.path().join("missing-tool"));
+
+        assert_eq!(report.status, SignatureStatus::InspectionFailed);
+        assert_eq!(
+            report.failure.unwrap().kind,
+            SignatureFailureKind::TargetMissing
+        );
+    }
+
+    #[test]
+    fn directory_target_is_not_mislabeled_as_unsigned() {
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("tool");
+        fs::create_dir(&target).unwrap();
+
+        let report = verify(&target);
+
+        assert_eq!(report.status, SignatureStatus::InspectionFailed);
+        assert_eq!(
+            report.failure.unwrap().kind,
+            SignatureFailureKind::TargetNonRegularFile
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn supported_file_on_non_macos_is_explicitly_unsupported() {
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("tool");
+        fs::write(&target, b"not an executable for a signature verifier").unwrap();
+
+        let report = verify(&target);
+
+        assert_eq!(report.status, SignatureStatus::Unsupported);
+        assert_eq!(
+            report.failure.unwrap().kind,
+            SignatureFailureKind::PlatformUnsupported
+        );
+    }
+
+    #[test]
+    fn inspecting_a_fake_executable_never_launches_it() {
+        let temp = TempDir::new().unwrap();
+        let marker = temp.path().join("launched");
+        let target = temp.path().join("fake executable");
+        let script = format!("#!/bin/sh\ntouch {}\n", marker.display());
+        fs::write(&target, script).unwrap();
+
+        let _report = verify(&target);
+
+        assert!(!marker.exists());
+    }
+}

--- a/crates/dustfril-core/src/models/integrity.rs
+++ b/crates/dustfril-core/src/models/integrity.rs
@@ -5,6 +5,8 @@ use std::{collections::BTreeMap, fmt, path::PathBuf};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use super::SignatureReport;
+
 /// Version of the on-disk executable-integrity baseline format.
 pub const INTEGRITY_STATE_VERSION: u32 = 1;
 
@@ -150,6 +152,10 @@ pub struct IntegrityCheck {
     pub observation: Option<ExecutableObservation>,
     pub previous_observation: Option<ExecutableObservation>,
     pub failure: Option<IntegrityFailure>,
+    /// Signature evidence for the current canonical target, when the target
+    /// was resolved successfully. Signature verification is deliberately not
+    /// part of the hash baseline comparison.
+    pub signature: Option<SignatureReport>,
 }
 
 /// Structured results for an executable-integrity scan.

--- a/crates/dustfril-core/src/models/mod.rs
+++ b/crates/dustfril-core/src/models/mod.rs
@@ -6,6 +6,7 @@ mod history;
 mod integrity;
 mod lockfile;
 mod scan;
+mod signature;
 
 pub use analysis::*;
 pub use audit::*;
@@ -15,3 +16,4 @@ pub use integrity::*;
 pub use lockfile::*;
 pub(crate) use scan::effective_security_ecosystems;
 pub use scan::*;
+pub use signature::*;

--- a/crates/dustfril-core/src/models/signature.rs
+++ b/crates/dustfril-core/src/models/signature.rs
@@ -67,6 +67,7 @@ pub enum SignatureFailureKind {
     TargetMissing,
     TargetUnreadable,
     TargetNonRegularFile,
+    TargetChangedDuringVerification,
 }
 
 impl fmt::Display for SignatureFailureKind {
@@ -78,6 +79,7 @@ impl fmt::Display for SignatureFailureKind {
             Self::TargetMissing => "Target missing",
             Self::TargetUnreadable => "Target unreadable",
             Self::TargetNonRegularFile => "Target is not a regular file",
+            Self::TargetChangedDuringVerification => "Target changed during verification",
         };
 
         f.write_str(label)

--- a/crates/dustfril-core/src/models/signature.rs
+++ b/crates/dustfril-core/src/models/signature.rs
@@ -1,0 +1,148 @@
+//! Platform-aware executable code-signature verification models.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// The operating-system signing mechanism used for a signature inspection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SignaturePlatform {
+    MacOs,
+    Windows,
+    Linux,
+    Other,
+}
+
+impl fmt::Display for SignaturePlatform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::MacOs => "macOS",
+            Self::Windows => "Windows",
+            Self::Linux => "Linux",
+            Self::Other => "Other",
+        };
+
+        f.write_str(label)
+    }
+}
+
+/// Platform-neutral result of checking an executable's code signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SignatureStatus {
+    /// The platform verifier accepted the signature cryptographically.
+    Valid,
+    /// The target has no signature understood by the platform verifier.
+    Unsigned,
+    /// The target has a signature, but verification rejected it.
+    Invalid,
+    /// The current platform has no supported verifier for this check.
+    Unsupported,
+    /// The target or verifier could not be inspected reliably.
+    InspectionFailed,
+}
+
+impl fmt::Display for SignatureStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::Valid => "Valid",
+            Self::Unsigned => "Unsigned",
+            Self::Invalid => "Invalid",
+            Self::Unsupported => "Unsupported",
+            Self::InspectionFailed => "Inspection failed",
+        };
+
+        f.write_str(label)
+    }
+}
+
+/// The operational reason a signature check could not be completed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SignatureFailureKind {
+    PlatformUnsupported,
+    VerifierUnavailable,
+    VerifierFailed,
+    TargetMissing,
+    TargetUnreadable,
+    TargetNonRegularFile,
+}
+
+impl fmt::Display for SignatureFailureKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::PlatformUnsupported => "Platform unsupported",
+            Self::VerifierUnavailable => "Verifier unavailable",
+            Self::VerifierFailed => "Verifier failed",
+            Self::TargetMissing => "Target missing",
+            Self::TargetUnreadable => "Target unreadable",
+            Self::TargetNonRegularFile => "Target is not a regular file",
+        };
+
+        f.write_str(label)
+    }
+}
+
+/// Details about an operational failure, separate from an unsigned or
+/// cryptographically invalid signature result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignatureFailure {
+    pub kind: SignatureFailureKind,
+    pub message: String,
+}
+
+impl SignatureFailure {
+    pub(crate) fn new(kind: SignatureFailureKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+/// Structured evidence from one platform-specific signature inspection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignatureReport {
+    pub platform: SignaturePlatform,
+    pub status: SignatureStatus,
+    /// Signer/publisher information reported by the operating system, when
+    /// available. This is evidence, not a general trust verdict.
+    pub signer: Option<String>,
+    pub team_identifier: Option<String>,
+    pub verification_message: Option<String>,
+    pub verification_code: Option<i32>,
+    pub failure: Option<SignatureFailure>,
+}
+
+impl SignatureReport {
+    pub(crate) fn new(platform: SignaturePlatform, status: SignatureStatus) -> Self {
+        Self {
+            platform,
+            status,
+            signer: None,
+            team_identifier: None,
+            verification_message: None,
+            verification_code: None,
+            failure: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_and_platform_serialize_as_stable_wire_values() {
+        let mut report = SignatureReport::new(SignaturePlatform::MacOs, SignatureStatus::Valid);
+        report.signer = Some("Example Developer".to_owned());
+
+        let value = serde_json::to_value(report).unwrap();
+
+        assert_eq!(value["platform"], "macos");
+        assert_eq!(value["status"], "valid");
+        assert_eq!(value["signer"], "Example Developer");
+    }
+}


### PR DESCRIPTION
## Summary

Implements #63 on top of the resolved executable path supplied by #62.

- Adds a platform-neutral `SignatureReport` with `Valid`, `Unsigned`, `Invalid`, `Unsupported`, and `InspectionFailed` states.
- Verifies canonical executable paths read-only; target binaries are never launched.
- Adds macOS `/usr/bin/codesign` verification through `Command` arguments, including signer/team metadata from a separate display pass.
- Re-inspects the resolved target after verification and invalidates the signature result if path, symlink relationship, size, or SHA-256 changes during the check.
- Reports Linux as explicitly `Unsupported` and leaves Windows Authenticode for follow-up #124.
- Exposes signature evidence in Core integrity checks and CLI output without turning hash/signature changes into malware claims.
- Documents the platform behavior in English and Korean README files.

## Safety

- No shell interpolation of executable paths.
- No target execution, permission mutation, or cleanup side effects.
- Missing/unreadable targets, verifier failures, and target replacement during verification remain distinct from unsigned results.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (159 Core tests, 22 CLI tests, 12 Tauri tests)
- `cargo llvm-cov --workspace --all-features --summary-only`
- `git diff --check`

Closes #63
Related: #62, #114, #124
