### PR TITLE
Add explicit dependency baseline change detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,7 @@ dependencies = [
  "trash",
  "url",
  "walkdir",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.ko.md
+++ b/README.ko.md
@@ -21,6 +21,7 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 - 스캔·정리 활동 이력을 버전 형식으로 운영체제 앱 데이터 디렉터리에 저장
 - Node 및 Rust 프로젝트의 오프라인 공급망 보안 점검
 - 매니페스트와 lockfile에서 Node 및 Rust 의존성 inventory를 결정적으로 계산
+- 명시적 로컬 baseline과 의존성 inventory를 비교해 추가·삭제·버전·지원되는 소스 변경을 출력
 - 지원 lockfile의 존재 여부와 Git 상태 점검
 - 대상 개발 도구를 실행하지 않고 로컬 SHA-256 baseline과 실행 파일 무결성 비교
 - CLI 정리 이력을 운영체제 앱 데이터 디렉터리에 저장
@@ -61,6 +62,8 @@ cargo run -p dustfril-cli -- clean
 cargo run -p dustfril-cli -- clean --permanent
 cargo run -p dustfril-cli -- audit --node
 cargo run -p dustfril-cli -- dependencies --node
+cargo run -p dustfril-cli -- dependencies --compare --node
+cargo run -p dustfril-cli -- dependencies --compare --accept-baseline --node
 cargo run -p dustfril-cli -- security scan --node
 cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 ```
@@ -78,7 +81,7 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 - `analyze [path] [--rust] [--node] [--java]`
 - `clean [path] [--dry-run] [--permanent] [--rust] [--node] [--java]`
 - `audit [path] [--node]`
-- `dependencies [path] [--rust] [--node] [--java]`
+- `dependencies [path] [--compare] [--accept-baseline] [--rust] [--node] [--java]`
 - `security scan [path] [--node]`
 - `integrity scan [--tool <name>]...`
 
@@ -99,6 +102,16 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 lockfile 누락과 Yarn, 레거시 `bun.lockb`, Java 및 지원하지 않는 package manager는
 명시적인 상태로 출력합니다. 설치된 의존성의 디스크 크기나 취약점 점수는 계산하지
 않습니다.
+
+`dependencies --compare`는 OS 앱 데이터 디렉터리의 버전 형식
+`dependency-baseline.json`에 저장된 명시적 baseline과 현재 정규화된
+inventory를 비교합니다. 첫 번째 완전한 관측은 기존 의존성을 전부 추가로
+출력하지 않고 baseline만 생성합니다. 비교만 수행할 때 기존 baseline은
+변경되지 않으며, diff를 확인한 뒤 `--accept-baseline`을 명시해야 현재
+inventory로 교체됩니다. baseline 키는 canonical workspace 경로이므로
+심볼릭 링크와 canonical 경로는 같은 프로젝트로 처리하고, workspace를
+이동하면 새 프로젝트로 처리합니다. 불완전하거나 지원되지 않는 결과는
+경고로 남기며 기존 baseline을 지우지 않습니다.
 
 `integrity scan`은 PATH에서 요청한 개발 도구를 찾고 파일 메타데이터와 바이트를
 읽어 SHA-256을 스트리밍 계산합니다. 대상 실행 파일을 절대 실행하지 않으며,

--- a/README.ko.md
+++ b/README.ko.md
@@ -112,6 +112,8 @@ inventory로 교체됩니다. baseline 키는 canonical workspace 경로이므�
 심볼릭 링크와 canonical 경로는 같은 프로젝트로 처리하고, workspace를
 이동하면 새 프로젝트로 처리합니다. 불완전하거나 지원되지 않는 결과는
 경고로 남기며 기존 baseline을 지우지 않습니다.
+완전한 inventory가 하나도 없으면 비교 상태를 `Unavailable`로 표시하고
+해당 경고를 그대로 반환합니다.
 
 `integrity scan`은 PATH에서 요청한 개발 도구를 찾고 파일 메타데이터와 바이트를
 읽어 SHA-256을 스트리밍 계산합니다. 대상 실행 파일을 절대 실행하지 않으며,

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ comparison; pass `--accept-baseline` only after reviewing the diff. Baselines
 are keyed by the canonical workspace path, so symlink and canonical access share
 state while a moved workspace is treated as a new project. Unsupported or
 missing inventories are reported as warnings and are not used to erase a
-baseline.
+baseline; when no complete inventory is available, the comparison is marked
+unavailable and the warning is still returned.
 
 `integrity scan` resolves the requested development tools through PATH, reads
 filesystem metadata, streams each target through SHA-256, and stores its

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Persist versioned local activity history for scans, cleanup, and explicit security scans (including legacy cleanup history migration)
 - Run an offline supply-chain security scan for Node and Rust projects
 - Report deterministic Node and Rust dependency inventory from manifests and lockfiles
+- Compare dependency inventories with explicit local baselines and report added, removed, version, and supported source changes
 - Check supported lockfile presence and Git status
 - Compare selected development-tool executables with local SHA-256 baselines without launching them
 - Persist CLI cleanup history to the OS app data directory
@@ -68,6 +69,8 @@ cargo run -p dustfril-cli -- clean
 cargo run -p dustfril-cli -- clean --permanent
 cargo run -p dustfril-cli -- audit --node
 cargo run -p dustfril-cli -- dependencies --node
+cargo run -p dustfril-cli -- dependencies --compare --node
+cargo run -p dustfril-cli -- dependencies --compare --accept-baseline --node
 cargo run -p dustfril-cli -- security scan --node
 cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 cargo run -p dustfril-cli -- history
@@ -86,7 +89,7 @@ Available commands:
 - `analyze [path] [--rust] [--node] [--java]`
 - `clean [path] [--dry-run] [--permanent] [--rust] [--node] [--java]`
 - `audit [path] [--node]`
-- `dependencies [path] [--rust] [--node] [--java]`
+- `dependencies [path] [--compare] [--accept-baseline] [--rust] [--node] [--java]`
 - `security scan [path] [--node]`
 - `integrity scan [--tool <name>]...`
 - `history`
@@ -109,6 +112,16 @@ workspace member manifests have a dedicated aggregation design. Missing
 lockfiles and unsupported Yarn, legacy `bun.lockb`, Java, or package-manager
 formats are explicit report states. It does not measure installed dependency
 size or claim vulnerability risk.
+
+`dependencies --compare` compares the current normalized inventory with the
+explicit local baseline in `dependency-baseline.json` under the OS app data
+directory. The first complete observation creates a baseline without reporting
+all existing dependencies as added. Existing baselines are not replaced by a
+comparison; pass `--accept-baseline` only after reviewing the diff. Baselines
+are keyed by the canonical workspace path, so symlink and canonical access share
+state while a moved workspace is treated as a new project. Unsupported or
+missing inventories are reported as warnings and are not used to erase a
+baseline.
 
 `integrity scan` resolves the requested development tools through PATH, reads
 filesystem metadata, streams each target through SHA-256, and stores its

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -10,7 +10,7 @@ This package exposes the `dfr` binary and wraps the shared logic from `dustfril-
 - `analyze`: report artifact size, age, and cleanup recommendation
 - `clean`: preview or execute cleanup
 - `audit`: inspect Node lifecycle scripts
-- `dependencies`: report direct, resolved, transitive, and duplicate-version dependency metrics
+- `dependencies`: report dependency metrics and optionally compare an explicit local baseline
 - `security scan`: inspect Node and Rust manifests and lockfiles for supply-chain risks
 - `integrity scan`: inspect selected development-tool executables without launching them
 - `history`: load the unified local activity history as JSON
@@ -25,6 +25,8 @@ cargo run -p dustfril-cli -- analyze
 cargo run -p dustfril-cli -- clean --dry-run
 cargo run -p dustfril-cli -- audit --node
 cargo run -p dustfril-cli -- dependencies --node
+cargo run -p dustfril-cli -- dependencies --compare --node
+cargo run -p dustfril-cli -- dependencies --compare --accept-baseline --node
 cargo run -p dustfril-cli -- security scan --node
 cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 cargo run -p dustfril-cli -- history
@@ -39,6 +41,10 @@ cargo build -p dustfril-cli
 ## Notes
 
 - Supported ecosystem filters: `--rust`, `--node`, `--java`
+- `dependencies --compare` creates the first baseline without Added findings;
+  later comparisons preserve it until `--accept-baseline` is explicitly passed
+- dependency baselines are local, versioned, canonical-workspace keyed, and
+  stored separately from activity history
 - `clean` asks for confirmation before deletion
 - `clean --dry-run` previews without appending a cleanup activity
 - command failures return a non-zero process exit status

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -45,6 +45,8 @@ cargo build -p dustfril-cli
   later comparisons preserve it until `--accept-baseline` is explicitly passed
 - dependency baselines are local, versioned, canonical-workspace keyed, and
   stored separately from activity history
+- incomplete comparison inventories remain visible as warnings and produce an
+  `Unavailable` comparison without changing the stored baseline
 - `clean` asks for confirmation before deletion
 - `clean --dry-run` previews without appending a cleanup activity
 - command failures return a non-zero process exit status

--- a/apps/dustfril-cli/src/cli.rs
+++ b/apps/dustfril-cli/src/cli.rs
@@ -33,9 +33,9 @@ pub enum Commands {
     /// Audit lifecycle scripts
     Audit(PathArgs),
 
-    /// Report dependency inventory and version exposure
+    /// Report dependency inventory and explicit baseline changes
     #[command(name = "dependencies", visible_alias = "dependency")]
-    Dependencies(PathArgs),
+    Dependencies(DependencyArgs),
 
     /// Scan lifecycle scripts for suspicious commands
     Security(SecurityArgs),
@@ -97,6 +97,26 @@ pub struct PathArgs {
 
     #[arg(long)]
     pub java: bool,
+}
+
+#[derive(Args)]
+pub struct DependencyArgs {
+    #[command(flatten)]
+    pub path_args: PathArgs,
+
+    /// Compare the current inventory with the stored local baseline.
+    #[arg(long)]
+    pub compare: bool,
+
+    /// Explicitly accept the current inventory after displaying its diff.
+    #[arg(long)]
+    pub accept_baseline: bool,
+}
+
+impl DependencyArgs {
+    pub fn ecosystems(&self) -> Vec<Ecosystem> {
+        self.path_args.ecosystems()
+    }
 }
 
 impl PathArgs {
@@ -207,8 +227,31 @@ mod tests {
 
         assert!(matches!(
             cli.command,
-            Commands::Dependencies(PathArgs { rust: true, .. })
+            Commands::Dependencies(DependencyArgs {
+                path_args: PathArgs { rust: true, .. },
+                compare: false,
+                accept_baseline: false,
+            })
         ));
+    }
+
+    #[test]
+    fn cli_parses_dependency_comparison_and_explicit_acceptance() {
+        let cli = Cli::try_parse_from([
+            "dfr",
+            "dependencies",
+            "--compare",
+            "--accept-baseline",
+            "--node",
+        ])
+        .unwrap();
+
+        let Commands::Dependencies(args) = cli.command else {
+            panic!("expected dependency command");
+        };
+        assert!(args.compare);
+        assert!(args.accept_baseline);
+        assert_eq!(args.ecosystems(), vec![Ecosystem::Node]);
     }
 
     #[test]

--- a/apps/dustfril-cli/src/commands/dependency.rs
+++ b/apps/dustfril-cli/src/commands/dependency.rs
@@ -1,14 +1,10 @@
 use dustfril_core::api;
 
-use crate::{
-    cli::PathArgs,
-    format,
-    shared::path::{resolve_path, validate_path},
-};
+use crate::{cli::DependencyArgs, format, shared::path::resolve_path};
 
-/// Builds and prints the structured Core dependency inventory.
-pub fn execute(args: &PathArgs) -> bool {
-    let path = match resolve_path(&args.path) {
+/// Builds and prints the structured Core dependency inventory or baseline diff.
+pub fn execute(args: &DependencyArgs) -> bool {
+    let path = match resolve_path(&args.path_args.path) {
         Ok(path) => path,
         Err(error) => {
             eprintln!("Failed to resolve path: {error}");
@@ -16,18 +12,70 @@ pub fn execute(args: &PathArgs) -> bool {
         }
     };
 
-    if !validate_path(&path) {
+    if !validate_dependency_path(&path) {
         return false;
     }
 
+    if args.compare || args.accept_baseline {
+        return compare(&path, args);
+    }
+
     match api::dependency_report(&path, &args.ecosystems()) {
-        Ok(reports) => {
-            format::print_dependency_reports(&reports);
-            true
-        }
+        Ok(reports) => format::print_dependency_reports(&reports),
         Err(error) => {
             eprintln!("Dependency report failed: {error}");
+            return false;
+        }
+    }
+
+    true
+}
+
+fn validate_dependency_path(path: &std::path::Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => true,
+        Ok(_) => {
+            eprintln!("Path is not a directory: {}", path.display());
+            false
+        }
+        Err(error) => {
+            eprintln!("Cannot access path {}: {error}", path.display());
             false
         }
     }
+}
+
+fn compare(path: &std::path::Path, args: &DependencyArgs) -> bool {
+    let baseline_path = match api::dependency_baseline_path() {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("Failed to determine dependency baseline path: {error}");
+            return false;
+        }
+    };
+    let reports = match api::dependency_report(path, &args.ecosystems()) {
+        Ok(reports) => reports,
+        Err(error) => {
+            eprintln!("Dependency report failed: {error}");
+            return false;
+        }
+    };
+    let diff = match api::dependency_diff(path, &reports, &baseline_path) {
+        Ok(diff) => diff,
+        Err(error) => {
+            eprintln!("Dependency comparison failed: {error}");
+            return false;
+        }
+    };
+    format::print_dependency_diff(&diff);
+
+    if args.accept_baseline {
+        if let Err(error) = api::accept_dependency_baseline(path, &reports, &baseline_path) {
+            eprintln!("Failed to accept dependency baseline: {error}");
+            return false;
+        }
+        println!("Baseline accepted.");
+    }
+
+    true
 }

--- a/apps/dustfril-cli/src/format/dependency_format.rs
+++ b/apps/dustfril-cli/src/format/dependency_format.rs
@@ -1,4 +1,7 @@
-use dustfril_core::models::{DependencyMetric, DependencyReport, DuplicateDependency};
+use dustfril_core::models::{
+    DependencyChange, DependencyDiff, DependencyEntry, DependencyMetric, DependencyReport,
+    DuplicateDependency,
+};
 
 /// Prints dependency reports without adding CLI-specific analysis semantics.
 pub fn print_dependency_reports(reports: &[DependencyReport]) {
@@ -14,6 +17,53 @@ pub fn print_dependency_reports(reports: &[DependencyReport]) {
             println!();
         }
         print_dependency_report(report);
+    }
+}
+
+/// Prints the structured logical diff from an explicit dependency baseline.
+pub fn print_dependency_diff(diff: &DependencyDiff) {
+    println!("Dependency change report\n");
+    println!("Workspace:    {}", diff.workspace_id);
+    println!("Baseline:     {}", diff.baseline_status);
+    print_changes("Added", &diff.added);
+    print_changes("Removed", &diff.removed);
+    print_changes("Version changed", &diff.version_changes);
+    print_changes("Source changed", &diff.source_changes);
+    for warning in &diff.warnings {
+        println!("Warning:       {warning}");
+    }
+    if !diff.has_changes() {
+        println!("No dependency changes detected.");
+    }
+}
+
+fn print_changes(label: &str, changes: &[DependencyChange]) {
+    if changes.is_empty() {
+        return;
+    }
+    println!("{label}: {}", changes.len());
+    for change in changes {
+        let entry = change.current.as_ref().or(change.previous.as_ref());
+        if let Some(entry) = entry {
+            println!(
+                "  {} {} {} ({})",
+                entry.ecosystem, entry.name, entry.version, entry.scope
+            );
+        }
+        if let (Some(previous), Some(current)) = (&change.previous, &change.current) {
+            println!(
+                "    {} -> {}",
+                dependency_label(previous),
+                dependency_label(current)
+            );
+        }
+    }
+}
+
+fn dependency_label(entry: &DependencyEntry) -> String {
+    match &entry.source {
+        Some(source) => format!("{} {} [{}]", entry.name, entry.version, source),
+        None => format!("{} {}", entry.name, entry.version),
     }
 }
 

--- a/crates/dustfril-core/Cargo.toml
+++ b/crates/dustfril-core/Cargo.toml
@@ -17,5 +17,8 @@ toml = "0.9.12"
 url = "2.5.8"
 sha2 = "0.10"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -16,6 +16,8 @@ This crate contains the filesystem scanners, analyzers, cleanup planner and exec
 - `api::security_scan`: preserve the lifecycle-only security warnings API
 - `api::security_scan_report`: run the complete offline supply-chain scan
 - `api::dependency_report`: build structured dependency exposure/inventory reports
+- `api::dependency_changes`: compare a parsed inventory with an explicit local baseline
+- `api::accept_dependency_baseline`: explicitly replace selected workspace baseline data
 - `api::integrity`: resolve selected development tools without executing them, hash their bytes, and compare local baselines
 - `api::integrity::verify_signature`: inspect an already resolved executable with the supported platform verifier
 - `api::check_lockfile_integrity`: check supported lockfile presence and Git status
@@ -84,6 +86,18 @@ are explicit unknown values when a lockfile is missing, and duplicate versions
 are returned in sorted order. Installed trees, registry caches, Java dependency
 formats, Yarn lockfiles, and legacy binary Bun lockfiles are outside this
 report's scope.
+
+Dependency change detection stores only normalized entries in the versioned
+local `dependency-baseline.json` state. The identity is ecosystem, package
+name, resolved version, and source when available; lockfile ordering and
+formatting are not identity. The first complete observation creates a baseline
+without Added findings. Later comparisons preserve the stored baseline until
+`accept_dependency_baseline` is called explicitly. Baselines use the canonical
+workspace path, so symlink access resolves to the same project and moved
+directories are treated as new projects. Direct/transitive scope is retained
+only where the inventory parser can classify it; otherwise entries are
+`Unknown`. Source changes are emitted only when both observations contain
+source identifiers.
 
 ## Test
 

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -97,7 +97,8 @@ workspace path, so symlink access resolves to the same project and moved
 directories are treated as new projects. Direct/transitive scope is retained
 only where the inventory parser can classify it; otherwise entries are
 `Unknown`. Source changes are emitted only when both observations contain
-source identifiers.
+source identifiers. If no complete inventory is available, comparison returns
+an `Unavailable` result with warnings and leaves the stored baseline untouched.
 
 ## Test
 

--- a/crates/dustfril-core/src/api/dependency.rs
+++ b/crates/dustfril-core/src/api/dependency.rs
@@ -1,10 +1,12 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::{
-    dependency,
+    dependency, dependency_baseline,
     error::DustResult,
-    models::{DependencyReport, Ecosystem},
+    models::{DependencyDiff, DependencyReport, Ecosystem},
 };
+
+pub use crate::dependency_baseline::DependencyBaselineStore;
 
 /// Builds deterministic dependency inventory reports without traversing
 /// installed dependency trees or contacting package registries.
@@ -21,6 +23,43 @@ pub fn dependency_exposure_report(
     ecosystems: &[Ecosystem],
 ) -> DustResult<Vec<DependencyReport>> {
     dependency_report(root, ecosystems)
+}
+
+/// Returns the OS-specific local path used for dependency baselines.
+pub fn dependency_baseline_path() -> std::io::Result<PathBuf> {
+    dependency_baseline::default_state_path()
+}
+
+/// Compares an already parsed inventory with the explicit local baseline.
+///
+/// The reports are accepted as input so callers can reuse one parsed
+/// inventory for both reporting and comparison.
+pub fn dependency_diff(
+    root: &Path,
+    reports: &[DependencyReport],
+    baseline_path: &Path,
+) -> DustResult<DependencyDiff> {
+    DependencyBaselineStore::new(baseline_path).compare(root, reports)
+}
+
+/// Explicitly replaces the selected workspace inventories in the local
+/// baseline after the caller has inspected a diff.
+pub fn accept_dependency_baseline(
+    root: &Path,
+    reports: &[DependencyReport],
+    baseline_path: &Path,
+) -> DustResult<()> {
+    DependencyBaselineStore::new(baseline_path).accept(root, reports)
+}
+
+/// Parses the current inventory once and compares it with the local baseline.
+pub fn dependency_changes(
+    root: &Path,
+    ecosystems: &[Ecosystem],
+    baseline_path: &Path,
+) -> DustResult<DependencyDiff> {
+    let reports = dependency_report(root, ecosystems)?;
+    dependency_diff(root, &reports, baseline_path)
 }
 
 #[cfg(test)]
@@ -49,5 +88,53 @@ mod tests {
 
         assert_eq!(reports.len(), 1);
         assert_eq!(reports[0].resolved_dependency_count.value, Some(1));
+        assert_eq!(reports[0].resolved_dependencies[0].name, "left-pad");
+        assert_eq!(
+            reports[0].resolved_dependencies[0].scope,
+            crate::models::DependencyScope::Direct
+        );
+    }
+
+    #[test]
+    fn api_compares_the_same_parsed_inventory_and_accepts_explicitly() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","dependencies":{"left-pad":"1.0.0"}}"#,
+        )
+        .unwrap();
+        let lockfile = temp_dir.path().join("package-lock.json");
+        fs::write(
+            &lockfile,
+            r#"{"lockfileVersion":3,"packages":{"":{"name":"demo"},"node_modules/left-pad":{"version":"1.0.0"}}}"#,
+        )
+        .unwrap();
+        let baseline_path = temp_dir.path().join("dependency-baseline.json");
+
+        let first_reports = dependency_report(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+        let first = dependency_diff(temp_dir.path(), &first_reports, &baseline_path).unwrap();
+        assert_eq!(
+            first.baseline_status,
+            crate::models::DependencyBaselineStatus::BaselineCreated
+        );
+        assert!(!first.has_changes());
+
+        fs::write(
+            &lockfile,
+            r#"{"lockfileVersion":3,"packages":{"node_modules/new-package":{"version":"1.0.0"},"":{"name":"demo"},"node_modules/left-pad":{"version":"1.0.0"}}}"#,
+        )
+        .unwrap();
+        let current_reports = dependency_report(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+        let diff = dependency_diff(temp_dir.path(), &current_reports, &baseline_path).unwrap();
+        assert_eq!(diff.added.len(), 1);
+        assert_eq!(diff.added[0].current.as_ref().unwrap().name, "new-package");
+        assert_eq!(
+            diff.added[0].current.as_ref().unwrap().scope,
+            crate::models::DependencyScope::Transitive
+        );
+
+        accept_dependency_baseline(temp_dir.path(), &current_reports, &baseline_path).unwrap();
+        let accepted = dependency_diff(temp_dir.path(), &current_reports, &baseline_path).unwrap();
+        assert!(!accepted.has_changes());
     }
 }

--- a/crates/dustfril-core/src/dependency.rs
+++ b/crates/dustfril-core/src/dependency.rs
@@ -16,8 +16,9 @@ use serde_yaml::Value as YamlValue;
 use crate::{
     error::{DustError, DustResult},
     models::{
-        DependencyLockfile, DependencyLockfileStatus, DependencyMetric, DependencyReport,
-        DependencyReportStatus, DuplicateDependency, Ecosystem, LockfileKind,
+        DependencyEntry, DependencyLockfile, DependencyLockfileStatus, DependencyMetric,
+        DependencyReport, DependencyReportStatus, DependencyScope, DuplicateDependency, Ecosystem,
+        LockfileKind,
     },
 };
 
@@ -71,6 +72,7 @@ enum LockSelection {
 struct ResolvedDependency {
     name: String,
     version: String,
+    source: Option<String>,
     direct: bool,
     classification_available: bool,
 }
@@ -183,8 +185,26 @@ fn complete_report(
     let duplicates = duplicate_versions(&entries);
     let resolved_count = entries.len();
     let transitive_count = entries.iter().filter(|entry| !entry.direct).count();
+    let all_classifications_available = entries.iter().all(|entry| entry.classification_available);
+    let mut resolved_dependencies = entries
+        .into_iter()
+        .map(|entry| DependencyEntry {
+            ecosystem: ecosystem_for_kind(kind),
+            name: entry.name,
+            version: entry.version,
+            source: entry.source,
+            scope: if !entry.classification_available {
+                DependencyScope::Unknown
+            } else if entry.direct {
+                DependencyScope::Direct
+            } else {
+                DependencyScope::Transitive
+            },
+        })
+        .collect::<Vec<_>>();
+    resolved_dependencies.sort();
     let lockfile_format = lockfile_format(kind);
-    let transitive_metric = if entries.iter().all(|entry| entry.classification_available) {
+    let transitive_metric = if all_classifications_available {
         DependencyMetric::available(transitive_count)
     } else {
         DependencyMetric::unknown(
@@ -209,6 +229,7 @@ fn complete_report(
         resolved_dependency_count: DependencyMetric::available(resolved_count),
         transitive_dependency_count: transitive_metric,
         duplicate_versions: duplicates,
+        resolved_dependencies,
         warnings: Vec::new(),
     }
 }
@@ -240,6 +261,7 @@ fn missing_lockfile_report(
         resolved_dependency_count: DependencyMetric::unknown(reason.clone()),
         transitive_dependency_count: DependencyMetric::unknown(reason.clone()),
         duplicate_versions: Vec::new(),
+        resolved_dependencies: Vec::new(),
         warnings: vec![reason],
     }
 }
@@ -267,6 +289,7 @@ fn unsupported_format_report(
         resolved_dependency_count: DependencyMetric::unsupported(reason.clone()),
         transitive_dependency_count: DependencyMetric::unsupported(reason.clone()),
         duplicate_versions: Vec::new(),
+        resolved_dependencies: Vec::new(),
         warnings: vec![reason],
     }
 }
@@ -678,6 +701,7 @@ fn parse_package_lock_packages(
         entries.push(ResolvedDependency {
             name,
             version: version.to_owned(),
+            source: optional_json_string(object, "resolved", path)?.map(str::to_owned),
             direct,
             classification_available: true,
         });
@@ -703,6 +727,7 @@ fn parse_npm_dependency_tree(
         entries.push(ResolvedDependency {
             name: name.clone(),
             version: version.to_owned(),
+            source: optional_json_string(object, "resolved", path)?.map(str::to_owned),
             direct: depth == 0,
             classification_available: true,
         });
@@ -814,10 +839,19 @@ fn parse_pnpm_section(
             continue;
         }
         let (name, version) = parsed_selector.expect("selector was validated above");
+        let source = yaml_value_field(package, "resolution")
+            .and_then(YamlValue::as_mapping)
+            .and_then(|resolution| {
+                ["tarball", "repo", "url"]
+                    .into_iter()
+                    .find_map(|key| yaml_value_field(resolution, key).and_then(YamlValue::as_str))
+            })
+            .map(str::to_owned);
         resolved.push(ResolvedDependency {
             direct: manifest.direct_names.contains(&name),
             name,
             version,
+            source,
             classification_available: false,
         });
     }
@@ -897,6 +931,7 @@ fn parse_bun_lock(path: &Path, manifest: &ParsedManifest) -> DustResult<Vec<Reso
                         direct: manifest.direct_names.contains(&name),
                         name,
                         version,
+                        source: values.get(1).and_then(Value::as_str).map(str::to_owned),
                         classification_available: false,
                     });
                 }
@@ -986,6 +1021,7 @@ fn parse_bun_workspace_dependency(
                 direct,
                 name,
                 version,
+                source: values.get(1).and_then(Value::as_str).map(str::to_owned),
                 classification_available: false,
             });
             for value in values.iter().skip(1) {
@@ -1013,6 +1049,11 @@ fn parse_bun_workspace_dependency(
                 direct,
                 name: name.to_owned(),
                 version: version.to_owned(),
+                source: object
+                    .get("resolved")
+                    .or_else(|| object.get("url"))
+                    .and_then(Value::as_str)
+                    .map(str::to_owned),
                 classification_available: false,
             });
             parse_bun_nested_dependencies(path, object, manifest, entries)
@@ -1068,6 +1109,11 @@ fn parse_bun_package_value(
         direct: manifest.direct_names.contains(name),
         name: name.to_owned(),
         version: version.to_owned(),
+        source: object
+            .get("resolved")
+            .or_else(|| object.get("url"))
+            .and_then(Value::as_str)
+            .map(str::to_owned),
         classification_available: false,
     });
     Ok(())
@@ -1197,6 +1243,10 @@ fn parse_cargo_lock(path: &Path, manifest: &ParsedManifest) -> DustResult<Vec<Re
             direct,
             name: name.to_owned(),
             version: version.to_owned(),
+            source: package
+                .get("source")
+                .and_then(toml::Value::as_str)
+                .map(str::to_owned),
             classification_available: true,
         });
     }
@@ -1446,10 +1496,11 @@ fn read_input(path: &Path) -> DustResult<String> {
 }
 
 fn validate_root(root: &Path) -> DustResult<()> {
-    match fs::symlink_metadata(root) {
-        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
-            Err(DustError::InvalidPath(root.to_path_buf()))
-        }
+    // Dependency reporting is read-only and keys baselines by the canonical
+    // target, so a directory reached through a symlink is a valid project
+    // input. Artifact scanning keeps its stricter symlink-root policy.
+    match fs::metadata(root) {
+        Ok(metadata) if !metadata.is_dir() => Err(DustError::InvalidPath(root.to_path_buf())),
         Ok(_) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             Err(DustError::InvalidPath(root.to_path_buf()))
@@ -1560,6 +1611,22 @@ mod tests {
         assert_eq!(report.transitive_dependency_count.value, Some(1));
         assert_eq!(report.duplicate_versions[0].name, "shared");
         assert_eq!(report.duplicate_versions[0].versions, ["1.0.0", "2.0.0"]);
+        assert_eq!(
+            report
+                .resolved_dependencies
+                .iter()
+                .filter(|entry| entry.scope == DependencyScope::Direct)
+                .count(),
+            5
+        );
+        assert_eq!(
+            report
+                .resolved_dependencies
+                .iter()
+                .filter(|entry| entry.scope == DependencyScope::Transitive)
+                .count(),
+            1
+        );
     }
 
     #[test]
@@ -1758,6 +1825,7 @@ dependencies = ["serde 1.0.0"]
 [[package]]
 name = "serde"
 version = "1.0.0"
+source = "registry+https://example.invalid/index"
 
 [[package]]
 name = "serde"
@@ -1789,6 +1857,15 @@ version = "1.0.0"
         assert_eq!(report.resolved_dependency_count.value, Some(5));
         assert_eq!(report.transitive_dependency_count.value, Some(1));
         assert_eq!(report.duplicate_versions[0].name, "serde");
+        assert_eq!(
+            report
+                .resolved_dependencies
+                .iter()
+                .find(|entry| entry.name == "serde")
+                .unwrap()
+                .source,
+            Some("registry+https://example.invalid/index".to_owned())
+        );
     }
 
     #[test]

--- a/crates/dustfril-core/src/dependency_baseline.rs
+++ b/crates/dustfril-core/src/dependency_baseline.rs
@@ -1,0 +1,688 @@
+//! Explicit, local dependency baseline storage and logical comparison.
+//!
+//! A comparison reads an existing baseline without replacing it. The only
+//! implicit write is creating a missing first-observation baseline; callers
+//! must explicitly call `accept` to replace an existing comparison point.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::{self, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
+};
+
+use directories::ProjectDirs;
+use serde_json::Value;
+
+use crate::{
+    error::{DustError, DustResult},
+    models::{
+        DEPENDENCY_BASELINE_STATE_VERSION, DependencyBaseline, DependencyBaselineState,
+        DependencyBaselineStatus, DependencyChange, DependencyChangeKind, DependencyDiff,
+        DependencyEntry, DependencyReport, DependencyReportStatus, DependencyScope, Ecosystem,
+    },
+};
+
+static BASELINE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static NEXT_TEMP_FILE_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+type Inventories = BTreeMap<Ecosystem, Vec<DependencyEntry>>;
+
+/// Access to the versioned local dependency-baseline collection.
+#[derive(Debug, Clone)]
+pub struct DependencyBaselineStore {
+    path: PathBuf,
+}
+
+impl DependencyBaselineStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Loads all project baselines. Missing state is an empty collection;
+    /// malformed or unsupported state is returned as an explicit error.
+    pub fn load(&self) -> DustResult<DependencyBaselineState> {
+        let _guard = baseline_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        load_unlocked(&self.path)
+    }
+
+    /// Atomically replaces the versioned baseline collection.
+    pub fn save(&self, state: &DependencyBaselineState) -> DustResult<()> {
+        let _guard = baseline_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        save_unlocked(&self.path, state)
+    }
+
+    /// Compares reports with the stored baseline. A missing project (or
+    /// ecosystem within an existing project) is initialized without emitting
+    /// false Added findings. An existing baseline is never replaced here.
+    pub fn compare(
+        &self,
+        workspace_root: &Path,
+        reports: &[DependencyReport],
+    ) -> DustResult<DependencyDiff> {
+        let workspace_id = workspace_id(workspace_root)?;
+        let (current, warnings) = current_inventories(reports)?;
+        let _guard = baseline_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let mut state = load_unlocked(&self.path)?;
+
+        let Some(previous) = state.projects.get(&workspace_id).cloned() else {
+            state
+                .projects
+                .insert(workspace_id.clone(), baseline_for(&workspace_id, &current));
+            save_unlocked(&self.path, &state)?;
+
+            let mut diff =
+                DependencyDiff::empty(workspace_id, DependencyBaselineStatus::BaselineCreated);
+            diff.warnings = warnings;
+            return Ok(diff);
+        };
+
+        let mut diff = compare_inventories(&workspace_id, &previous.inventories, &current);
+        diff.warnings = warnings;
+
+        let mut missing_ecosystem = false;
+        let mut merged = previous.inventories.clone();
+        for (ecosystem, entries) in &current {
+            if !merged.contains_key(ecosystem) {
+                merged.insert(*ecosystem, entries.clone());
+                missing_ecosystem = true;
+            }
+        }
+        if missing_ecosystem {
+            state.projects.insert(
+                workspace_id.clone(),
+                DependencyBaseline {
+                    workspace_id: workspace_id.clone(),
+                    inventories: merged,
+                },
+            );
+            save_unlocked(&self.path, &state)?;
+            diff.baseline_status = DependencyBaselineStatus::BaselineCreated;
+        }
+
+        Ok(diff)
+    }
+
+    /// Explicitly accepts the supplied complete inventories as the next
+    /// baseline. Existing baselines for other workspaces or ecosystems remain
+    /// untouched.
+    pub fn accept(&self, workspace_root: &Path, reports: &[DependencyReport]) -> DustResult<()> {
+        let workspace_id = workspace_id(workspace_root)?;
+        let (current, _) = current_inventories(reports)?;
+        let _guard = baseline_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let mut state = load_unlocked(&self.path)?;
+        let mut inventories = state
+            .projects
+            .get(&workspace_id)
+            .map(|baseline| baseline.inventories.clone())
+            .unwrap_or_default();
+        inventories.extend(current);
+        state.projects.insert(
+            workspace_id.clone(),
+            DependencyBaseline {
+                workspace_id,
+                inventories,
+            },
+        );
+        save_unlocked(&self.path, &state)
+    }
+}
+
+/// Returns the OS-specific local dependency-baseline path.
+pub fn default_state_path() -> io::Result<PathBuf> {
+    let dirs = ProjectDirs::from("dev", "FrilLab", "DustFril")
+        .ok_or_else(|| io::Error::other("Failed to determine data directory"))?;
+    let data_dir = dirs.data_dir();
+    fs::create_dir_all(data_dir)?;
+    Ok(data_dir.join("dependency-baseline.json"))
+}
+
+fn current_inventories(reports: &[DependencyReport]) -> DustResult<(Inventories, Vec<String>)> {
+    let mut inventories = BTreeMap::new();
+    let mut warnings = Vec::new();
+
+    for report in reports {
+        if report.status != DependencyReportStatus::Complete {
+            let reason = report
+                .warnings
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "the inventory is not complete".to_owned());
+            warnings.push(format!(
+                "{} dependency baseline comparison skipped: {reason}",
+                report.ecosystem
+            ));
+            continue;
+        }
+
+        let mut entries = BTreeMap::<IdentityKey, DependencyEntry>::new();
+        for entry in &report.resolved_dependencies {
+            if entry.ecosystem != report.ecosystem {
+                return Err(DustError::DependencyState(format!(
+                    "report ecosystem {} does not match dependency entry {}",
+                    report.ecosystem, entry.name
+                )));
+            }
+            let key = IdentityKey::from(entry);
+            entries
+                .entry(key)
+                .and_modify(|existing| existing.scope = merge_scope(existing.scope, entry.scope))
+                .or_insert_with(|| entry.clone());
+        }
+        inventories.insert(report.ecosystem, entries.into_values().collect());
+    }
+
+    if inventories.is_empty() {
+        return Err(DustError::DependencyState(
+            "at least one complete dependency inventory is required to compare or accept a baseline"
+                .to_owned(),
+        ));
+    }
+
+    warnings.sort();
+    warnings.dedup();
+    Ok((inventories, warnings))
+}
+
+fn baseline_for(workspace_id: &str, inventories: &Inventories) -> DependencyBaseline {
+    DependencyBaseline {
+        workspace_id: workspace_id.to_owned(),
+        inventories: inventories.clone(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct IdentityKey {
+    ecosystem: Ecosystem,
+    name: String,
+    version: String,
+    source: Option<String>,
+}
+
+impl From<&DependencyEntry> for IdentityKey {
+    fn from(entry: &DependencyEntry) -> Self {
+        Self {
+            ecosystem: entry.ecosystem,
+            name: entry.name.clone(),
+            version: entry.version.clone(),
+            source: entry.source.clone(),
+        }
+    }
+}
+
+fn merge_scope(left: DependencyScope, right: DependencyScope) -> DependencyScope {
+    if left == right {
+        return left;
+    }
+    if left == DependencyScope::Direct || right == DependencyScope::Direct {
+        return DependencyScope::Direct;
+    }
+    DependencyScope::Unknown
+}
+
+fn compare_inventories(
+    workspace_id: &str,
+    previous: &Inventories,
+    current: &Inventories,
+) -> DependencyDiff {
+    let mut diff = DependencyDiff::empty(workspace_id, DependencyBaselineStatus::Compared);
+    // Compare only ecosystems present in this explicit scan. A filtered scan
+    // must not interpret an unselected ecosystem as removed.
+    for ecosystem in current.keys() {
+        if !previous.contains_key(ecosystem) {
+            continue;
+        }
+        let before = previous.get(ecosystem).map(Vec::as_slice).unwrap_or(&[]);
+        let after = current.get(ecosystem).map(Vec::as_slice).unwrap_or(&[]);
+        compare_entries(before, after, &mut diff);
+    }
+
+    diff.added.sort();
+    diff.removed.sort();
+    diff.version_changes.sort();
+    diff.source_changes.sort();
+    diff
+}
+
+fn compare_entries(
+    previous: &[DependencyEntry],
+    current: &[DependencyEntry],
+    diff: &mut DependencyDiff,
+) {
+    let mut previous_by_identity = previous
+        .iter()
+        .cloned()
+        .map(|entry| (IdentityKey::from(&entry), entry))
+        .collect::<BTreeMap<_, _>>();
+    let mut current_by_identity = current
+        .iter()
+        .cloned()
+        .map(|entry| (IdentityKey::from(&entry), entry))
+        .collect::<BTreeMap<_, _>>();
+
+    let exact = previous_by_identity
+        .keys()
+        .filter(|key| current_by_identity.contains_key(*key))
+        .cloned()
+        .collect::<Vec<_>>();
+    for key in exact {
+        previous_by_identity.remove(&key);
+        current_by_identity.remove(&key);
+    }
+
+    let names = previous_by_identity
+        .values()
+        .chain(current_by_identity.values())
+        .map(|entry| (entry.ecosystem, entry.name.clone()))
+        .collect::<BTreeSet<_>>();
+
+    for (ecosystem, name) in names {
+        let mut before = previous_by_identity
+            .values()
+            .filter(|entry| entry.ecosystem == ecosystem && entry.name == name)
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut after = current_by_identity
+            .values()
+            .filter(|entry| entry.ecosystem == ecosystem && entry.name == name)
+            .cloned()
+            .collect::<Vec<_>>();
+        before.sort();
+        after.sort();
+
+        // A source change is trustworthy only when both snapshots contain
+        // source identifiers for the same name/version.
+        let mut index = 0;
+        while index < before.len() {
+            let Some(current_index) = after.iter().position(|candidate| {
+                candidate.version == before[index].version
+                    && (candidate.source == before[index].source
+                        || (candidate.source.is_some() && before[index].source.is_some()))
+            }) else {
+                index += 1;
+                continue;
+            };
+            let old = before.remove(index);
+            let new = after.remove(current_index);
+            if old.source != new.source {
+                diff.source_changes.push(DependencyChange {
+                    kind: DependencyChangeKind::SourceChanged,
+                    previous: Some(old),
+                    current: Some(new),
+                });
+            }
+        }
+
+        // If only one side has source metadata, retain the logical
+        // name/version match and avoid inventing a source change.
+        let mut index = 0;
+        while index < before.len() {
+            let Some(current_index) = after
+                .iter()
+                .position(|candidate| candidate.version == before[index].version)
+            else {
+                index += 1;
+                continue;
+            };
+            before.remove(index);
+            after.remove(current_index);
+        }
+
+        let version_pairs = before.len().min(after.len());
+        for _ in 0..version_pairs {
+            diff.version_changes.push(DependencyChange {
+                kind: DependencyChangeKind::VersionChanged,
+                previous: Some(before.remove(0)),
+                current: Some(after.remove(0)),
+            });
+        }
+        for entry in after {
+            diff.added.push(DependencyChange {
+                kind: DependencyChangeKind::Added,
+                previous: None,
+                current: Some(entry),
+            });
+        }
+        for entry in before {
+            diff.removed.push(DependencyChange {
+                kind: DependencyChangeKind::Removed,
+                previous: Some(entry),
+                current: None,
+            });
+        }
+    }
+}
+
+fn workspace_id(root: &Path) -> DustResult<String> {
+    let canonical = fs::canonicalize(root).map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            DustError::InvalidPath(root.to_path_buf())
+        } else {
+            DustError::Io(error)
+        }
+    })?;
+    if !fs::metadata(&canonical)?.is_dir() {
+        return Err(DustError::InvalidPath(root.to_path_buf()));
+    }
+    Ok(format!("v1:{}", canonical.to_string_lossy()))
+}
+
+fn load_unlocked(path: &Path) -> DustResult<DependencyBaselineState> {
+    if !path.exists() {
+        return Ok(DependencyBaselineState::default());
+    }
+
+    let json = fs::read_to_string(path)?;
+    let value: Value = serde_json::from_str(&json).map_err(state_error)?;
+    let state: DependencyBaselineState = serde_json::from_value(value).map_err(state_error)?;
+
+    if state.version != DEPENDENCY_BASELINE_STATE_VERSION {
+        return Err(DustError::DependencyState(format!(
+            "unsupported dependency baseline state version: {}",
+            state.version
+        )));
+    }
+    for (key, baseline) in &state.projects {
+        if key != &baseline.workspace_id {
+            return Err(DustError::DependencyState(
+                "baseline project key does not match workspace_id".to_owned(),
+            ));
+        }
+        for (ecosystem, entries) in &baseline.inventories {
+            if entries.iter().any(|entry| entry.ecosystem != *ecosystem) {
+                return Err(DustError::DependencyState(format!(
+                    "baseline inventory for {ecosystem} contains an entry from another ecosystem"
+                )));
+            }
+        }
+    }
+
+    Ok(state)
+}
+
+fn save_unlocked(path: &Path, state: &DependencyBaselineState) -> DustResult<()> {
+    if state.version != DEPENDENCY_BASELINE_STATE_VERSION {
+        return Err(DustError::DependencyState(format!(
+            "unsupported dependency baseline state version: {}",
+            state.version
+        )));
+    }
+
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    let json = serde_json::to_string_pretty(state).map_err(state_serialize_error)?;
+    let temporary_path = temporary_path(path);
+    let write_result = (|| -> io::Result<()> {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary_path)?;
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+        fs::rename(&temporary_path, path)
+    })();
+
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temporary_path);
+        return Err(error.into());
+    }
+
+    Ok(())
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("dependency-baseline.json");
+    let id = NEXT_TEMP_FILE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    path.with_file_name(format!(".{file_name}.{}.{}.tmp", std::process::id(), id))
+}
+
+fn state_error(error: serde_json::Error) -> DustError {
+    DustError::DependencyState(error.to_string())
+}
+
+fn state_serialize_error(error: serde_json::Error) -> DustError {
+    DustError::DependencyState(format!("could not serialize dependency baseline: {error}"))
+}
+
+fn baseline_lock() -> &'static Mutex<()> {
+    BASELINE_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::models::{DependencyBaselineStatus, DependencyChangeKind};
+
+    fn entry(name: &str, version: &str, scope: DependencyScope) -> DependencyEntry {
+        DependencyEntry {
+            ecosystem: Ecosystem::Node,
+            name: name.to_owned(),
+            version: version.to_owned(),
+            source: None,
+            scope,
+        }
+    }
+
+    fn report(entries: Vec<DependencyEntry>) -> DependencyReport {
+        DependencyReport {
+            ecosystem: Ecosystem::Node,
+            status: DependencyReportStatus::Complete,
+            manifest: Path::new("package.json").to_owned(),
+            manifest_format: Some("package.json".to_owned()),
+            lockfile: None,
+            direct_dependency_counts: BTreeMap::new(),
+            direct_dependency_total: 0,
+            resolved_dependency_count: crate::models::DependencyMetric::available(entries.len()),
+            transitive_dependency_count: crate::models::DependencyMetric::available(0),
+            duplicate_versions: Vec::new(),
+            resolved_dependencies: entries,
+            warnings: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn first_observation_creates_baseline_without_added_findings() {
+        let project = TempDir::new().unwrap();
+        let state = project.path().join("state.json");
+        let store = DependencyBaselineStore::new(&state);
+        let reports = vec![report(vec![entry(
+            "serde",
+            "1.0.0",
+            DependencyScope::Direct,
+        )])];
+
+        let diff = store.compare(project.path(), &reports).unwrap();
+
+        assert_eq!(
+            diff.baseline_status,
+            DependencyBaselineStatus::BaselineCreated
+        );
+        assert!(!diff.has_changes());
+        assert!(state.is_file());
+    }
+
+    #[test]
+    fn repeated_compare_is_empty_and_does_not_replace_baseline() {
+        let project = TempDir::new().unwrap();
+        let state = project.path().join("state.json");
+        let store = DependencyBaselineStore::new(&state);
+        let first = vec![report(vec![
+            entry("serde", "1.0.0", DependencyScope::Direct),
+            entry("syn", "2.0.0", DependencyScope::Transitive),
+        ])];
+        store.compare(project.path(), &first).unwrap();
+        let original = fs::read_to_string(&state).unwrap();
+
+        // Reversing the caller's order models lockfile key/format changes.
+        let second = vec![report(vec![
+            entry("syn", "2.0.0", DependencyScope::Transitive),
+            entry("serde", "1.0.0", DependencyScope::Direct),
+        ])];
+        let restarted_store = DependencyBaselineStore::new(&state);
+        let diff = restarted_store.compare(project.path(), &second).unwrap();
+
+        assert_eq!(diff.baseline_status, DependencyBaselineStatus::Compared);
+        assert!(!diff.has_changes());
+        assert_eq!(fs::read_to_string(state).unwrap(), original);
+    }
+
+    #[test]
+    fn added_removed_and_version_changes_are_distinguished() {
+        let project = TempDir::new().unwrap();
+        let state = project.path().join("state.json");
+        let store = DependencyBaselineStore::new(&state);
+        store
+            .compare(
+                project.path(),
+                &[report(vec![
+                    entry("removed", "1.0.0", DependencyScope::Direct),
+                    entry("changed", "1.0.0", DependencyScope::Direct),
+                ])],
+            )
+            .unwrap();
+
+        let diff = store
+            .compare(
+                project.path(),
+                &[report(vec![
+                    entry("added", "1.0.0", DependencyScope::Direct),
+                    entry("changed", "2.0.0", DependencyScope::Direct),
+                ])],
+            )
+            .unwrap();
+
+        assert_eq!(diff.added.len(), 1);
+        assert_eq!(diff.removed.len(), 1);
+        assert_eq!(diff.version_changes.len(), 1);
+        assert_eq!(
+            diff.version_changes[0].kind,
+            DependencyChangeKind::VersionChanged
+        );
+    }
+
+    #[test]
+    fn source_changes_require_source_data_on_both_sides() {
+        let project = TempDir::new().unwrap();
+        let state = project.path().join("state.json");
+        let store = DependencyBaselineStore::new(&state);
+        let mut old = entry("serde", "1.0.0", DependencyScope::Transitive);
+        old.source = Some("registry+old".to_owned());
+        store.compare(project.path(), &[report(vec![old])]).unwrap();
+
+        let mut new = entry("serde", "1.0.0", DependencyScope::Transitive);
+        new.source = Some("registry+new".to_owned());
+        let diff = store.compare(project.path(), &[report(vec![new])]).unwrap();
+
+        assert_eq!(diff.source_changes.len(), 1);
+        assert!(diff.version_changes.is_empty());
+    }
+
+    #[test]
+    fn accepting_updates_only_when_explicitly_requested() {
+        let project = TempDir::new().unwrap();
+        let state = project.path().join("state.json");
+        let store = DependencyBaselineStore::new(&state);
+        let old = vec![report(vec![entry("old", "1.0.0", DependencyScope::Direct)])];
+        store.compare(project.path(), &old).unwrap();
+        let new = vec![report(vec![entry("new", "1.0.0", DependencyScope::Direct)])];
+
+        assert!(store.compare(project.path(), &new).unwrap().has_changes());
+        store.accept(project.path(), &new).unwrap();
+        assert!(!store.compare(project.path(), &new).unwrap().has_changes());
+    }
+
+    #[test]
+    fn two_projects_with_the_same_package_name_are_isolated() {
+        let root = TempDir::new().unwrap();
+        let first = root.path().join("first");
+        let second = root.path().join("second");
+        fs::create_dir(&first).unwrap();
+        fs::create_dir(&second).unwrap();
+        let state = root.path().join("state.json");
+        let store = DependencyBaselineStore::new(&state);
+        let first_report = vec![report(vec![entry(
+            "same",
+            "1.0.0",
+            DependencyScope::Direct,
+        )])];
+        let second_report = vec![report(vec![entry(
+            "same",
+            "2.0.0",
+            DependencyScope::Direct,
+        )])];
+
+        store.compare(&first, &first_report).unwrap();
+        let diff = store.compare(&second, &second_report).unwrap();
+
+        assert_eq!(
+            diff.baseline_status,
+            DependencyBaselineStatus::BaselineCreated
+        );
+        assert!(!diff.has_changes());
+        assert_eq!(store.load().unwrap().projects.len(), 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_and_canonical_paths_share_a_baseline() {
+        let project = TempDir::new().unwrap();
+        let link_parent = TempDir::new().unwrap();
+        let link = link_parent.path().join("project");
+        std::os::unix::fs::symlink(project.path(), &link).unwrap();
+        let state = link_parent.path().join("state.json");
+        let store = DependencyBaselineStore::new(&state);
+        let reports = vec![report(vec![entry(
+            "same",
+            "1.0.0",
+            DependencyScope::Direct,
+        )])];
+
+        store.compare(project.path(), &reports).unwrap();
+        let diff = store.compare(&link, &reports).unwrap();
+
+        assert_eq!(diff.baseline_status, DependencyBaselineStatus::Compared);
+        assert!(!diff.has_changes());
+    }
+
+    #[test]
+    fn malformed_or_unsupported_state_is_rejected_without_replacement() {
+        let project = TempDir::new().unwrap();
+        let state = project.path().join("state.json");
+        fs::write(&state, r#"{"version":2,"projects":{}}"#).unwrap();
+        let store = DependencyBaselineStore::new(&state);
+
+        assert!(matches!(
+            store.load(),
+            Err(DustError::DependencyState(message)) if message.contains("version")
+        ));
+        assert_eq!(
+            fs::read_to_string(state).unwrap(),
+            r#"{"version":2,"projects":{}}"#
+        );
+    }
+}

--- a/crates/dustfril-core/src/dependency_baseline.rs
+++ b/crates/dustfril-core/src/dependency_baseline.rs
@@ -76,6 +76,13 @@ impl DependencyBaselineStore {
             .unwrap_or_else(|error| error.into_inner());
         let mut state = load_unlocked(&self.path)?;
 
+        if current.is_empty() {
+            let mut diff =
+                DependencyDiff::empty(workspace_id, DependencyBaselineStatus::Unavailable);
+            diff.warnings = warnings;
+            return Ok(diff);
+        }
+
         let Some(previous) = state.projects.get(&workspace_id).cloned() else {
             state
                 .projects
@@ -120,6 +127,12 @@ impl DependencyBaselineStore {
     pub fn accept(&self, workspace_root: &Path, reports: &[DependencyReport]) -> DustResult<()> {
         let workspace_id = workspace_id(workspace_root)?;
         let (current, _) = current_inventories(reports)?;
+        if current.is_empty() {
+            return Err(DustError::DependencyState(
+                "at least one complete dependency inventory is required to accept a baseline"
+                    .to_owned(),
+            ));
+        }
         let _guard = baseline_lock()
             .lock()
             .unwrap_or_else(|error| error.into_inner());
@@ -183,13 +196,6 @@ fn current_inventories(reports: &[DependencyReport]) -> DustResult<(Inventories,
                 .or_insert_with(|| entry.clone());
         }
         inventories.insert(report.ecosystem, entries.into_values().collect());
-    }
-
-    if inventories.is_empty() {
-        return Err(DustError::DependencyState(
-            "at least one complete dependency inventory is required to compare or accept a baseline"
-                .to_owned(),
-        ));
     }
 
     warnings.sort();
@@ -437,7 +443,7 @@ fn save_unlocked(path: &Path, state: &DependencyBaselineState) -> DustResult<()>
             .open(&temporary_path)?;
         file.write_all(json.as_bytes())?;
         file.sync_all()?;
-        fs::rename(&temporary_path, path)
+        replace_file(&temporary_path, path)
     })();
 
     if let Err(error) = write_result {
@@ -446,6 +452,46 @@ fn save_unlocked(path: &Path, state: &DependencyBaselineState) -> DustResult<()>
     }
 
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    fs::rename(source, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+
+    let source = source
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let destination = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+
+    // SAFETY: both buffers are null-terminated UTF-16 paths that remain alive
+    // for the duration of the call, and the flags request replacement with a
+    // write-through move so an existing destination is replaced atomically.
+    let result = unsafe {
+        MoveFileExW(
+            source.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 fn temporary_path(path: &Path) -> PathBuf {
@@ -552,6 +598,29 @@ mod tests {
     }
 
     #[test]
+    fn saving_replaces_an_existing_baseline_file() {
+        let project = TempDir::new().unwrap();
+        let state = project.path().join("state.json");
+        let store = DependencyBaselineStore::new(&state);
+        let first = DependencyBaselineState::default();
+        store.save(&first).unwrap();
+
+        let workspace_id = "v1:test-workspace".to_owned();
+        let mut second = first;
+        second.projects.insert(
+            workspace_id.clone(),
+            DependencyBaseline {
+                workspace_id,
+                inventories: BTreeMap::new(),
+            },
+        );
+        store.save(&second).unwrap();
+
+        assert_eq!(store.load().unwrap(), second);
+        assert_eq!(fs::read_dir(project.path()).unwrap().count(), 1);
+    }
+
+    #[test]
     fn added_removed_and_version_changes_are_distinguished() {
         let project = TempDir::new().unwrap();
         let state = project.path().join("state.json");
@@ -614,6 +683,47 @@ mod tests {
         assert!(store.compare(project.path(), &new).unwrap().has_changes());
         store.accept(project.path(), &new).unwrap();
         assert!(!store.compare(project.path(), &new).unwrap().has_changes());
+    }
+
+    #[test]
+    fn incomplete_inventory_returns_warnings_without_changing_the_baseline() {
+        let project = TempDir::new().unwrap();
+        let state = project.path().join("state.json");
+        let store = DependencyBaselineStore::new(&state);
+        let mut missing = report(Vec::new());
+        missing.status = DependencyReportStatus::MissingLockfile;
+        missing.warnings = vec!["package-lock.json is missing".to_owned()];
+
+        let first = store.compare(project.path(), &[missing.clone()]).unwrap();
+        assert_eq!(first.baseline_status, DependencyBaselineStatus::Unavailable);
+        assert_eq!(
+            first.warnings,
+            vec!["Node dependency baseline comparison skipped: package-lock.json is missing"]
+        );
+        assert!(!state.exists());
+
+        store
+            .compare(
+                project.path(),
+                &[report(vec![entry(
+                    "existing",
+                    "1.0.0",
+                    DependencyScope::Direct,
+                )])],
+            )
+            .unwrap();
+        let original = fs::read_to_string(&state).unwrap();
+
+        let second = store.compare(project.path(), &[missing]).unwrap();
+        assert_eq!(
+            second.baseline_status,
+            DependencyBaselineStatus::Unavailable
+        );
+        assert_eq!(
+            second.warnings,
+            vec!["Node dependency baseline comparison skipped: package-lock.json is missing"]
+        );
+        assert_eq!(fs::read_to_string(state).unwrap(), original);
     }
 
     #[test]

--- a/crates/dustfril-core/src/error.rs
+++ b/crates/dustfril-core/src/error.rs
@@ -19,6 +19,8 @@ pub enum DustError {
     Manifest(String),
     /// Indicates that the persisted executable-integrity state is invalid.
     IntegrityState(String),
+    /// Indicates that the persisted dependency-baseline state is invalid.
+    DependencyState(String),
 }
 
 /// Standard result type used by the core crate.
@@ -50,6 +52,9 @@ impl fmt::Display for DustError {
             }
             DustError::IntegrityState(message) => {
                 write!(f, "Executable integrity state error: {message}")
+            }
+            DustError::DependencyState(message) => {
+                write!(f, "Dependency baseline state error: {message}")
             }
         }
     }

--- a/crates/dustfril-core/src/lib.rs
+++ b/crates/dustfril-core/src/lib.rs
@@ -6,6 +6,7 @@ mod analyzer;
 mod audit_tool;
 mod cleaner;
 mod dependency;
+mod dependency_baseline;
 mod fs;
 mod history;
 mod integrity;

--- a/crates/dustfril-core/src/models/dependency.rs
+++ b/crates/dustfril-core/src/models/dependency.rs
@@ -186,6 +186,9 @@ pub enum DependencyBaselineStatus {
     /// A prior baseline was compared and remains unchanged until explicitly
     /// accepted by the caller.
     Compared,
+    /// No complete inventory was available, so no baseline was read or
+    /// modified.
+    Unavailable,
 }
 
 impl fmt::Display for DependencyBaselineStatus {
@@ -193,6 +196,7 @@ impl fmt::Display for DependencyBaselineStatus {
         let value = match self {
             Self::BaselineCreated => "Baseline created",
             Self::Compared => "Compared",
+            Self::Unavailable => "Unavailable",
         };
 
         f.write_str(value)

--- a/crates/dustfril-core/src/models/dependency.rs
+++ b/crates/dustfril-core/src/models/dependency.rs
@@ -139,6 +139,166 @@ pub struct DuplicateDependency {
     pub versions: Vec<String>,
 }
 
+/// Whether a resolved dependency is directly declared, transitive, or cannot
+/// be classified reliably by the selected lockfile format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DependencyScope {
+    Direct,
+    Transitive,
+    Unknown,
+}
+
+impl fmt::Display for DependencyScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Direct => "Direct",
+            Self::Transitive => "Transitive",
+            Self::Unknown => "Unknown",
+        };
+
+        f.write_str(value)
+    }
+}
+
+/// A normalized logical dependency entry used by reports and baselines.
+///
+/// The dependency identity is `(ecosystem, name, version, source)`. A
+/// lockfile location is intentionally not included, so ordering and layout
+/// changes do not create false changes.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyEntry {
+    pub ecosystem: Ecosystem,
+    pub name: String,
+    pub version: String,
+    /// Registry/source identifier when the parser can obtain it reliably.
+    pub source: Option<String>,
+    pub scope: DependencyScope,
+}
+
+/// State of the explicit baseline used for a dependency comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DependencyBaselineStatus {
+    /// No prior baseline existed; the current inventory was stored.
+    BaselineCreated,
+    /// A prior baseline was compared and remains unchanged until explicitly
+    /// accepted by the caller.
+    Compared,
+}
+
+impl fmt::Display for DependencyBaselineStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::BaselineCreated => "Baseline created",
+            Self::Compared => "Compared",
+        };
+
+        f.write_str(value)
+    }
+}
+
+/// The kind of logical dependency change found between two baselines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DependencyChangeKind {
+    Added,
+    Removed,
+    VersionChanged,
+    SourceChanged,
+}
+
+impl fmt::Display for DependencyChangeKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Added => "Added",
+            Self::Removed => "Removed",
+            Self::VersionChanged => "Version changed",
+            Self::SourceChanged => "Source changed",
+        };
+
+        f.write_str(value)
+    }
+}
+
+/// One deterministic dependency change. Added entries have only `current`,
+/// removed entries only `previous`, and replacement changes have both.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyChange {
+    pub kind: DependencyChangeKind,
+    pub previous: Option<DependencyEntry>,
+    pub current: Option<DependencyEntry>,
+}
+
+/// Structured result of comparing a current inventory with an explicit local
+/// baseline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyDiff {
+    /// Stable identity derived from the canonical workspace root.
+    pub workspace_id: String,
+    pub baseline_status: DependencyBaselineStatus,
+    pub added: Vec<DependencyChange>,
+    pub removed: Vec<DependencyChange>,
+    pub version_changes: Vec<DependencyChange>,
+    pub source_changes: Vec<DependencyChange>,
+    pub warnings: Vec<String>,
+}
+
+impl DependencyDiff {
+    pub fn empty(
+        workspace_id: impl Into<String>,
+        baseline_status: DependencyBaselineStatus,
+    ) -> Self {
+        Self {
+            workspace_id: workspace_id.into(),
+            baseline_status,
+            added: Vec::new(),
+            removed: Vec::new(),
+            version_changes: Vec::new(),
+            source_changes: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Returns whether the comparison found any logical dependency changes.
+    pub fn has_changes(&self) -> bool {
+        !self.added.is_empty()
+            || !self.removed.is_empty()
+            || !self.version_changes.is_empty()
+            || !self.source_changes.is_empty()
+    }
+}
+
+/// Versioned local state containing one inventory per observed ecosystem and
+/// workspace. Only normalized dependency data is persisted.
+pub const DEPENDENCY_BASELINE_STATE_VERSION: u32 = 1;
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyBaseline {
+    pub workspace_id: String,
+    pub inventories: BTreeMap<Ecosystem, Vec<DependencyEntry>>,
+}
+
+/// On-disk dependency baseline collection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyBaselineState {
+    pub version: u32,
+    pub projects: BTreeMap<String, DependencyBaseline>,
+}
+
+impl Default for DependencyBaselineState {
+    fn default() -> Self {
+        Self {
+            version: DEPENDENCY_BASELINE_STATE_VERSION,
+            projects: BTreeMap::new(),
+        }
+    }
+}
+
 /// Structured dependency inventory for one supported ecosystem.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DependencyReport {
@@ -166,6 +326,8 @@ pub struct DependencyReport {
     pub transitive_dependency_count: DependencyMetric,
     /// Packages with more than one distinct resolved version.
     pub duplicate_versions: Vec<DuplicateDependency>,
+    /// Normalized resolved dependency entries reused by baseline comparison.
+    pub resolved_dependencies: Vec<DependencyEntry>,
     /// Non-fatal scope or availability notes.
     pub warnings: Vec<String>,
 }
@@ -187,6 +349,7 @@ impl DependencyReport {
             resolved_dependency_count: DependencyMetric::unsupported(reason.clone()),
             transitive_dependency_count: DependencyMetric::unsupported(reason.clone()),
             duplicate_versions: Vec::new(),
+            resolved_dependencies: Vec::new(),
             warnings: vec![reason],
         }
     }

--- a/crates/dustfril-core/src/models/scan.rs
+++ b/crates/dustfril-core/src/models/scan.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 /// Supported project ecosystems.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Ecosystem {
     Rust,
     Node,


### PR DESCRIPTION
## Summary

- add normalized dependency entries to the Core inventory for baseline reuse
- add versioned, atomic local dependency baseline storage isolated by canonical workspace path
- report deterministic Added, Removed, VersionChanged, and supported SourceChanged results
- preserve Direct/Transitive/Unknown scope without guessing unsupported formats
- add CLI comparison and explicit baseline acceptance flags
- document baseline semantics and moved/symlink workspace behavior

The first complete observation creates a baseline without reporting all existing dependencies as Added. Comparisons do not replace an existing baseline; `--accept-baseline` or `api::accept_dependency_baseline` performs the explicit update.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (179 Core tests, 24 CLI tests, 12 Tauri tests)
- `cargo llvm-cov --workspace --all-features --summary-only`
- `git diff --check`

Closes #66
