### PR TITLE
Add dependency exposure report

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -94,9 +94,11 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 해결된 lockfile 노드 수, 형식이 보존하는 경우의 전이 의존성 수, 여러 버전으로
 해결된 패키지를 출력합니다. `package.json`은 npm `package-lock.json`(1–3),
 `pnpm-lock.yaml`(5–9), Bun JSONC `bun.lock`(1–2)을 지원하고, Rust는
-`Cargo.toml`과 `Cargo.lock`(1–4)을 지원합니다. lockfile 누락과 Yarn, 레거시
-`bun.lockb`, Java 및 지원하지 않는 package manager는 명시적인 상태로
-출력합니다. 설치된 의존성의 디스크 크기나 취약점 점수는 계산하지 않습니다.
+`Cargo.toml`과 `Cargo.lock`(1–4)을 지원합니다. Cargo workspace 루트는 member
+매니페스트를 집계하는 별도 설계가 마련될 때까지 명시적으로 지원하지 않습니다.
+lockfile 누락과 Yarn, 레거시 `bun.lockb`, Java 및 지원하지 않는 package manager는
+명시적인 상태로 출력합니다. 설치된 의존성의 디스크 크기나 취약점 점수는 계산하지
+않습니다.
 
 `integrity scan`은 PATH에서 요청한 개발 도구를 찾고 파일 메타데이터와 바이트를
 읽어 SHA-256을 스트리밍 계산합니다. 대상 실행 파일을 절대 실행하지 않으며,

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,6 +20,7 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 - `preinstall`, `postinstall` 같은 Node 라이프사이클 스크립트 점검
 - 스캔·정리 활동 이력을 버전 형식으로 운영체제 앱 데이터 디렉터리에 저장
 - Node 및 Rust 프로젝트의 오프라인 공급망 보안 점검
+- 매니페스트와 lockfile에서 Node 및 Rust 의존성 inventory를 결정적으로 계산
 - 지원 lockfile의 존재 여부와 Git 상태 점검
 - 대상 개발 도구를 실행하지 않고 로컬 SHA-256 baseline과 실행 파일 무결성 비교
 - CLI 정리 이력을 운영체제 앱 데이터 디렉터리에 저장
@@ -59,6 +60,7 @@ cargo run -p dustfril-cli -- clean --dry-run
 cargo run -p dustfril-cli -- clean
 cargo run -p dustfril-cli -- clean --permanent
 cargo run -p dustfril-cli -- audit --node
+cargo run -p dustfril-cli -- dependencies --node
 cargo run -p dustfril-cli -- security scan --node
 cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 ```
@@ -76,6 +78,7 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 - `analyze [path] [--rust] [--node] [--java]`
 - `clean [path] [--dry-run] [--permanent] [--rust] [--node] [--java]`
 - `audit [path] [--node]`
+- `dependencies [path] [--rust] [--node] [--java]`
 - `security scan [path] [--node]`
 - `integrity scan [--tool <name>]...`
 
@@ -86,6 +89,14 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 잘못되었거나 지원되지 않으면 해당 파일 경로를 포함한 오류를 반환합니다. 탐지된
 명령이나 패키지 매니저를 실행하지 않고, 네트워크 및 프로젝트 파일 변경도 사용하지
 않습니다.
+
+`dependencies`는 매니페스트와 lockfile만 읽어 카테고리별 직접 의존성 수,
+해결된 lockfile 노드 수, 형식이 보존하는 경우의 전이 의존성 수, 여러 버전으로
+해결된 패키지를 출력합니다. `package.json`은 npm `package-lock.json`(1–3),
+`pnpm-lock.yaml`(5–9), Bun JSONC `bun.lock`(1–2)을 지원하고, Rust는
+`Cargo.toml`과 `Cargo.lock`(1–4)을 지원합니다. lockfile 누락과 Yarn, 레거시
+`bun.lockb`, Java 및 지원하지 않는 package manager는 명시적인 상태로
+출력합니다. 설치된 의존성의 디스크 크기나 취약점 점수는 계산하지 않습니다.
 
 `integrity scan`은 PATH에서 요청한 개발 도구를 찾고 파일 메타데이터와 바이트를
 읽어 SHA-256을 스트리밍 계산합니다. 대상 실행 파일을 절대 실행하지 않으며,

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Audit Node lifecycle scripts such as `preinstall` and `postinstall`
 - Persist versioned local activity history for scans, cleanup, and explicit security scans (including legacy cleanup history migration)
 - Run an offline supply-chain security scan for Node and Rust projects
+- Report deterministic Node and Rust dependency inventory from manifests and lockfiles
 - Check supported lockfile presence and Git status
 - Compare selected development-tool executables with local SHA-256 baselines without launching them
 - Persist CLI cleanup history to the OS app data directory
@@ -66,6 +67,7 @@ cargo run -p dustfril-cli -- clean --dry-run
 cargo run -p dustfril-cli -- clean
 cargo run -p dustfril-cli -- clean --permanent
 cargo run -p dustfril-cli -- audit --node
+cargo run -p dustfril-cli -- dependencies --node
 cargo run -p dustfril-cli -- security scan --node
 cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 cargo run -p dustfril-cli -- history
@@ -84,6 +86,7 @@ Available commands:
 - `analyze [path] [--rust] [--node] [--java]`
 - `clean [path] [--dry-run] [--permanent] [--rust] [--node] [--java]`
 - `audit [path] [--node]`
+- `dependencies [path] [--rust] [--node] [--java]`
 - `security scan [path] [--node]`
 - `integrity scan [--tool <name>]...`
 - `history`
@@ -95,6 +98,15 @@ package names on a built-in list of historically compromised packages, and
 missing or changed lockfiles. Parse and read failures identify the relevant
 manifest or lockfile and fail the scan. It never runs detected commands,
 invokes a package manager, contacts the network, or modifies project files.
+
+`dependencies` reports direct dependency categories, resolved lockfile nodes,
+transitive nodes where the format preserves that distinction, and packages
+resolved at multiple versions. It reads `package.json` with npm
+`package-lock.json` (versions 1–3), `pnpm-lock.yaml` (versions 5–9), or Bun
+JSONC `bun.lock` (versions 1–2), and reads `Cargo.toml` with `Cargo.lock`
+(versions 1–4). Missing lockfiles and unsupported Yarn, legacy `bun.lockb`,
+Java, or package-manager formats are explicit report states. It does not
+measure installed dependency size or claim vulnerability risk.
 
 `integrity scan` resolves the requested development tools through PATH, reads
 filesystem metadata, streams each target through SHA-256, and stores its

--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ transitive nodes where the format preserves that distinction, and packages
 resolved at multiple versions. It reads `package.json` with npm
 `package-lock.json` (versions 1–3), `pnpm-lock.yaml` (versions 5–9), or Bun
 JSONC `bun.lock` (versions 1–2), and reads `Cargo.toml` with `Cargo.lock`
-(versions 1–4). Missing lockfiles and unsupported Yarn, legacy `bun.lockb`,
-Java, or package-manager formats are explicit report states. It does not
-measure installed dependency size or claim vulnerability risk.
+(versions 1–4). Cargo workspace roots are explicitly unsupported until
+workspace member manifests have a dedicated aggregation design. Missing
+lockfiles and unsupported Yarn, legacy `bun.lockb`, Java, or package-manager
+formats are explicit report states. It does not measure installed dependency
+size or claim vulnerability risk.
 
 `integrity scan` resolves the requested development tools through PATH, reads
 filesystem metadata, streams each target through SHA-256, and stores its

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -10,6 +10,7 @@ This package exposes the `dfr` binary and wraps the shared logic from `dustfril-
 - `analyze`: report artifact size, age, and cleanup recommendation
 - `clean`: preview or execute cleanup
 - `audit`: inspect Node lifecycle scripts
+- `dependencies`: report direct, resolved, transitive, and duplicate-version dependency metrics
 - `security scan`: inspect Node and Rust manifests and lockfiles for supply-chain risks
 - `integrity scan`: inspect selected development-tool executables without launching them
 - `history`: load the unified local activity history as JSON
@@ -23,6 +24,7 @@ cargo run -p dustfril-cli -- scan
 cargo run -p dustfril-cli -- analyze
 cargo run -p dustfril-cli -- clean --dry-run
 cargo run -p dustfril-cli -- audit --node
+cargo run -p dustfril-cli -- dependencies --node
 cargo run -p dustfril-cli -- security scan --node
 cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 cargo run -p dustfril-cli -- history

--- a/apps/dustfril-cli/src/cli.rs
+++ b/apps/dustfril-cli/src/cli.rs
@@ -33,6 +33,10 @@ pub enum Commands {
     /// Audit lifecycle scripts
     Audit(PathArgs),
 
+    /// Report dependency inventory and version exposure
+    #[command(name = "dependencies", visible_alias = "dependency")]
+    Dependencies(PathArgs),
+
     /// Scan lifecycle scripts for suspicious commands
     Security(SecurityArgs),
 
@@ -194,6 +198,16 @@ mod tests {
             Commands::Security(SecurityArgs {
                 command: SecurityCommands::Scan(PathArgs { node: true, .. })
             })
+        ));
+    }
+
+    #[test]
+    fn cli_parses_dependency_report_command() {
+        let cli = Cli::try_parse_from(["dfr", "dependencies", "--rust"]).unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Commands::Dependencies(PathArgs { rust: true, .. })
         ));
     }
 

--- a/apps/dustfril-cli/src/commands/dependency.rs
+++ b/apps/dustfril-cli/src/commands/dependency.rs
@@ -1,0 +1,33 @@
+use dustfril_core::api;
+
+use crate::{
+    cli::PathArgs,
+    format,
+    shared::path::{resolve_path, validate_path},
+};
+
+/// Builds and prints the structured Core dependency inventory.
+pub fn execute(args: &PathArgs) -> bool {
+    let path = match resolve_path(&args.path) {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("Failed to resolve path: {error}");
+            return false;
+        }
+    };
+
+    if !validate_path(&path) {
+        return false;
+    }
+
+    match api::dependency_report(&path, &args.ecosystems()) {
+        Ok(reports) => {
+            format::print_dependency_reports(&reports);
+            true
+        }
+        Err(error) => {
+            eprintln!("Dependency report failed: {error}");
+            false
+        }
+    }
+}

--- a/apps/dustfril-cli/src/commands/mod.rs
+++ b/apps/dustfril-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod analyze;
 pub mod audit;
 pub mod clean;
+pub mod dependency;
 pub mod history;
 pub mod integrity;
 pub mod scan;

--- a/apps/dustfril-cli/src/format/dependency_format.rs
+++ b/apps/dustfril-cli/src/format/dependency_format.rs
@@ -1,0 +1,75 @@
+use dustfril_core::models::{DependencyMetric, DependencyReport, DuplicateDependency};
+
+/// Prints dependency reports without adding CLI-specific analysis semantics.
+pub fn print_dependency_reports(reports: &[DependencyReport]) {
+    println!("Dependency exposure report\n");
+
+    if reports.is_empty() {
+        println!("No dependency reports available.");
+        return;
+    }
+
+    for (index, report) in reports.iter().enumerate() {
+        if index > 0 {
+            println!();
+        }
+        print_dependency_report(report);
+    }
+}
+
+fn print_dependency_report(report: &DependencyReport) {
+    println!("Ecosystem:    {}", report.ecosystem);
+    println!("Status:       {}", report.status);
+    println!("Manifest:     {}", report.manifest.display());
+    if let Some(format) = &report.manifest_format {
+        println!("Manifest format: {format}");
+    }
+    if let Some(lockfile) = &report.lockfile {
+        println!(
+            "Lockfile:     {} ({})",
+            lockfile.path.display(),
+            lockfile.status
+        );
+        if let Some(format) = &lockfile.format {
+            println!("Lockfile format: {format}");
+        }
+    }
+
+    println!("Direct dependencies: {}", report.direct_dependency_total);
+    for (category, count) in &report.direct_dependency_counts {
+        println!("  {category}: {count}");
+    }
+    print_metric("Resolved dependencies", &report.resolved_dependency_count);
+    print_metric(
+        "Transitive dependencies",
+        &report.transitive_dependency_count,
+    );
+
+    if report.duplicate_versions.is_empty() {
+        println!("Duplicate versions: none");
+    } else {
+        println!("Duplicate versions:");
+        for duplicate in &report.duplicate_versions {
+            print_duplicate(duplicate);
+        }
+    }
+
+    for warning in &report.warnings {
+        println!("Note:          {warning}");
+    }
+}
+
+fn print_metric(label: &str, metric: &DependencyMetric) {
+    match metric.value {
+        Some(value) => println!("{label}: {value}"),
+        None => println!(
+            "{label}: {} ({})",
+            metric.status,
+            metric.reason.as_deref().unwrap_or("no value")
+        ),
+    }
+}
+
+fn print_duplicate(duplicate: &DuplicateDependency) {
+    println!("  {}: {}", duplicate.name, duplicate.versions.join(", "));
+}

--- a/apps/dustfril-cli/src/format/mod.rs
+++ b/apps/dustfril-cli/src/format/mod.rs
@@ -1,10 +1,12 @@
 pub mod audit_format;
+pub mod dependency_format;
 pub mod integrity_format;
 pub mod security_format;
 pub mod size_format;
 pub mod time_format;
 
 pub use audit_format::*;
+pub use dependency_format::*;
 pub use integrity_format::*;
 pub use security_format::*;
 pub use size_format::*;

--- a/apps/dustfril-cli/src/main.rs
+++ b/apps/dustfril-cli/src/main.rs
@@ -29,6 +29,8 @@ fn main() -> ExitCode {
 
         Commands::Audit(args) => commands::audit::execute(&args),
 
+        Commands::Dependencies(args) => commands::dependency::execute(&args),
+
         Commands::Security(args) => match args.command {
             cli::SecurityCommands::Scan(args) => commands::security::scan(&args),
         },

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -15,6 +15,7 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - `api::history`: record and load versioned activity history, including cleanup-history migration and security scan summaries
 - `api::security_scan`: preserve the lifecycle-only security warnings API
 - `api::security_scan_report`: run the complete offline supply-chain scan
+- `api::dependency_report`: build structured dependency exposure/inventory reports
 - `api::integrity`: resolve selected development tools without executing them, hash their bytes, and compare local baselines
 - `api::integrity::verify_signature`: inspect an already resolved executable with the supported platform verifier
 - `api::check_lockfile_integrity`: check supported lockfile presence and Git status
@@ -72,6 +73,15 @@ Lockfile checks report `Missing`, `Modified`, `Untracked`, or `Clean`. Git
 worktrees use libgit2 status information equivalent to
 `git status --porcelain -- <lockfile>`; outside Git, only file existence is
 validated, so existing files are reported as `Clean`.
+
+Dependency reports read only manifests and lockfiles. Node direct counts are
+reported separately for `dependencies`, `devDependencies`,
+`optionalDependencies`, and `peerDependencies`; Rust reports `dependencies`,
+`dev-dependencies`, and `build-dependencies`. Resolved and transitive counts
+are explicit unknown values when a lockfile is missing, and duplicate versions
+are returned in sorted order. Installed trees, registry caches, Java dependency
+formats, Yarn lockfiles, and legacy binary Bun lockfiles are outside this
+report's scope.
 
 ## Test
 

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -47,9 +47,11 @@ are evidence about the verifier result, not malware claims.
 The supply-chain report reads `package.json` and `Cargo.toml` plus supported
 lockfiles without executing scripts or contacting an external advisory service.
 It parses npm lockfile versions 1–3, pnpm YAML, Bun JSONC lockfile versions
-1–2, and Cargo.lock versions 1–4. Yarn lockfiles and legacy binary `bun.lockb`
-are intentionally opaque; no npm-missing result is inferred from either when
-it is the only Node lockfile present.
+1–2, and Cargo.lock versions 1–4. Cargo workspace roots are explicitly
+unsupported because member manifest aggregation requires a separate design.
+Yarn lockfiles and legacy binary `bun.lockb` are intentionally opaque; no
+npm-missing result is inferred from either when it is the only Node lockfile
+present.
 
 Explicit security scans can be recorded as one `ActivityKind::Security` event
 through `api::history`. The event stores finding counts, highest severity,

--- a/crates/dustfril-core/src/api/dependency.rs
+++ b/crates/dustfril-core/src/api/dependency.rs
@@ -1,0 +1,53 @@
+use std::path::Path;
+
+use crate::{
+    dependency,
+    error::DustResult,
+    models::{DependencyReport, Ecosystem},
+};
+
+/// Builds deterministic dependency inventory reports without traversing
+/// installed dependency trees or contacting package registries.
+pub fn dependency_report(
+    root: &Path,
+    ecosystems: &[Ecosystem],
+) -> DustResult<Vec<DependencyReport>> {
+    dependency::report(root, ecosystems)
+}
+
+/// Alias emphasizing the exposure/inventory meaning of the report.
+pub fn dependency_exposure_report(
+    root: &Path,
+    ecosystems: &[Ecosystem],
+) -> DustResult<Vec<DependencyReport>> {
+    dependency_report(root, ecosystems)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn api_exposes_node_dependency_report() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","dependencies":{"left-pad":"1.0.0"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("package-lock.json"),
+            r#"{"lockfileVersion":3,"packages":{"":{"name":"demo","version":"1.0.0"},"node_modules/left-pad":{"version":"1.0.0"}}}"#,
+        )
+        .unwrap();
+
+        let reports = dependency_report(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].resolved_dependency_count.value, Some(1));
+    }
+}

--- a/crates/dustfril-core/src/api/mod.rs
+++ b/crates/dustfril-core/src/api/mod.rs
@@ -1,6 +1,7 @@
 pub mod analyze;
 pub mod audit;
 pub mod clean;
+pub mod dependency;
 pub mod history;
 pub mod integrity;
 pub mod lockfile;
@@ -9,6 +10,7 @@ pub mod scan;
 pub use analyze::*;
 pub use audit::*;
 pub use clean::*;
+pub use dependency::*;
 pub use history::*;
 pub use lockfile::*;
 pub use scan::*;

--- a/crates/dustfril-core/src/dependency.rs
+++ b/crates/dustfril-core/src/dependency.rs
@@ -655,6 +655,9 @@ fn parse_package_lock_packages(
             // link, so neither record is a resolved external package node.
             continue;
         }
+        if object.get("link").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
 
         let selector_name = package_name_from_selector(key);
         let name = optional_json_string(object, "name", path)?
@@ -664,10 +667,6 @@ fn parse_package_lock_packages(
             continue;
         };
         let Some(version) = optional_json_string(object, "version", path)? else {
-            // Workspace/link entries do not represent a resolved package node.
-            if object.get("link").and_then(Value::as_bool) == Some(true) {
-                continue;
-            }
             return Err(manifest_error(
                 path,
                 format!("package-lock.json package entry {key:?} is missing version"),

--- a/crates/dustfril-core/src/dependency.rs
+++ b/crates/dustfril-core/src/dependency.rs
@@ -1,0 +1,1820 @@
+//! Deterministic dependency inventory parsing.
+//!
+//! This module only reads project manifests and lockfiles. It deliberately
+//! does not inspect installed dependency trees, Cargo registries, or network
+//! metadata, and it does not share security findings with the security scan.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde_json::Value;
+use serde_yaml::Value as YamlValue;
+
+use crate::{
+    error::{DustError, DustResult},
+    models::{
+        DependencyLockfile, DependencyLockfileStatus, DependencyMetric, DependencyReport,
+        DependencyReportStatus, DuplicateDependency, Ecosystem, LockfileKind,
+    },
+};
+
+const NODE_DEPENDENCY_CATEGORIES: &[&str] = &[
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+];
+const CARGO_DEPENDENCY_CATEGORIES: &[&str] =
+    &["dependencies", "dev-dependencies", "build-dependencies"];
+
+#[derive(Debug)]
+struct ParsedManifest {
+    path: PathBuf,
+    format: String,
+    project_names: BTreeSet<String>,
+    direct_counts: BTreeMap<String, usize>,
+    direct_names: BTreeSet<String>,
+    node_manager: Option<NodeManager>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeManager {
+    Npm,
+    Pnpm,
+    Yarn,
+    Bun,
+    Unsupported,
+}
+
+#[derive(Debug)]
+enum LockSelection {
+    Supported {
+        kind: LockfileKind,
+        path: PathBuf,
+    },
+    Missing {
+        kind: LockfileKind,
+        path: PathBuf,
+    },
+    Unsupported {
+        path: Option<PathBuf>,
+        format: Option<String>,
+        reason: String,
+    },
+}
+
+#[derive(Debug)]
+struct ResolvedDependency {
+    name: String,
+    version: String,
+    direct: bool,
+    classification_available: bool,
+}
+
+/// Produces one report for every selected ecosystem.
+pub fn report(root: &Path, selected: &[Ecosystem]) -> DustResult<Vec<DependencyReport>> {
+    validate_root(root)?;
+
+    let ecosystems = effective_ecosystems(selected);
+    ecosystems
+        .into_iter()
+        .map(|ecosystem| match ecosystem {
+            Ecosystem::Node => report_node(root),
+            Ecosystem::Rust => report_rust(root),
+            Ecosystem::Java => Ok(DependencyReport::unsupported(
+                Ecosystem::Java,
+                root.to_path_buf(),
+                "Java dependency analysis is not supported; Maven and Gradle formats require a separate design.",
+            )),
+        })
+        .collect()
+}
+
+fn effective_ecosystems(selected: &[Ecosystem]) -> Vec<Ecosystem> {
+    if selected.is_empty() {
+        return vec![Ecosystem::Node, Ecosystem::Rust];
+    }
+
+    let mut result = Vec::new();
+    for ecosystem in selected.iter().copied() {
+        if !result.contains(&ecosystem) {
+            result.push(ecosystem);
+        }
+    }
+    result
+}
+
+fn report_node(root: &Path) -> DustResult<DependencyReport> {
+    let path = root.join("package.json");
+    if !path.is_file() {
+        return Ok(DependencyReport::unsupported(
+            Ecosystem::Node,
+            path,
+            "Node dependency reporting requires a package.json manifest.",
+        ));
+    }
+
+    let manifest = parse_node_manifest(&path)?;
+    let selection = select_node_lockfile(root, manifest.node_manager);
+
+    match selection {
+        LockSelection::Supported { kind, path } => {
+            let entries = parse_lockfile(&path, kind, &manifest)?;
+            Ok(complete_report(manifest, kind, path, entries))
+        }
+        LockSelection::Missing { kind, path } => Ok(missing_lockfile_report(manifest, kind, path)),
+        LockSelection::Unsupported {
+            path,
+            format,
+            reason,
+        } => Ok(unsupported_format_report(manifest, path, format, reason)),
+    }
+}
+
+fn report_rust(root: &Path) -> DustResult<DependencyReport> {
+    let path = root.join("Cargo.toml");
+    if !path.is_file() {
+        return Ok(DependencyReport::unsupported(
+            Ecosystem::Rust,
+            path,
+            "Rust dependency reporting requires a Cargo.toml manifest.",
+        ));
+    }
+
+    let manifest = parse_cargo_manifest(&path)?;
+    let lockfile_path = root.join(LockfileKind::CargoLock.filename());
+
+    if !lockfile_path.is_file() {
+        return Ok(missing_lockfile_report(
+            manifest,
+            LockfileKind::CargoLock,
+            lockfile_path,
+        ));
+    }
+
+    let entries = parse_lockfile(&lockfile_path, LockfileKind::CargoLock, &manifest)?;
+    Ok(complete_report(
+        manifest,
+        LockfileKind::CargoLock,
+        lockfile_path,
+        entries,
+    ))
+}
+
+fn complete_report(
+    manifest: ParsedManifest,
+    kind: LockfileKind,
+    lockfile_path: PathBuf,
+    entries: Vec<ResolvedDependency>,
+) -> DependencyReport {
+    let duplicates = duplicate_versions(&entries);
+    let resolved_count = entries.len();
+    let transitive_count = entries.iter().filter(|entry| !entry.direct).count();
+    let lockfile_format = lockfile_format(kind);
+    let transitive_metric = if entries.iter().all(|entry| entry.classification_available) {
+        DependencyMetric::available(transitive_count)
+    } else {
+        DependencyMetric::unknown(
+            "This lockfile records resolved packages but does not preserve enough graph context for a trustworthy direct/transitive split.",
+        )
+    };
+
+    DependencyReport {
+        ecosystem: ecosystem_for_kind(kind),
+        status: DependencyReportStatus::Complete,
+        manifest: manifest.path,
+        manifest_format: Some(manifest.format),
+        lockfile: Some(DependencyLockfile {
+            path: lockfile_path,
+            kind: Some(kind),
+            format: Some(lockfile_format),
+            status: DependencyLockfileStatus::Parsed,
+            reason: None,
+        }),
+        direct_dependency_counts: manifest.direct_counts,
+        direct_dependency_total: manifest.direct_names.len(),
+        resolved_dependency_count: DependencyMetric::available(resolved_count),
+        transitive_dependency_count: transitive_metric,
+        duplicate_versions: duplicates,
+        warnings: Vec::new(),
+    }
+}
+
+fn missing_lockfile_report(
+    manifest: ParsedManifest,
+    kind: LockfileKind,
+    path: PathBuf,
+) -> DependencyReport {
+    let reason = format!(
+        "Expected {} is missing; resolved and transitive dependency counts are unknown.",
+        kind.filename()
+    );
+
+    DependencyReport {
+        ecosystem: ecosystem_for_kind(kind),
+        status: DependencyReportStatus::MissingLockfile,
+        manifest: manifest.path,
+        manifest_format: Some(manifest.format),
+        lockfile: Some(DependencyLockfile {
+            path,
+            kind: Some(kind),
+            format: Some(kind.filename().to_owned()),
+            status: DependencyLockfileStatus::Missing,
+            reason: Some(reason.clone()),
+        }),
+        direct_dependency_counts: manifest.direct_counts,
+        direct_dependency_total: manifest.direct_names.len(),
+        resolved_dependency_count: DependencyMetric::unknown(reason.clone()),
+        transitive_dependency_count: DependencyMetric::unknown(reason.clone()),
+        duplicate_versions: Vec::new(),
+        warnings: vec![reason],
+    }
+}
+
+fn unsupported_format_report(
+    manifest: ParsedManifest,
+    path: Option<PathBuf>,
+    format: Option<String>,
+    reason: String,
+) -> DependencyReport {
+    DependencyReport {
+        ecosystem: manifest_ecosystem(&manifest),
+        status: DependencyReportStatus::Unsupported,
+        manifest: manifest.path,
+        manifest_format: Some(manifest.format),
+        lockfile: path.map(|path| DependencyLockfile {
+            path,
+            kind: None,
+            format,
+            status: DependencyLockfileStatus::Unsupported,
+            reason: Some(reason.clone()),
+        }),
+        direct_dependency_counts: manifest.direct_counts,
+        direct_dependency_total: manifest.direct_names.len(),
+        resolved_dependency_count: DependencyMetric::unsupported(reason.clone()),
+        transitive_dependency_count: DependencyMetric::unsupported(reason.clone()),
+        duplicate_versions: Vec::new(),
+        warnings: vec![reason],
+    }
+}
+
+fn ecosystem_for_kind(kind: LockfileKind) -> Ecosystem {
+    kind.ecosystem()
+}
+
+fn manifest_ecosystem(manifest: &ParsedManifest) -> Ecosystem {
+    if manifest.format == "Cargo.toml" {
+        Ecosystem::Rust
+    } else {
+        Ecosystem::Node
+    }
+}
+
+fn lockfile_format(kind: LockfileKind) -> String {
+    // The parser stores normalized package/version records, so the format
+    // name remains useful even when a lockfile has no package entries.
+    kind.filename().to_owned()
+}
+
+fn select_node_lockfile(root: &Path, manager: Option<NodeManager>) -> LockSelection {
+    let package_lock = root.join(LockfileKind::PackageLockJson.filename());
+    let pnpm_lock = root.join(LockfileKind::PnpmLockYaml.filename());
+    let bun_lock = root.join(LockfileKind::BunLock.filename());
+    let yarn_lock = root.join("yarn.lock");
+    let bun_legacy_lock = root.join("bun.lockb");
+
+    match manager {
+        Some(NodeManager::Npm) => supported_or_missing(LockfileKind::PackageLockJson, package_lock),
+        Some(NodeManager::Pnpm) => supported_or_missing(LockfileKind::PnpmLockYaml, pnpm_lock),
+        Some(NodeManager::Bun) => {
+            if bun_lock.is_file() {
+                LockSelection::Supported {
+                    kind: LockfileKind::BunLock,
+                    path: bun_lock,
+                }
+            } else if bun_legacy_lock.is_file() {
+                unsupported_lock(
+                    Some(bun_legacy_lock),
+                    Some("bun.lockb".to_owned()),
+                    "Legacy binary bun.lockb is not supported by the dependency report.",
+                )
+            } else {
+                LockSelection::Missing {
+                    kind: LockfileKind::BunLock,
+                    path: bun_lock,
+                }
+            }
+        }
+        Some(NodeManager::Yarn) => unsupported_lock(
+            Some(yarn_lock),
+            Some("yarn.lock".to_owned()),
+            "Yarn lockfiles are not supported by the dependency report.",
+        ),
+        Some(NodeManager::Unsupported) => unsupported_lock(
+            None,
+            None,
+            "The package.json packageManager declares an unsupported package manager.",
+        ),
+        None => {
+            if package_lock.is_file() {
+                LockSelection::Supported {
+                    kind: LockfileKind::PackageLockJson,
+                    path: package_lock,
+                }
+            } else if pnpm_lock.is_file() {
+                LockSelection::Supported {
+                    kind: LockfileKind::PnpmLockYaml,
+                    path: pnpm_lock,
+                }
+            } else if bun_lock.is_file() {
+                LockSelection::Supported {
+                    kind: LockfileKind::BunLock,
+                    path: bun_lock,
+                }
+            } else if yarn_lock.is_file() {
+                unsupported_lock(
+                    Some(yarn_lock),
+                    Some("yarn.lock".to_owned()),
+                    "Yarn lockfiles are not supported by the dependency report.",
+                )
+            } else if bun_legacy_lock.is_file() {
+                unsupported_lock(
+                    Some(bun_legacy_lock),
+                    Some("bun.lockb".to_owned()),
+                    "Legacy binary bun.lockb is not supported by the dependency report.",
+                )
+            } else {
+                LockSelection::Missing {
+                    kind: LockfileKind::PackageLockJson,
+                    path: package_lock,
+                }
+            }
+        }
+    }
+}
+
+fn supported_or_missing(kind: LockfileKind, path: PathBuf) -> LockSelection {
+    if path.is_file() {
+        LockSelection::Supported { kind, path }
+    } else {
+        LockSelection::Missing { kind, path }
+    }
+}
+
+fn unsupported_lock(path: Option<PathBuf>, format: Option<String>, reason: &str) -> LockSelection {
+    LockSelection::Unsupported {
+        path,
+        format,
+        reason: reason.to_owned(),
+    }
+}
+
+fn parse_node_manifest(path: &Path) -> DustResult<ParsedManifest> {
+    let content = read_input(path)?;
+    let value: Value =
+        serde_json::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+    let object = value.as_object().ok_or_else(|| {
+        manifest_error(path, "package.json must contain a JSON object".to_owned())
+    })?;
+
+    let node_manager = object
+        .get("packageManager")
+        .map(|value| {
+            let declaration = value.as_str().ok_or_else(|| {
+                manifest_error(path, "packageManager must be a string".to_owned())
+            })?;
+            Ok::<NodeManager, DustError>(node_manager_from_declaration(declaration))
+        })
+        .transpose()?;
+
+    let mut direct_counts = BTreeMap::new();
+    let mut direct_names = BTreeSet::new();
+    for category in NODE_DEPENDENCY_CATEGORIES {
+        let Some(value) = object.get(*category) else {
+            continue;
+        };
+        let dependencies = value
+            .as_object()
+            .ok_or_else(|| manifest_error(path, format!("{category} must be a JSON object")))?;
+
+        direct_counts.insert((*category).to_owned(), dependencies.len());
+        for (name, specification) in dependencies {
+            if !specification.is_string() {
+                return Err(manifest_error(
+                    path,
+                    format!("{category} entry {name:?} must have a string specification"),
+                ));
+            }
+            direct_names.insert(name.clone());
+        }
+    }
+    for category in NODE_DEPENDENCY_CATEGORIES {
+        direct_counts.entry((*category).to_owned()).or_insert(0);
+    }
+
+    Ok(ParsedManifest {
+        path: path.to_path_buf(),
+        format: "package.json".to_owned(),
+        project_names: object
+            .get("name")
+            .and_then(Value::as_str)
+            .map(|name| [name.to_owned()].into_iter().collect())
+            .unwrap_or_default(),
+        direct_counts,
+        direct_names,
+        node_manager,
+    })
+}
+
+fn node_manager_from_declaration(value: &str) -> NodeManager {
+    let manager = value.split_once('@').map_or(value, |(manager, _)| manager);
+    match manager {
+        "npm" => NodeManager::Npm,
+        "pnpm" => NodeManager::Pnpm,
+        "yarn" => NodeManager::Yarn,
+        "bun" => NodeManager::Bun,
+        _ => NodeManager::Unsupported,
+    }
+}
+
+fn parse_cargo_manifest(path: &Path) -> DustResult<ParsedManifest> {
+    let content = read_input(path)?;
+    let value: toml::Value =
+        toml::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+    let table = value
+        .as_table()
+        .ok_or_else(|| manifest_error(path, "Cargo.toml must contain a TOML table".to_owned()))?;
+
+    let mut direct_counts = BTreeMap::new();
+    let mut direct_names = BTreeSet::new();
+    collect_cargo_dependencies(table, path, &mut direct_counts, &mut direct_names)?;
+
+    let project_names = if let Some(package) = table.get("package") {
+        let package = package
+            .as_table()
+            .ok_or_else(|| manifest_error(path, "[package] must be a TOML table".to_owned()))?;
+        let name = package
+            .get("name")
+            .ok_or_else(|| manifest_error(path, "[package] is missing required name".to_owned()))?;
+        let name = name
+            .as_str()
+            .ok_or_else(|| manifest_error(path, "[package].name must be a string".to_owned()))?;
+        [name.to_owned()].into_iter().collect()
+    } else {
+        BTreeSet::new()
+    };
+
+    Ok(ParsedManifest {
+        path: path.to_path_buf(),
+        format: "Cargo.toml".to_owned(),
+        project_names,
+        direct_counts,
+        direct_names,
+        node_manager: None,
+    })
+}
+
+fn collect_cargo_dependencies(
+    table: &toml::map::Map<String, toml::Value>,
+    path: &Path,
+    counts: &mut BTreeMap<String, usize>,
+    names: &mut BTreeSet<String>,
+) -> DustResult<()> {
+    for (key, value) in table {
+        if CARGO_DEPENDENCY_CATEGORIES.contains(&key.as_str()) {
+            let dependencies = value
+                .as_table()
+                .ok_or_else(|| manifest_error(path, format!("[{key}] must be a TOML table")))?;
+            *counts.entry(key.clone()).or_default() += dependencies.len();
+            for (name, specification) in dependencies {
+                let package_name = cargo_dependency_name(path, name, specification)?;
+                names.insert(package_name);
+            }
+            continue;
+        }
+
+        if let Some(nested) = value.as_table() {
+            collect_cargo_dependencies(nested, path, counts, names)?;
+        }
+    }
+
+    for category in CARGO_DEPENDENCY_CATEGORIES {
+        counts.entry((*category).to_owned()).or_insert(0);
+    }
+
+    Ok(())
+}
+
+fn cargo_dependency_name(
+    path: &Path,
+    name: &str,
+    specification: &toml::Value,
+) -> DustResult<String> {
+    match specification {
+        toml::Value::String(_) => Ok(name.to_owned()),
+        toml::Value::Table(table) => {
+            if let Some(package) = table.get("package") {
+                package.as_str().map(str::to_owned).ok_or_else(|| {
+                    manifest_error(
+                        path,
+                        format!("dependency {name:?} package must be a string"),
+                    )
+                })
+            } else {
+                Ok(name.to_owned())
+            }
+        }
+        _ => Err(manifest_error(
+            path,
+            format!("dependency {name:?} must be a string or table"),
+        )),
+    }
+}
+
+fn parse_lockfile(
+    path: &Path,
+    kind: LockfileKind,
+    manifest: &ParsedManifest,
+) -> DustResult<Vec<ResolvedDependency>> {
+    match kind {
+        LockfileKind::PackageLockJson => parse_package_lock(path, manifest),
+        LockfileKind::PnpmLockYaml => parse_pnpm_lock(path, manifest),
+        LockfileKind::BunLock => parse_bun_lock(path, manifest),
+        LockfileKind::CargoLock => parse_cargo_lock(path, manifest),
+    }
+}
+
+fn parse_package_lock(
+    path: &Path,
+    manifest: &ParsedManifest,
+) -> DustResult<Vec<ResolvedDependency>> {
+    let content = read_input(path)?;
+    let lockfile: Value =
+        serde_json::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+    let object = lockfile.as_object().ok_or_else(|| {
+        manifest_error(
+            path,
+            "package-lock.json must contain a JSON object".to_owned(),
+        )
+    })?;
+    let version = object
+        .get("lockfileVersion")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| {
+            manifest_error(
+                path,
+                "package-lock.json must declare a numeric lockfileVersion".to_owned(),
+            )
+        })?;
+    if !(1..=3).contains(&version) {
+        return Err(manifest_error(
+            path,
+            format!("unsupported package-lock.json lockfileVersion {version}"),
+        ));
+    }
+
+    if version >= 2 {
+        let packages = object.get("packages").ok_or_else(|| {
+            manifest_error(
+                path,
+                format!("package-lock.json lockfileVersion {version} is missing packages"),
+            )
+        })?;
+        let packages = packages.as_object().ok_or_else(|| {
+            manifest_error(
+                path,
+                "package-lock.json packages must be an object".to_owned(),
+            )
+        })?;
+        parse_package_lock_packages(path, packages, manifest)
+    } else {
+        let dependencies = object.get("dependencies").ok_or_else(|| {
+            manifest_error(
+                path,
+                "package-lock.json lockfileVersion 1 is missing dependencies".to_owned(),
+            )
+        })?;
+        let dependencies = dependencies.as_object().ok_or_else(|| {
+            manifest_error(
+                path,
+                "package-lock.json dependencies must be an object".to_owned(),
+            )
+        })?;
+        let mut entries = Vec::new();
+        parse_npm_dependency_tree(path, dependencies, 0, &mut entries)?;
+        Ok(entries)
+    }
+}
+
+fn parse_package_lock_packages(
+    path: &Path,
+    packages: &serde_json::Map<String, Value>,
+    manifest: &ParsedManifest,
+) -> DustResult<Vec<ResolvedDependency>> {
+    let mut entries = Vec::new();
+    for (key, value) in packages {
+        let object = value.as_object().ok_or_else(|| {
+            manifest_error(
+                path,
+                format!("package-lock.json package entry {key:?} must be an object"),
+            )
+        })?;
+        if key.is_empty() {
+            continue;
+        }
+
+        let selector_name = package_name_from_selector(key);
+        let name = optional_json_string(object, "name", path)?
+            .map(str::to_owned)
+            .or_else(|| selector_name.as_ref().map(|name| (*name).to_owned()));
+        let Some(name) = name else {
+            continue;
+        };
+        let Some(version) = optional_json_string(object, "version", path)? else {
+            // Workspace/link entries do not represent a resolved package node.
+            if object.get("link").and_then(Value::as_bool) == Some(true) {
+                continue;
+            }
+            return Err(manifest_error(
+                path,
+                format!("package-lock.json package entry {key:?} is missing version"),
+            ));
+        };
+        let direct = package_lock_path_is_direct(key)
+            && (manifest.direct_names.contains(&name)
+                || selector_name.is_some_and(|selector| manifest.direct_names.contains(selector)));
+        entries.push(ResolvedDependency {
+            name,
+            version: version.to_owned(),
+            direct,
+            classification_available: true,
+        });
+    }
+
+    Ok(entries)
+}
+
+fn parse_npm_dependency_tree(
+    path: &Path,
+    dependencies: &serde_json::Map<String, Value>,
+    depth: usize,
+    entries: &mut Vec<ResolvedDependency>,
+) -> DustResult<()> {
+    for (name, value) in dependencies {
+        let object = value.as_object().ok_or_else(|| {
+            manifest_error(
+                path,
+                format!("package-lock.json dependency entry {name:?} must be an object"),
+            )
+        })?;
+        let version = required_json_string(object, "version", path)?;
+        entries.push(ResolvedDependency {
+            name: name.clone(),
+            version: version.to_owned(),
+            direct: depth == 0,
+            classification_available: true,
+        });
+
+        if let Some(nested) = object.get("dependencies") {
+            let nested = nested.as_object().ok_or_else(|| {
+                manifest_error(
+                    path,
+                    format!("package-lock.json nested dependencies for {name:?} must be an object"),
+                )
+            })?;
+            parse_npm_dependency_tree(path, nested, depth + 1, entries)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn package_lock_path_is_direct(path: &str) -> bool {
+    path.starts_with("node_modules/") && path.matches("node_modules/").count() == 1
+}
+
+fn parse_pnpm_lock(path: &Path, manifest: &ParsedManifest) -> DustResult<Vec<ResolvedDependency>> {
+    let content = read_input(path)?;
+    let lockfile: YamlValue =
+        serde_yaml::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+    let object = lockfile.as_mapping().ok_or_else(|| {
+        manifest_error(
+            path,
+            "pnpm-lock.yaml must contain a YAML mapping".to_owned(),
+        )
+    })?;
+    let version = yaml_scalar_field(object, "lockfileVersion", path)?.ok_or_else(|| {
+        manifest_error(
+            path,
+            "pnpm-lock.yaml must declare lockfileVersion".to_owned(),
+        )
+    })?;
+    let major = version
+        .split('.')
+        .next()
+        .and_then(|major| major.parse::<u64>().ok())
+        .ok_or_else(|| {
+            manifest_error(
+                path,
+                format!("unsupported pnpm lockfileVersion {version:?}"),
+            )
+        })?;
+    if !(5..=9).contains(&major) {
+        return Err(manifest_error(
+            path,
+            format!("unsupported pnpm lockfileVersion {version:?}"),
+        ));
+    }
+
+    let snapshots_present = yaml_value_field(object, "snapshots").is_some();
+    let packages = parse_pnpm_section(object, "packages", path, manifest, !snapshots_present)?;
+    let snapshots = parse_pnpm_section(object, "snapshots", path, manifest, snapshots_present)?;
+
+    if snapshots_present {
+        Ok(snapshots)
+    } else {
+        Ok(packages)
+    }
+}
+
+fn parse_pnpm_section(
+    object: &serde_yaml::Mapping,
+    section: &str,
+    path: &Path,
+    manifest: &ParsedManifest,
+    collect: bool,
+) -> DustResult<Vec<ResolvedDependency>> {
+    let Some(value) = yaml_value_field(object, section) else {
+        return Ok(Vec::new());
+    };
+    let entries = value.as_mapping().ok_or_else(|| {
+        manifest_error(path, format!("pnpm-lock.yaml {section} must be a mapping"))
+    })?;
+    let mut resolved = Vec::new();
+
+    for (selector, package) in entries {
+        let selector = selector.as_str().ok_or_else(|| {
+            manifest_error(
+                path,
+                format!("pnpm-lock.yaml {section} keys must be strings"),
+            )
+        })?;
+        let package = package.as_mapping().ok_or_else(|| {
+            manifest_error(
+                path,
+                format!("pnpm-lock.yaml entry {selector:?} must be a mapping"),
+            )
+        })?;
+        validate_pnpm_resolution(package, selector, path)?;
+        let parsed_selector = package_selector(selector);
+        if parsed_selector.is_none() {
+            return Err(manifest_error(
+                path,
+                format!("pnpm-lock.yaml {section} entry {selector:?} is not a package selector"),
+            ));
+        }
+
+        if !collect {
+            continue;
+        }
+        let (name, version) = parsed_selector.expect("selector was validated above");
+        resolved.push(ResolvedDependency {
+            direct: manifest.direct_names.contains(&name),
+            name,
+            version,
+            classification_available: false,
+        });
+    }
+
+    Ok(resolved)
+}
+
+fn validate_pnpm_resolution(
+    package: &serde_yaml::Mapping,
+    selector: &str,
+    path: &Path,
+) -> DustResult<()> {
+    let Some(resolution) = yaml_value_field(package, "resolution") else {
+        return Ok(());
+    };
+    let resolution = resolution.as_mapping().ok_or_else(|| {
+        manifest_error(
+            path,
+            format!("pnpm-lock.yaml resolution for {selector:?} must be a mapping"),
+        )
+    })?;
+    for key in ["tarball", "repo", "url"] {
+        if let Some(value) = yaml_value_field(resolution, key)
+            && value.as_str().is_none()
+        {
+            return Err(manifest_error(
+                path,
+                format!("pnpm-lock.yaml resolution {key} for {selector:?} must be a string"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn parse_bun_lock(path: &Path, manifest: &ParsedManifest) -> DustResult<Vec<ResolvedDependency>> {
+    let content = read_input(path)?;
+    let lockfile = parse_jsonc(&content).map_err(|error| manifest_error(path, error))?;
+    let object = lockfile
+        .as_object()
+        .ok_or_else(|| manifest_error(path, "bun.lock must contain a JSON object".to_owned()))?;
+    let version = object
+        .get("lockfileVersion")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| {
+            manifest_error(
+                path,
+                "bun.lock must declare a numeric lockfileVersion".to_owned(),
+            )
+        })?;
+    if !(1..=2).contains(&version) {
+        return Err(manifest_error(
+            path,
+            format!("unsupported bun.lock lockfileVersion {version}"),
+        ));
+    }
+
+    let mut entries = Vec::new();
+    if let Some(packages) = object.get("packages") {
+        let packages = packages.as_object().ok_or_else(|| {
+            manifest_error(path, "bun.lock packages must be an object".to_owned())
+        })?;
+        for (selector, package) in packages {
+            match package {
+                Value::Array(values) => {
+                    let (name, version) = values
+                        .first()
+                        .and_then(Value::as_str)
+                        .and_then(package_selector)
+                        .or_else(|| package_selector(selector))
+                        .ok_or_else(|| {
+                            manifest_error(
+                                path,
+                                format!("bun.lock package entry {selector:?} is missing a version"),
+                            )
+                        })?;
+                    entries.push(ResolvedDependency {
+                        direct: manifest.direct_names.contains(&name),
+                        name,
+                        version,
+                        classification_available: false,
+                    });
+                }
+                Value::Object(_) => {
+                    let fallback_name = package_name_from_selector(selector).ok_or_else(|| {
+                        manifest_error(
+                            path,
+                            format!("bun.lock package key {selector:?} is not a package selector"),
+                        )
+                    })?;
+                    parse_bun_package_value(path, fallback_name, package, manifest, &mut entries)?
+                }
+                _ => {
+                    return Err(manifest_error(
+                        path,
+                        format!("bun.lock package entry {selector:?} must be an array or object"),
+                    ));
+                }
+            }
+        }
+    }
+
+    if entries.is_empty()
+        && let Some(workspaces) = object.get("workspaces")
+    {
+        parse_bun_workspaces(path, workspaces, manifest, &mut entries)?;
+    }
+
+    Ok(entries)
+}
+
+fn parse_bun_workspaces(
+    path: &Path,
+    workspaces: &Value,
+    manifest: &ParsedManifest,
+    entries: &mut Vec<ResolvedDependency>,
+) -> DustResult<()> {
+    let workspaces = workspaces
+        .as_object()
+        .ok_or_else(|| manifest_error(path, "bun.lock workspaces must be an object".to_owned()))?;
+    for (workspace_name, value) in workspaces {
+        let workspace = value.as_object().ok_or_else(|| {
+            manifest_error(
+                path,
+                format!("bun.lock workspace {workspace_name:?} must be an object"),
+            )
+        })?;
+        for category in NODE_DEPENDENCY_CATEGORIES {
+            let Some(dependencies) = workspace.get(*category) else {
+                continue;
+            };
+            let dependencies = dependencies.as_object().ok_or_else(|| {
+                manifest_error(
+                    path,
+                    format!("bun.lock workspace {workspace_name:?} {category} must be an object"),
+                )
+            })?;
+            for (name, dependency) in dependencies {
+                parse_bun_workspace_dependency(path, name, dependency, manifest, entries, true)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_bun_workspace_dependency(
+    path: &Path,
+    fallback_name: &str,
+    dependency: &Value,
+    manifest: &ParsedManifest,
+    entries: &mut Vec<ResolvedDependency>,
+    direct: bool,
+) -> DustResult<()> {
+    match dependency {
+        Value::Array(values) => {
+            let (name, version) = values
+                .first()
+                .and_then(Value::as_str)
+                .and_then(package_selector)
+                .ok_or_else(|| {
+                    manifest_error(
+                        path,
+                        format!("bun.lock dependency {fallback_name:?} is missing a version"),
+                    )
+                })?;
+            entries.push(ResolvedDependency {
+                direct,
+                name,
+                version,
+                classification_available: false,
+            });
+            for value in values.iter().skip(1) {
+                if let Value::Object(object) = value {
+                    parse_bun_nested_dependencies(path, object, manifest, entries)?;
+                }
+            }
+            Ok(())
+        }
+        Value::Object(object) => {
+            let name = object
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or(fallback_name);
+            let version = object
+                .get("version")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    manifest_error(
+                        path,
+                        format!("bun.lock dependency {name:?} is missing a version"),
+                    )
+                })?;
+            entries.push(ResolvedDependency {
+                direct,
+                name: name.to_owned(),
+                version: version.to_owned(),
+                classification_available: false,
+            });
+            parse_bun_nested_dependencies(path, object, manifest, entries)
+        }
+        _ => Err(manifest_error(
+            path,
+            format!("bun.lock dependency {fallback_name:?} must be an array or object"),
+        )),
+    }
+}
+
+fn parse_bun_nested_dependencies(
+    path: &Path,
+    object: &serde_json::Map<String, Value>,
+    manifest: &ParsedManifest,
+    entries: &mut Vec<ResolvedDependency>,
+) -> DustResult<()> {
+    for category in NODE_DEPENDENCY_CATEGORIES {
+        let Some(dependencies) = object.get(*category) else {
+            continue;
+        };
+        let dependencies = dependencies.as_object().ok_or_else(|| {
+            manifest_error(path, format!("bun.lock {category} must be an object"))
+        })?;
+        for (name, dependency) in dependencies {
+            parse_bun_workspace_dependency(path, name, dependency, manifest, entries, false)?;
+        }
+    }
+    Ok(())
+}
+
+fn parse_bun_package_value(
+    path: &Path,
+    fallback_name: &str,
+    package: &Value,
+    manifest: &ParsedManifest,
+    entries: &mut Vec<ResolvedDependency>,
+) -> DustResult<()> {
+    let object = package.as_object().ok_or_else(|| {
+        manifest_error(path, "bun.lock package value must be an object".to_owned())
+    })?;
+    let name = object
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or(fallback_name);
+    let Some(version) = object.get("version").and_then(Value::as_str) else {
+        return Err(manifest_error(
+            path,
+            format!("bun.lock package {name:?} is missing a version"),
+        ));
+    };
+    entries.push(ResolvedDependency {
+        direct: manifest.direct_names.contains(name),
+        name: name.to_owned(),
+        version: version.to_owned(),
+        classification_available: false,
+    });
+    Ok(())
+}
+
+fn parse_cargo_lock(path: &Path, manifest: &ParsedManifest) -> DustResult<Vec<ResolvedDependency>> {
+    let content = read_input(path)?;
+    let lockfile: toml::Value =
+        toml::from_str(&content).map_err(|error| manifest_error(path, error.to_string()))?;
+    let table = lockfile
+        .as_table()
+        .ok_or_else(|| manifest_error(path, "Cargo.lock must contain a TOML table".to_owned()))?;
+    let version = match table.get("version") {
+        Some(value) => value.as_integer().ok_or_else(|| {
+            manifest_error(path, "Cargo.lock version must be an integer".to_owned())
+        })?,
+        None => 1,
+    };
+    if !(1..=4).contains(&version) {
+        return Err(manifest_error(
+            path,
+            format!("unsupported Cargo.lock version {version}"),
+        ));
+    }
+
+    let Some(packages) = table.get("package") else {
+        return Ok(Vec::new());
+    };
+    let packages = packages
+        .as_array()
+        .ok_or_else(|| manifest_error(path, "Cargo.lock package must be an array".to_owned()))?;
+    let mut root_dependency_refs = BTreeMap::<String, BTreeSet<Option<String>>>::new();
+
+    for package in packages {
+        let package = package.as_table().ok_or_else(|| {
+            manifest_error(path, "Cargo.lock package entries must be tables".to_owned())
+        })?;
+        let name = package
+            .get("name")
+            .and_then(toml::Value::as_str)
+            .ok_or_else(|| manifest_error(path, "Cargo.lock package is missing name".to_owned()))?;
+        if !manifest.project_names.contains(name) {
+            continue;
+        }
+        let Some(dependencies) = package.get("dependencies") else {
+            continue;
+        };
+        let dependencies = dependencies.as_array().ok_or_else(|| {
+            manifest_error(
+                path,
+                format!("Cargo.lock dependencies for {name:?} must be an array"),
+            )
+        })?;
+        for dependency in dependencies {
+            let dependency = dependency.as_str().ok_or_else(|| {
+                manifest_error(
+                    path,
+                    format!("Cargo.lock dependencies for {name:?} must contain strings"),
+                )
+            })?;
+            let mut parts = dependency.split_whitespace();
+            let dependency_name = parts.next().unwrap_or_default();
+            let dependency_version = parts
+                .next()
+                .filter(|version| version.chars().next().is_some_and(|c| c.is_ascii_digit()))
+                .map(str::to_owned);
+            if !dependency_name.is_empty() {
+                root_dependency_refs
+                    .entry(dependency_name.to_owned())
+                    .or_default()
+                    .insert(dependency_version);
+            }
+        }
+    }
+
+    let mut entries = Vec::new();
+
+    for package in packages {
+        let package = package.as_table().ok_or_else(|| {
+            manifest_error(path, "Cargo.lock package entries must be tables".to_owned())
+        })?;
+        let name = package
+            .get("name")
+            .and_then(toml::Value::as_str)
+            .ok_or_else(|| manifest_error(path, "Cargo.lock package is missing name".to_owned()))?;
+        let version = package
+            .get("version")
+            .and_then(toml::Value::as_str)
+            .ok_or_else(|| {
+                manifest_error(
+                    path,
+                    format!("Cargo.lock package {name:?} is missing version"),
+                )
+            })?;
+        if manifest.project_names.contains(name) {
+            continue;
+        }
+        if let Some(source) = package.get("source")
+            && !source.is_str()
+        {
+            return Err(manifest_error(
+                path,
+                format!("Cargo.lock source for {name:?} must be a string"),
+            ));
+        }
+        if let Some(dependencies) = package.get("dependencies") {
+            let dependencies = dependencies.as_array().ok_or_else(|| {
+                manifest_error(
+                    path,
+                    format!("Cargo.lock dependencies for {name:?} must be an array"),
+                )
+            })?;
+            if dependencies.iter().any(|dependency| !dependency.is_str()) {
+                return Err(manifest_error(
+                    path,
+                    format!("Cargo.lock dependencies for {name:?} must contain strings"),
+                ));
+            }
+        }
+        let direct = match root_dependency_refs.get(name) {
+            Some(references) => {
+                references.contains(&Some(version.to_owned())) || references.contains(&None)
+            }
+            None => manifest.direct_names.contains(name),
+        };
+        entries.push(ResolvedDependency {
+            direct,
+            name: name.to_owned(),
+            version: version.to_owned(),
+            classification_available: true,
+        });
+    }
+
+    let mut package_counts = BTreeMap::<String, usize>::new();
+    for entry in &entries {
+        *package_counts.entry(entry.name.clone()).or_default() += 1;
+    }
+    for entry in &mut entries {
+        let ambiguous_unversioned_reference =
+            root_dependency_refs
+                .get(&entry.name)
+                .is_some_and(|references| {
+                    references.contains(&None) && package_counts.get(&entry.name) > Some(&1)
+                });
+        entry.classification_available = !ambiguous_unversioned_reference
+            && (!entry.direct
+                || root_dependency_refs.contains_key(&entry.name)
+                || package_counts.get(&entry.name) == Some(&1));
+    }
+
+    Ok(entries)
+}
+
+fn duplicate_versions(entries: &[ResolvedDependency]) -> Vec<DuplicateDependency> {
+    let mut versions = BTreeMap::<String, BTreeSet<String>>::new();
+    for entry in entries {
+        versions
+            .entry(entry.name.clone())
+            .or_default()
+            .insert(entry.version.clone());
+    }
+
+    versions
+        .into_iter()
+        .filter_map(|(name, versions)| {
+            (versions.len() > 1).then(|| DuplicateDependency {
+                name,
+                versions: versions.into_iter().collect(),
+            })
+        })
+        .collect()
+}
+
+fn package_selector(selector: &str) -> Option<(String, String)> {
+    let selector = selector
+        .rsplit("/node_modules/")
+        .next()
+        .unwrap_or(selector)
+        .trim()
+        .trim_start_matches("node_modules/")
+        .trim_matches(['\'', '"'])
+        .trim_start_matches('/')
+        .split('(')
+        .next()
+        .unwrap_or_default();
+    if selector.is_empty() {
+        return None;
+    }
+
+    if selector.starts_with('@') {
+        let slash = selector.find('/')?;
+        let after_scope = &selector[slash + 1..];
+        if let Some(at) = after_scope.find('@') {
+            let name_end = slash + 1 + at;
+            let name = &selector[..name_end];
+            let version = &selector[name_end + 1..];
+            return (!version.is_empty()).then(|| (name.to_owned(), version.to_owned()));
+        }
+        if let Some(slash_after_name) = after_scope.find('/') {
+            let name_end = slash + 1 + slash_after_name;
+            let name = &selector[..name_end];
+            let version = &selector[name_end + 1..];
+            return (!version.is_empty()).then(|| (name.to_owned(), version.to_owned()));
+        }
+        return None;
+    }
+
+    if let Some(at) = selector.find('@') {
+        let name = &selector[..at];
+        let version = &selector[at + 1..];
+        return (!name.is_empty() && !version.is_empty())
+            .then(|| (name.to_owned(), version.to_owned()));
+    }
+    if let Some(slash) = selector.rfind('/') {
+        let name = &selector[..slash];
+        let version = &selector[slash + 1..];
+        return (!name.is_empty() && !version.is_empty())
+            .then(|| (name.to_owned(), version.to_owned()));
+    }
+
+    None
+}
+
+fn package_name_from_selector(selector: &str) -> Option<&str> {
+    let selector = selector
+        .rsplit("/node_modules/")
+        .next()
+        .unwrap_or(selector)
+        .trim()
+        .trim_start_matches("node_modules/")
+        .trim_matches(['\'', '"'])
+        .trim_start_matches('/')
+        .split('(')
+        .next()
+        .unwrap_or_default();
+    if selector.is_empty() || selector.contains("://") {
+        return None;
+    }
+
+    if selector.starts_with('@') {
+        let slash = selector.find('/')?;
+        let after_scope = &selector[slash + 1..];
+        if let Some(at) = after_scope.find('@') {
+            return Some(&selector[..slash + 1 + at]);
+        }
+        if let Some(version_slash) = after_scope.find('/') {
+            return Some(&selector[..slash + 1 + version_slash]);
+        }
+        return Some(selector);
+    }
+
+    if let Some(at) = selector.find('@') {
+        return Some(&selector[..at]);
+    }
+    if let Some(slash) = selector.rfind('/') {
+        return Some(&selector[..slash]);
+    }
+    Some(selector)
+}
+
+fn parse_jsonc(content: &str) -> Result<Value, String> {
+    let without_comments = strip_jsonc_comments(content)?;
+    let normalized = remove_jsonc_trailing_commas(&without_comments);
+    serde_json::from_str(&normalized).map_err(|error| error.to_string())
+}
+
+fn strip_jsonc_comments(content: &str) -> Result<String, String> {
+    let characters: Vec<char> = content.chars().collect();
+    let mut result = String::with_capacity(content.len());
+    let mut index = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while index < characters.len() {
+        let character = characters[index];
+        if in_string {
+            result.push(character);
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+        if character == '"' {
+            in_string = true;
+            result.push(character);
+            index += 1;
+            continue;
+        }
+        if character == '/' && characters.get(index + 1) == Some(&'/') {
+            index += 2;
+            while index < characters.len() && characters[index] != '\n' {
+                index += 1;
+            }
+            continue;
+        }
+        if character == '/' && characters.get(index + 1) == Some(&'*') {
+            index += 2;
+            let mut closed = false;
+            while index < characters.len() {
+                if characters[index] == '*' && characters.get(index + 1) == Some(&'/') {
+                    index += 2;
+                    closed = true;
+                    break;
+                }
+                if characters[index] == '\n' {
+                    result.push('\n');
+                }
+                index += 1;
+            }
+            if !closed {
+                return Err("unterminated JSONC block comment".to_owned());
+            }
+            continue;
+        }
+        result.push(character);
+        index += 1;
+    }
+
+    Ok(result)
+}
+
+fn remove_jsonc_trailing_commas(content: &str) -> String {
+    let characters: Vec<char> = content.chars().collect();
+    let mut result = String::with_capacity(content.len());
+    let mut index = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while index < characters.len() {
+        let character = characters[index];
+        if in_string {
+            result.push(character);
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+        if character == '"' {
+            in_string = true;
+            result.push(character);
+            index += 1;
+            continue;
+        }
+        if character == ',' {
+            let mut next = index + 1;
+            while characters
+                .get(next)
+                .is_some_and(|value| value.is_whitespace())
+            {
+                next += 1;
+            }
+            if matches!(characters.get(next), Some(']' | '}')) {
+                index += 1;
+                continue;
+            }
+        }
+        result.push(character);
+        index += 1;
+    }
+
+    result
+}
+
+fn read_input(path: &Path) -> DustResult<String> {
+    fs::read_to_string(path).map_err(|error| manifest_error(path, error.to_string()))
+}
+
+fn validate_root(root: &Path) -> DustResult<()> {
+    match fs::symlink_metadata(root) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            Err(DustError::InvalidPath(root.to_path_buf()))
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Err(DustError::InvalidPath(root.to_path_buf()))
+        }
+        Err(error) => Err(DustError::Io(error)),
+    }
+}
+
+fn manifest_error(path: &Path, message: String) -> DustError {
+    DustError::Manifest(format!("{}: {message}", path.display()))
+}
+
+fn optional_json_string<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    key: &str,
+    path: &Path,
+) -> DustResult<Option<&'a str>> {
+    let Some(value) = object.get(key) else {
+        return Ok(None);
+    };
+    value
+        .as_str()
+        .map(Some)
+        .ok_or_else(|| manifest_error(path, format!("{key} field in JSON object must be a string")))
+}
+
+fn required_json_string<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    key: &str,
+    path: &Path,
+) -> DustResult<&'a str> {
+    optional_json_string(object, key, path)?
+        .ok_or_else(|| manifest_error(path, format!("JSON object is missing required {key} field")))
+}
+
+fn yaml_value_field<'a>(object: &'a serde_yaml::Mapping, key: &str) -> Option<&'a YamlValue> {
+    object.get(YamlValue::String(key.to_owned()))
+}
+
+fn yaml_scalar_field(
+    object: &serde_yaml::Mapping,
+    key: &str,
+    path: &Path,
+) -> DustResult<Option<String>> {
+    let Some(value) = yaml_value_field(object, key) else {
+        return Ok(None);
+    };
+    match value {
+        YamlValue::String(value) => Ok(Some(value.clone())),
+        YamlValue::Number(value) => Ok(Some(value.to_string())),
+        _ => Err(manifest_error(
+            path,
+            format!("{key} field in YAML must be a scalar string or number"),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn write_node_project(root: &Path, manifest: &str, lockfile: &str) {
+        fs::write(root.join("package.json"), manifest).unwrap();
+        fs::write(root.join("package-lock.json"), lockfile).unwrap();
+    }
+
+    #[test]
+    fn node_counts_categories_and_unique_direct_names() {
+        let temp_dir = TempDir::new().unwrap();
+        write_node_project(
+            temp_dir.path(),
+            r#"{
+                "name":"demo",
+                "dependencies":{"runtime":"1.0.0","shared":"1.0.0"},
+                "devDependencies":{"tools":"1.0.0","shared":"2.0.0"},
+                "optionalDependencies":{"optional":"1.0.0"},
+                "peerDependencies":{"peer":"^1.0.0"}
+            }"#,
+            r#"{
+                "lockfileVersion":3,
+                "packages":{
+                    "":{"name":"demo","version":"1.0.0"},
+                    "node_modules/runtime":{"version":"1.0.0"},
+                    "node_modules/shared":{"version":"1.0.0"},
+                    "node_modules/tools":{"version":"1.0.0"},
+                    "node_modules/optional":{"version":"1.0.0"},
+                    "node_modules/peer":{"version":"1.0.0"},
+                    "node_modules/tools/node_modules/shared":{"version":"2.0.0"}
+                }
+            }"#,
+        );
+
+        let report = report(temp_dir.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(report.status, DependencyReportStatus::Complete);
+        assert_eq!(report.direct_dependency_counts["dependencies"], 2);
+        assert_eq!(report.direct_dependency_counts["devDependencies"], 2);
+        assert_eq!(report.direct_dependency_counts["optionalDependencies"], 1);
+        assert_eq!(report.direct_dependency_counts["peerDependencies"], 1);
+        assert_eq!(report.direct_dependency_total, 5);
+        assert_eq!(report.resolved_dependency_count.value, Some(6));
+        assert_eq!(report.transitive_dependency_count.value, Some(1));
+        assert_eq!(report.duplicate_versions[0].name, "shared");
+        assert_eq!(report.duplicate_versions[0].versions, ["1.0.0", "2.0.0"]);
+    }
+
+    #[test]
+    fn package_lock_v1_uses_tree_depth_for_transitive_count() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","dependencies":{"root":"1.0.0"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("package-lock.json"),
+            r#"{"lockfileVersion":1,"dependencies":{"root":{"version":"1.0.0","dependencies":{"nested":{"version":"2.0.0"}}}}}"#,
+        )
+        .unwrap();
+
+        let report = report(temp_dir.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(report.resolved_dependency_count.value, Some(2));
+        assert_eq!(report.transitive_dependency_count.value, Some(1));
+    }
+
+    #[test]
+    fn lockfile_order_does_not_change_logical_metrics() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","dependencies":{"alpha":"1.0.0","beta":"1.0.0"}}"#,
+        )
+        .unwrap();
+        let lockfile = temp_dir.path().join("package-lock.json");
+        fs::write(
+            &lockfile,
+            r#"{"lockfileVersion":3,"packages":{"node_modules/alpha":{"version":"1.0.0"},"":{"name":"demo","version":"1.0.0"},"node_modules/beta":{"version":"1.0.0"}}}"#,
+        )
+        .unwrap();
+        let first = report(temp_dir.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+
+        fs::write(
+            &lockfile,
+            r#"{"packages":{"node_modules/beta":{"version":"1.0.0"},"node_modules/alpha":{"version":"1.0.0"},"":{"version":"1.0.0","name":"demo"}},"lockfileVersion":3}"#,
+        )
+        .unwrap();
+        let second = report(temp_dir.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(
+            first.direct_dependency_counts,
+            second.direct_dependency_counts
+        );
+        assert_eq!(
+            first.resolved_dependency_count,
+            second.resolved_dependency_count
+        );
+        assert_eq!(
+            first.transitive_dependency_count,
+            second.transitive_dependency_count
+        );
+        assert_eq!(first.duplicate_versions, second.duplicate_versions);
+    }
+
+    #[test]
+    fn pnpm_and_bun_lockfiles_are_supported_without_tree_traversal() {
+        let pnpm_dir = TempDir::new().unwrap();
+        fs::write(
+            pnpm_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"pnpm@9.0.0","dependencies":{"foo":"1.0.0"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            pnpm_dir.path().join("pnpm-lock.yaml"),
+            "lockfileVersion: '9.0'\npackages:\n  foo@1.0.0:\n    resolution: {integrity: sha512-test}\n  foo@2.0.0:\n    resolution: {integrity: sha512-test}\n",
+        )
+        .unwrap();
+
+        let pnpm_report = report(pnpm_dir.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+        assert_eq!(pnpm_report.resolved_dependency_count.value, Some(2));
+        assert_eq!(
+            pnpm_report.transitive_dependency_count.status,
+            crate::models::DependencyMetricStatus::Unknown
+        );
+        assert_eq!(
+            pnpm_report.duplicate_versions[0].versions,
+            ["1.0.0", "2.0.0"]
+        );
+
+        let bun_dir = TempDir::new().unwrap();
+        fs::write(
+            bun_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"bun@1.0.0","dependencies":{"foo":"1.0.0"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            bun_dir.path().join("bun.lock"),
+            r#"{"lockfileVersion":1,"packages":{"foo":["foo@1.0.0","https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",{},"sha512-test"]}}"#,
+        )
+        .unwrap();
+
+        let bun_report = report(bun_dir.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+        assert_eq!(bun_report.resolved_dependency_count.value, Some(1));
+        assert_eq!(
+            bun_report.transitive_dependency_count.status,
+            crate::models::DependencyMetricStatus::Unknown
+        );
+
+        let workspace_dir = TempDir::new().unwrap();
+        fs::write(
+            workspace_dir.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"bun@1.0.0","dependencies":{"foo":"1.0.0"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            workspace_dir.path().join("bun.lock"),
+            r#"{"lockfileVersion":1,"workspaces":{"":{"dependencies":{"foo":["foo@1.0.0","",{},"sha512-test"]}}}}"#,
+        )
+        .unwrap();
+        let workspace_report = report(workspace_dir.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+        assert_eq!(workspace_report.resolved_dependency_count.value, Some(1));
+    }
+
+    #[test]
+    fn rust_counts_dependency_categories_and_excludes_project_package() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("Cargo.toml"),
+            r#"[package]
+name = "demo"
+version = "0.1.0"
+[dependencies]
+serde = "1"
+alias = { package = "real-name", version = "1" }
+[dev-dependencies]
+criterion = "0.5"
+[build-dependencies]
+cc = "1"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("Cargo.lock"),
+            r#"version = 3
+
+[[package]]
+name = "demo"
+version = "0.1.0"
+dependencies = ["serde 1.0.0"]
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+
+[[package]]
+name = "serde"
+version = "2.0.0"
+
+[[package]]
+name = "real-name"
+version = "1.0.0"
+
+[[package]]
+name = "criterion"
+version = "0.5.0"
+
+[[package]]
+name = "cc"
+version = "1.0.0"
+"#,
+        )
+        .unwrap();
+
+        let report = report(temp_dir.path(), &[Ecosystem::Rust])
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(report.direct_dependency_counts["dependencies"], 2);
+        assert_eq!(report.direct_dependency_counts["dev-dependencies"], 1);
+        assert_eq!(report.direct_dependency_counts["build-dependencies"], 1);
+        assert_eq!(report.direct_dependency_total, 4);
+        assert_eq!(report.resolved_dependency_count.value, Some(5));
+        assert_eq!(report.transitive_dependency_count.value, Some(1));
+        assert_eq!(report.duplicate_versions[0].name, "serde");
+    }
+
+    #[test]
+    fn missing_and_unsupported_lockfiles_are_explicit() {
+        let missing = TempDir::new().unwrap();
+        fs::write(
+            missing.path().join("package.json"),
+            r#"{"name":"demo","dependencies":{"foo":"1.0.0"}}"#,
+        )
+        .unwrap();
+        let missing_report = report(missing.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+        assert_eq!(
+            missing_report.status,
+            DependencyReportStatus::MissingLockfile
+        );
+        assert_eq!(
+            missing_report.resolved_dependency_count.status.to_string(),
+            "Unknown"
+        );
+
+        let unsupported = TempDir::new().unwrap();
+        fs::write(
+            unsupported.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"yarn@4.0.0","dependencies":{}}"#,
+        )
+        .unwrap();
+        fs::write(unsupported.path().join("yarn.lock"), "__metadata:\n").unwrap();
+        let unsupported_report = report(unsupported.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+        assert_eq!(
+            unsupported_report.status,
+            DependencyReportStatus::Unsupported
+        );
+        assert_eq!(
+            unsupported_report.lockfile.unwrap().format,
+            Some("yarn.lock".to_owned())
+        );
+
+        let unknown_manager = TempDir::new().unwrap();
+        fs::write(
+            unknown_manager.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"deno@2.0.0","dependencies":{}}"#,
+        )
+        .unwrap();
+        let unknown_report = report(unknown_manager.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+        assert_eq!(unknown_report.status, DependencyReportStatus::Unsupported);
+        assert!(unknown_report.lockfile.is_none());
+        assert!(unknown_report.warnings[0].contains("unsupported package manager"));
+    }
+
+    #[test]
+    fn malformed_inputs_fail_with_the_relevant_path() {
+        let node = TempDir::new().unwrap();
+        fs::write(node.path().join("package.json"), "{invalid").unwrap();
+        assert!(matches!(
+            report(node.path(), &[Ecosystem::Node]),
+            Err(DustError::Manifest(message)) if message.contains("package.json")
+        ));
+
+        let rust = TempDir::new().unwrap();
+        fs::write(rust.path().join("Cargo.toml"), "[package").unwrap();
+        assert!(matches!(
+            report(rust.path(), &[Ecosystem::Rust]),
+            Err(DustError::Manifest(message)) if message.contains("Cargo.toml")
+        ));
+
+        let lockfile = TempDir::new().unwrap();
+        fs::write(
+            lockfile.path().join("package.json"),
+            r#"{"name":"demo","packageManager":"npm@10.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(
+            lockfile.path().join("package-lock.json"),
+            r#"{"lockfileVersion":3,"packages":[]}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            report(lockfile.path(), &[Ecosystem::Node]),
+            Err(DustError::Manifest(message)) if message.contains("package-lock.json")
+        ));
+    }
+
+    #[test]
+    fn java_is_explicitly_unsupported() {
+        let temp_dir = TempDir::new().unwrap();
+        let report = report(temp_dir.path(), &[Ecosystem::Java])
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(report.status, DependencyReportStatus::Unsupported);
+        assert!(report.warnings[0].contains("Java"));
+    }
+}

--- a/crates/dustfril-core/src/dependency.rs
+++ b/crates/dustfril-core/src/dependency.rs
@@ -38,6 +38,7 @@ struct ParsedManifest {
     direct_counts: BTreeMap<String, usize>,
     direct_names: BTreeSet<String>,
     node_manager: Option<NodeManager>,
+    is_cargo_workspace: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -145,6 +146,15 @@ fn report_rust(root: &Path) -> DustResult<DependencyReport> {
     }
 
     let manifest = parse_cargo_manifest(&path)?;
+    if manifest.is_cargo_workspace {
+        return Ok(unsupported_format_report(
+            manifest,
+            None,
+            None,
+            "Cargo workspace dependency reporting is not supported yet; member manifests require a separate workspace-aware design."
+                .to_owned(),
+        ));
+    }
     let lockfile_path = root.join(LockfileKind::CargoLock.filename());
 
     if !lockfile_path.is_file() {
@@ -426,6 +436,7 @@ fn parse_node_manifest(path: &Path) -> DustResult<ParsedManifest> {
         direct_counts,
         direct_names,
         node_manager,
+        is_cargo_workspace: false,
     })
 }
 
@@ -447,6 +458,18 @@ fn parse_cargo_manifest(path: &Path) -> DustResult<ParsedManifest> {
     let table = value
         .as_table()
         .ok_or_else(|| manifest_error(path, "Cargo.toml must contain a TOML table".to_owned()))?;
+
+    if table.contains_key("workspace") {
+        return Ok(ParsedManifest {
+            path: path.to_path_buf(),
+            format: "Cargo.toml".to_owned(),
+            project_names: BTreeSet::new(),
+            direct_counts: BTreeMap::new(),
+            direct_names: BTreeSet::new(),
+            node_manager: None,
+            is_cargo_workspace: true,
+        });
+    }
 
     let mut direct_counts = BTreeMap::new();
     let mut direct_names = BTreeSet::new();
@@ -474,6 +497,7 @@ fn parse_cargo_manifest(path: &Path) -> DustResult<ParsedManifest> {
         direct_counts,
         direct_names,
         node_manager: None,
+        is_cargo_workspace: false,
     })
 }
 
@@ -625,6 +649,12 @@ fn parse_package_lock_packages(
         if key.is_empty() {
             continue;
         }
+        if package_lock_path_is_workspace(key) {
+            // npm workspace package records use project-relative paths such
+            // as packages/app. The corresponding node_modules entry is a
+            // link, so neither record is a resolved external package node.
+            continue;
+        }
 
         let selector_name = package_name_from_selector(key);
         let name = optional_json_string(object, "name", path)?
@@ -694,6 +724,10 @@ fn parse_npm_dependency_tree(
 
 fn package_lock_path_is_direct(path: &str) -> bool {
     path.starts_with("node_modules/") && path.matches("node_modules/").count() == 1
+}
+
+fn package_lock_path_is_workspace(path: &str) -> bool {
+    !path.is_empty() && !path.starts_with("node_modules/") && !path.contains("/node_modules/")
 }
 
 fn parse_pnpm_lock(path: &Path, manifest: &ParsedManifest) -> DustResult<Vec<ResolvedDependency>> {
@@ -1530,6 +1564,43 @@ mod tests {
     }
 
     #[test]
+    fn npm_workspace_records_are_not_resolved_nodes() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{
+                "name":"root",
+                "workspaces":["packages/*"],
+                "dependencies":{"external":"1.0.0"}
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("package-lock.json"),
+            r#"{
+                "lockfileVersion":3,
+                "packages":{
+                    "":{"name":"root"},
+                    "packages/a":{},
+                    "packages/versioned":{"name":"versioned","version":"1.0.0"},
+                    "node_modules/a":{"resolved":"packages/a","link":true},
+                    "node_modules/versioned":{"resolved":"packages/versioned","link":true},
+                    "node_modules/external":{"version":"1.0.0"}
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let report = report(temp_dir.path(), &[Ecosystem::Node])
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(report.resolved_dependency_count.value, Some(1));
+        assert_eq!(report.transitive_dependency_count.value, Some(0));
+        assert!(report.duplicate_versions.is_empty());
+    }
+
+    #[test]
     fn package_lock_v1_uses_tree_depth_for_transitive_count() {
         let temp_dir = TempDir::new().unwrap();
         fs::write(
@@ -1719,6 +1790,43 @@ version = "1.0.0"
         assert_eq!(report.resolved_dependency_count.value, Some(5));
         assert_eq!(report.transitive_dependency_count.value, Some(1));
         assert_eq!(report.duplicate_versions[0].name, "serde");
+    }
+
+    #[test]
+    fn cargo_workspaces_are_explicitly_unsupported() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("Cargo.toml"),
+            r#"[workspace]
+members = ["crates/*"]
+
+[workspace.dependencies]
+serde = "1"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("Cargo.lock"),
+            r#"version = 4
+
+[[package]]
+name = "workspace-member"
+version = "0.1.0"
+"#,
+        )
+        .unwrap();
+
+        let report = report(temp_dir.path(), &[Ecosystem::Rust])
+            .unwrap()
+            .remove(0);
+
+        assert_eq!(report.status, DependencyReportStatus::Unsupported);
+        assert!(report.direct_dependency_counts.is_empty());
+        assert_eq!(
+            report.resolved_dependency_count.status,
+            crate::models::DependencyMetricStatus::Unsupported
+        );
+        assert!(report.warnings[0].contains("workspace"));
     }
 
     #[test]

--- a/crates/dustfril-core/src/lib.rs
+++ b/crates/dustfril-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod models;
 mod analyzer;
 mod audit_tool;
 mod cleaner;
+mod dependency;
 mod fs;
 mod history;
 mod integrity;

--- a/crates/dustfril-core/src/models/dependency.rs
+++ b/crates/dustfril-core/src/models/dependency.rs
@@ -1,0 +1,193 @@
+use core::fmt;
+use std::{collections::BTreeMap, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::{Ecosystem, LockfileKind};
+
+/// Overall state of one ecosystem's dependency inventory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DependencyReportStatus {
+    /// The manifest and supported lockfile were parsed successfully.
+    Complete,
+    /// The manifest was parsed, but its expected lockfile is not present.
+    MissingLockfile,
+    /// The ecosystem, package manager, or lockfile format is outside the
+    /// dependency report's supported scope.
+    Unsupported,
+}
+
+impl fmt::Display for DependencyReportStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Complete => "Complete",
+            Self::MissingLockfile => "Missing lockfile",
+            Self::Unsupported => "Unsupported",
+        };
+
+        f.write_str(value)
+    }
+}
+
+/// Availability of a metric whose value may not be derivable from the input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DependencyMetricStatus {
+    /// The value was calculated from a parsed lockfile.
+    Available,
+    /// The value is unknown because the expected lockfile is missing.
+    Unknown,
+    /// The value cannot be calculated for the selected format or ecosystem.
+    Unsupported,
+}
+
+impl fmt::Display for DependencyMetricStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Available => "Available",
+            Self::Unknown => "Unknown",
+            Self::Unsupported => "Unsupported",
+        };
+
+        f.write_str(value)
+    }
+}
+
+/// A count with an explicit availability state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DependencyMetric {
+    /// The count when `status` is `Available`.
+    pub value: Option<usize>,
+    /// Whether the count is available, unknown, or unsupported.
+    pub status: DependencyMetricStatus,
+    /// Explanation for an unknown or unsupported value.
+    pub reason: Option<String>,
+}
+
+impl DependencyMetric {
+    /// Creates an available count.
+    pub fn available(value: usize) -> Self {
+        Self {
+            value: Some(value),
+            status: DependencyMetricStatus::Available,
+            reason: None,
+        }
+    }
+
+    /// Creates a metric that is unavailable because a lockfile is missing.
+    pub fn unknown(reason: impl Into<String>) -> Self {
+        Self {
+            value: None,
+            status: DependencyMetricStatus::Unknown,
+            reason: Some(reason.into()),
+        }
+    }
+
+    /// Creates a metric that is not supported by the selected input.
+    pub fn unsupported(reason: impl Into<String>) -> Self {
+        Self {
+            value: None,
+            status: DependencyMetricStatus::Unsupported,
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+/// State of the lockfile selected for a dependency report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DependencyLockfileStatus {
+    /// The lockfile was parsed and contributed to the inventory.
+    Parsed,
+    /// The manifest implies a lockfile that is not present.
+    Missing,
+    /// A lockfile was identified but its format is not supported here.
+    Unsupported,
+}
+
+impl fmt::Display for DependencyLockfileStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Parsed => "Parsed",
+            Self::Missing => "Missing",
+            Self::Unsupported => "Unsupported",
+        };
+
+        f.write_str(value)
+    }
+}
+
+/// Metadata about the lockfile used by a dependency report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DependencyLockfile {
+    /// Expected or observed lockfile path.
+    pub path: PathBuf,
+    /// Existing DustFril lockfile kind, when recognized.
+    pub kind: Option<LockfileKind>,
+    /// Format and version description, when known.
+    pub format: Option<String>,
+    /// Parsing/availability state.
+    pub status: DependencyLockfileStatus,
+    /// Explanation for a missing or unsupported lockfile.
+    pub reason: Option<String>,
+}
+
+/// One package that resolves at more than one version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DuplicateDependency {
+    /// Package or crate name.
+    pub name: String,
+    /// Distinct resolved versions in deterministic order.
+    pub versions: Vec<String>,
+}
+
+/// Structured dependency inventory for one supported ecosystem.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DependencyReport {
+    /// Ecosystem represented by this report.
+    pub ecosystem: Ecosystem,
+    /// Whether the inventory is complete, missing a lockfile, or unsupported.
+    pub status: DependencyReportStatus,
+    /// Manifest inspected, or the expected manifest path for an unsupported
+    /// or missing project input.
+    pub manifest: PathBuf,
+    /// Manifest format, when known.
+    pub manifest_format: Option<String>,
+    /// Lockfile metadata and explicit missing/unsupported state.
+    pub lockfile: Option<DependencyLockfile>,
+    /// Direct dependency counts by ecosystem-specific category. Node uses
+    /// `dependencies`, `devDependencies`, `optionalDependencies`, and
+    /// `peerDependencies`; Rust uses `dependencies`, `dev-dependencies`, and
+    /// `build-dependencies`.
+    pub direct_dependency_counts: BTreeMap<String, usize>,
+    /// Number of unique direct package names across all categories.
+    pub direct_dependency_total: usize,
+    /// Number of logical package/version nodes represented by the lockfile.
+    pub resolved_dependency_count: DependencyMetric,
+    /// Number of resolved nodes classified as non-direct.
+    pub transitive_dependency_count: DependencyMetric,
+    /// Packages with more than one distinct resolved version.
+    pub duplicate_versions: Vec<DuplicateDependency>,
+    /// Non-fatal scope or availability notes.
+    pub warnings: Vec<String>,
+}
+
+impl DependencyReport {
+    /// Creates an unsupported report for an ecosystem or format outside the
+    /// inventory implementation.
+    pub fn unsupported(ecosystem: Ecosystem, manifest: PathBuf, reason: impl Into<String>) -> Self {
+        let reason = reason.into();
+
+        Self {
+            ecosystem,
+            status: DependencyReportStatus::Unsupported,
+            manifest,
+            manifest_format: None,
+            lockfile: None,
+            direct_dependency_counts: BTreeMap::new(),
+            direct_dependency_total: 0,
+            resolved_dependency_count: DependencyMetric::unsupported(reason.clone()),
+            transitive_dependency_count: DependencyMetric::unsupported(reason.clone()),
+            duplicate_versions: Vec::new(),
+            warnings: vec![reason],
+        }
+    }
+}

--- a/crates/dustfril-core/src/models/mod.rs
+++ b/crates/dustfril-core/src/models/mod.rs
@@ -2,6 +2,7 @@
 mod analysis;
 mod audit;
 mod cleanup;
+mod dependency;
 mod history;
 mod integrity;
 mod lockfile;
@@ -11,6 +12,7 @@ mod signature;
 pub use analysis::*;
 pub use audit::*;
 pub use cleanup::*;
+pub use dependency::*;
 pub use history::*;
 pub use integrity::*;
 pub use lockfile::*;


### PR DESCRIPTION
Closes #65

## Summary

- add a structured Core dependency inventory report for Node and Rust
- report direct dependency categories, resolved nodes, transitive nodes where the lockfile preserves the distinction, and duplicate versions
- support npm package-lock.json v1–3, pnpm-lock.yaml v5–9, Bun JSONC bun.lock v1–2, and Cargo.lock v1–4
- expose the report through `dfr dependencies` with explicit missing/unsupported states
- keep installed-tree traversal, dependency-size ranking, vulnerability scoring, and Java dependency parsing out of scope
- document supported formats and semantics in English and Korean READMEs

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo llvm-cov --workspace --all-features --summary-only`
- `git diff --check`
