### PR TITLE
feat: record bounded scan access summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Clean artifacts with Trash or permanent deletion mode
 - Audit Node lifecycle scripts such as `preinstall` and `postinstall`
 - Persist versioned local activity history for scans, cleanup, and explicit security scans (including legacy cleanup history migration)
+- Record a bounded access summary for each explicit artifact scan
 - Run an offline supply-chain security scan for Node and Rust projects
 - Report deterministic Node and Rust dependency inventory from manifests and lockfiles
 - Compare dependency inventories with explicit local baselines and report added, removed, version, and supported source changes
@@ -34,6 +35,13 @@ Scans reject missing, symbolic-link, or non-directory roots and report
 filesystem traversal errors. Cleanup only accepts real artifact directories,
 refuses symbolic links and protected paths, and reports Trash failures without
 permanently deleting the candidate as a fallback.
+
+Each explicit artifact scan collects its access summary during the existing
+traversal and stores it in the corresponding local Scan activity record. The
+summary includes visited directories, supported metadata files actually
+inspected, discovered artifact candidates, skipped symbolic links, and a total
+failure count with at most eight representative failure samples. Unrelated
+source files are not read or listed, and no per-file access log is created.
 
 ## Detected Artifacts
 

--- a/apps/dustfril-cli/src/commands/analyze.rs
+++ b/apps/dustfril-cli/src/commands/analyze.rs
@@ -74,8 +74,17 @@ pub fn execute(args: PathArgs) -> bool {
     let scan_result = match api::scan(&path, &ecosystems) {
         Ok(res) => res,
         Err(e) => {
-            if let Err(history_error) = history::record_scan_failure(&path, &e.to_string()) {
+            let history_result = match e.scan_access_summary() {
+                Some(summary) => {
+                    history::record_scan_failure_with_summary(&path, &e.to_string(), summary)
+                }
+                None => history::record_scan_failure(&path, &e.to_string()),
+            };
+            if let Err(history_error) = history_result {
                 eprintln!("Failed to record scan failure history: {history_error}");
+            }
+            if let Some(summary) = e.scan_access_summary() {
+                format::print_scan_access_summary(summary);
             }
             eprintln!("Scan failed: {}", e);
             return false;

--- a/apps/dustfril-cli/src/commands/analyze.rs
+++ b/apps/dustfril-cli/src/commands/analyze.rs
@@ -96,6 +96,8 @@ pub fn execute(args: PathArgs) -> bool {
         eprintln!("Failed to record scan history: {error}");
     }
 
+    format::print_scan_access_summary(&scan_result.access_summary);
+
     if analysis_result.artifacts.is_empty() {
         println!("No artifacts found.");
         return true;

--- a/apps/dustfril-cli/src/commands/scan.rs
+++ b/apps/dustfril-cli/src/commands/scan.rs
@@ -2,7 +2,7 @@ use dustfril_core::api;
 
 use crate::{
     cli::PathArgs,
-    history,
+    format, history,
     shared::path::{resolve_path, validate_path},
 };
 
@@ -43,6 +43,8 @@ pub fn execute(args: PathArgs) -> bool {
             eprintln!("Failed to calculate scan size; history was not recorded: {error}");
         }
     }
+
+    format::print_scan_access_summary(&result.access_summary);
 
     if result.artifacts.is_empty() {
         println!("No artifacts found.");

--- a/apps/dustfril-cli/src/commands/scan.rs
+++ b/apps/dustfril-cli/src/commands/scan.rs
@@ -24,8 +24,17 @@ pub fn execute(args: PathArgs) -> bool {
     let result = match api::scan(&path, &ecosystems) {
         Ok(res) => res,
         Err(e) => {
-            if let Err(history_error) = history::record_scan_failure(&path, &e.to_string()) {
+            let history_result = match e.scan_access_summary() {
+                Some(summary) => {
+                    history::record_scan_failure_with_summary(&path, &e.to_string(), summary)
+                }
+                None => history::record_scan_failure(&path, &e.to_string()),
+            };
+            if let Err(history_error) = history_result {
                 eprintln!("Failed to record scan failure history: {history_error}");
+            }
+            if let Some(summary) = e.scan_access_summary() {
+                format::print_scan_access_summary(summary);
             }
             eprintln!("Scan failed: {}", e);
             return false;

--- a/apps/dustfril-cli/src/format/mod.rs
+++ b/apps/dustfril-cli/src/format/mod.rs
@@ -1,6 +1,7 @@
 pub mod audit_format;
 pub mod dependency_format;
 pub mod integrity_format;
+pub mod scan_format;
 pub mod security_format;
 pub mod size_format;
 pub mod time_format;
@@ -9,6 +10,7 @@ pub mod workflow_security_format;
 pub use audit_format::*;
 pub use dependency_format::*;
 pub use integrity_format::*;
+pub use scan_format::*;
 pub use security_format::*;
 pub use size_format::*;
 pub use time_format::*;

--- a/apps/dustfril-cli/src/format/scan_format.rs
+++ b/apps/dustfril-cli/src/format/scan_format.rs
@@ -1,0 +1,35 @@
+use dustfril_core::models::ScanAccessSummary;
+
+/// Prints the bounded access scope collected during an explicit artifact scan.
+pub fn print_scan_access_summary(summary: &ScanAccessSummary) {
+    println!("\nScan Access Summary");
+    println!("  Workspace:                    {}", summary.root.display());
+    println!(
+        "  Directories visited:          {}",
+        summary.directories_visited
+    );
+    println!(
+        "  Files inspected:              {}",
+        summary.files_inspected
+    );
+    println!(
+        "  Manifest/metadata files:      {}",
+        summary.metadata_files_inspected
+    );
+    println!(
+        "  Artifact candidates:          {}",
+        summary.artifact_candidates
+    );
+    println!(
+        "  Symlinks skipped:             {}",
+        summary.symlinks_skipped
+    );
+    println!("  Traversal/read failures:      {}", summary.failures);
+
+    if !summary.failure_samples.is_empty() {
+        println!("  Representative failures:");
+        for failure in &summary.failure_samples {
+            println!("    {}: {}", failure.path.display(), failure.reason);
+        }
+    }
+}

--- a/apps/dustfril-cli/src/history.rs
+++ b/apps/dustfril-cli/src/history.rs
@@ -12,6 +12,15 @@ pub fn record_scan_failure(target_path: &std::path::Path, reason: &str) -> std::
         .map_err(|error| std::io::Error::other(error.to_string()))
 }
 
+pub fn record_scan_failure_with_summary(
+    target_path: &std::path::Path,
+    reason: &str,
+    access_summary: &dustfril_core::models::ScanAccessSummary,
+) -> std::io::Result<()> {
+    api::history::record_scan_failure_with_summary(target_path, reason, access_summary)
+        .map_err(|error| std::io::Error::other(error.to_string()))
+}
+
 pub fn record_cleanup_failure(
     mode: dustfril_core::models::DeleteMode,
     reason: &str,

--- a/apps/dustfril-tauri/src-tauri/src/contract.rs
+++ b/apps/dustfril-tauri/src-tauri/src/contract.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 pub(crate) struct RunOptions {
     pub(crate) root: Option<String>,
     pub(crate) ecosystems: Vec<EcosystemDto>,
+    #[serde(default)]
+    pub(crate) record_history: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -50,6 +52,8 @@ pub(crate) struct ArtifactDto {
 pub(crate) struct AnalysisResponse {
     pub(crate) artifacts: Vec<ArtifactAnalysisDto>,
     pub(crate) total_size_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) history_warning: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -427,6 +431,15 @@ mod tests {
             options.ecosystems,
             vec![EcosystemDto::Rust, EcosystemDto::Node, EcosystemDto::Java]
         );
+        assert_eq!(options.record_history, None);
+
+        let explicit_analysis_options: RunOptions = serde_json::from_value(json!({
+            "root": "/workspace",
+            "ecosystems": ["Rust"],
+            "recordHistory": true
+        }))
+        .unwrap();
+        assert_eq!(explicit_analysis_options.record_history, Some(true));
     }
 
     #[test]
@@ -459,6 +472,7 @@ mod tests {
                 recommendation: RecommendationDto::SafeToClean,
             }],
             total_size_bytes: 42,
+            history_warning: None,
         };
 
         assert_eq!(
@@ -645,6 +659,11 @@ mod tests {
             freed_size_bytes: 0,
             history_warning: Some("history is unavailable".to_owned()),
         };
+        let analysis = AnalysisResponse {
+            artifacts: Vec::new(),
+            total_size_bytes: 0,
+            history_warning: Some("history is unavailable".to_owned()),
+        };
 
         assert_eq!(
             serde_json::to_value(scan).unwrap(),
@@ -656,6 +675,14 @@ mod tests {
                 "deletedPaths": [],
                 "failedPaths": [],
                 "freedSizeBytes": 0,
+                "historyWarning": "history is unavailable"
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(analysis).unwrap(),
+            json!({
+                "artifacts": [],
+                "totalSizeBytes": 0,
                 "historyWarning": "history is unavailable"
             })
         );

--- a/apps/dustfril-tauri/src-tauri/src/history.rs
+++ b/apps/dustfril-tauri/src-tauri/src/history.rs
@@ -40,6 +40,16 @@ pub fn record_scan_failure(target_path: &Path, reason: &str) -> Result<(), Strin
     api::history::record_scan_failure(target_path, reason).map_err(|error| error.to_string())
 }
 
+/// Records a failed scan together with its bounded partial access summary.
+pub fn record_scan_failure_with_summary(
+    target_path: &Path,
+    reason: &str,
+    access_summary: &dustfril_core::models::ScanAccessSummary,
+) -> Result<(), String> {
+    api::history::record_scan_failure_with_summary(target_path, reason, access_summary)
+        .map_err(|error| error.to_string())
+}
+
 /// Records a cleanup that failed before producing a cleanup result.
 pub fn record_cleanup_failure(mode: DeleteMode, reason: &str) -> Result<(), String> {
     api::history::record_cleanup_failure(mode, reason).map_err(|error| error.to_string())

--- a/apps/dustfril-tauri/src-tauri/src/lib.rs
+++ b/apps/dustfril-tauri/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ use contract::{
 };
 use dustfril_core::{
     api,
+    error::DustError,
     models::{CleanupCandidate, CleanupPlan},
 };
 
@@ -71,6 +72,19 @@ fn report_failed_activity_record(operation: &str, error: impl Display) {
     let _ = format_history_warning(operation, error);
 }
 
+fn record_failed_scan_activity(root: &Path, error: &DustError) {
+    let result = match error.scan_access_summary() {
+        Some(summary) => {
+            history::record_scan_failure_with_summary(root, &error.to_string(), summary)
+        }
+        None => history::record_scan_failure(root, &error.to_string()),
+    };
+
+    if let Err(history_error) = result {
+        report_failed_activity_record("scan", history_error);
+    }
+}
+
 #[tauri::command]
 async fn default_root() -> Result<String, String> {
     tokio::task::spawn_blocking(|| default_root_path().map(|path| path.display().to_string()))
@@ -87,10 +101,7 @@ async fn scan(options: RunOptions) -> Result<ScanResponse, String> {
         let result = match api::scan(&root, &ecosystems) {
             Ok(result) => result,
             Err(error) => {
-                if let Err(history_error) = history::record_scan_failure(&root, &error.to_string())
-                {
-                    report_failed_activity_record("scan", history_error);
-                }
+                record_failed_scan_activity(&root, &error);
                 return Err(error.to_string());
             }
         };
@@ -131,15 +142,33 @@ async fn scan(options: RunOptions) -> Result<ScanResponse, String> {
 
 #[tauri::command]
 async fn analyze(options: RunOptions) -> Result<AnalysisResponse, String> {
+    let record_history = options.record_history.unwrap_or(false);
     let root = resolve_root(options.root)?;
     let ecosystems: Vec<_> = options.ecosystems.into_iter().map(Into::into).collect();
 
     tokio::task::spawn_blocking(move || {
-        let scan_result = api::scan(&root, &ecosystems).map_err(|error| error.to_string())?;
-        let analysis = api::analyze(scan_result).map_err(|error| error.to_string())?;
+        let scan_result = match api::scan(&root, &ecosystems) {
+            Ok(result) => result,
+            Err(error) => {
+                if record_history {
+                    record_failed_scan_activity(&root, &error);
+                }
+                return Err(error.to_string());
+            }
+        };
+        let analysis = api::analyze(scan_result.clone()).map_err(|error| error.to_string())?;
+        let history_warning = if record_history {
+            match history::record_scan(&root, &scan_result, analysis.total_size_bytes) {
+                Ok(()) => None,
+                Err(error) => Some(format_history_warning("scan", error)),
+            }
+        } else {
+            None
+        };
 
         Ok(AnalysisResponse {
             total_size_bytes: analysis.total_size_bytes,
+            history_warning,
             artifacts: analysis
                 .artifacts
                 .into_iter()

--- a/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
+++ b/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
@@ -1,4 +1,4 @@
-import type { ActivityRecord } from '../../types/workflow';
+import type { ActivityDetails, ActivityRecord } from '../../types/workflow';
 import { formatBytes, formatDate } from '../../lib/format';
 import { EmptyState } from '../EmptyState/EmptyState';
 
@@ -57,8 +57,43 @@ function ScanDetails({ entry }: { entry: ActivityRecord }) {
         <Detail label="Artifacts" value={String(details.artifacts ?? 0)} />
         <Detail label="Total Size" value={formatBytes(details.size ?? 0)} />
       </div>
+      {details.accessSummary ? <ScanAccessDetails summary={details.accessSummary} /> : null}
       {details.reason ? <p className="mt-4 text-sm text-rose-200">{details.reason}</p> : null}
     </>
+  );
+}
+
+function ScanAccessDetails({
+  summary,
+}: {
+  summary: NonNullable<ActivityDetails['accessSummary']>;
+}) {
+  return (
+    <div className="mt-4 rounded-2xl border border-white/6 bg-white/4 p-3">
+      <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Scan Access Summary</p>
+      <div className="mt-2 grid gap-2 text-sm text-slate-300 sm:grid-cols-3">
+        <Detail label="Directories" value={String(summary.directoriesVisited)} />
+        <Detail label="Files Inspected" value={String(summary.filesInspected)} />
+        <Detail label="Metadata Files" value={String(summary.metadataFilesInspected)} />
+        <Detail label="Artifact Candidates" value={String(summary.artifactCandidates)} />
+        <Detail label="Symlinks Skipped" value={String(summary.symlinksSkipped)} />
+        <Detail label="Failures" value={String(summary.failures)} />
+      </div>
+      {summary.failureSamples.length ? (
+        <div className="mt-3">
+          <p className="text-xs uppercase tracking-[0.14em] text-slate-500">
+            Representative Failures
+          </p>
+          <ul className="mt-2 space-y-1 text-sm text-rose-200">
+            {summary.failureSamples.map((failure) => (
+              <li key={`${failure.path}-${failure.reason}`} className="truncate">
+                {failure.path}: {failure.reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
@@ -309,7 +309,9 @@ export function useAppState() {
 
   async function handleAnalyzeCategory() {
     await runAction('analyze', async () => {
-      setAnalysisResult(await analyzeArtifacts(runOptions));
+      const analysis = await analyzeArtifacts({ ...runOptions, recordHistory: true });
+      setAnalysisResult(analysis);
+      setError(analysis.historyWarning ?? null);
       setHistoryEntries(await loadActivityHistory());
       setExplorerWorkflow('analysis');
     });

--- a/apps/dustfril-tauri/src/types/workflow.ts
+++ b/apps/dustfril-tauri/src/types/workflow.ts
@@ -33,6 +33,7 @@ export type ArtifactAnalysis = {
 export type AnalysisResponse = {
   artifacts: ArtifactAnalysis[];
   totalSizeBytes: number;
+  historyWarning?: string;
 };
 
 export type CleanupCandidate = {
@@ -162,6 +163,7 @@ export type ActivityRecord = {
 export type RunOptions = {
   root: string;
   ecosystems: Ecosystem[];
+  recordHistory?: boolean;
 };
 
 export const ecosystems: Ecosystem[] = ['Rust', 'Node', 'Java'];

--- a/apps/dustfril-tauri/src/types/workflow.ts
+++ b/apps/dustfril-tauri/src/types/workflow.ts
@@ -104,10 +104,27 @@ export type ActivityFailure = {
   reason?: string;
 };
 
+export type ScanAccessFailure = {
+  path: string;
+  reason: string;
+};
+
+export type ScanAccessSummary = {
+  root: string;
+  directoriesVisited: number;
+  filesInspected: number;
+  metadataFilesInspected: number;
+  artifactCandidates: number;
+  symlinksSkipped: number;
+  failures: number;
+  failureSamples: ScanAccessFailure[];
+};
+
 export type ActivityDetails = {
   path?: string;
   artifacts?: number;
   size?: number;
+  accessSummary?: ScanAccessSummary;
   mode?: 'trash' | 'permanent';
   deleted?: string[];
   failed?: ActivityFailure[];

--- a/crates/dustfril-core/src/analyzer/tests.rs
+++ b/crates/dustfril-core/src/analyzer/tests.rs
@@ -7,6 +7,7 @@ use crate::{analyzer::Analyzer, models::*};
 fn scan_result(path: PathBuf, ecosystem: Ecosystem) -> ScanResult {
     ScanResult {
         artifacts: vec![Artifact { path, ecosystem }],
+        ..ScanResult::default()
     }
 }
 
@@ -98,6 +99,7 @@ fn analyze_multiple_artifacts() {
                 ecosystem: Ecosystem::Node,
             },
         ],
+        ..ScanResult::default()
     })
     .unwrap();
 

--- a/crates/dustfril-core/src/api/analyze.rs
+++ b/crates/dustfril-core/src/api/analyze.rs
@@ -24,6 +24,7 @@ mod tests {
                 temp_dir.path().to_path_buf(),
                 Ecosystem::Rust,
             )],
+            ..ScanResult::default()
         };
 
         let result = analyze(scan_result).unwrap();

--- a/crates/dustfril-core/src/api/clean.rs
+++ b/crates/dustfril-core/src/api/clean.rs
@@ -36,6 +36,7 @@ mod tests {
                 temp_dir.path().to_path_buf(),
                 Ecosystem::Rust,
             )],
+            ..ScanResult::default()
         };
 
         let plan = build_plan(scan).unwrap();
@@ -52,6 +53,7 @@ mod tests {
                 temp_dir.path().to_path_buf(),
                 Ecosystem::Rust,
             )],
+            ..ScanResult::default()
         };
 
         let analysis = crate::api::analyze(scan).unwrap();

--- a/crates/dustfril-core/src/api/history.rs
+++ b/crates/dustfril-core/src/api/history.rs
@@ -4,8 +4,8 @@ use crate::{
     error::DustResult,
     history,
     models::{
-        ActivityRecord, CleanupHistoryEntry, CleanupResult, DeleteMode, Ecosystem, ScanResult,
-        SecurityReport,
+        ActivityRecord, CleanupHistoryEntry, CleanupResult, DeleteMode, Ecosystem,
+        ScanAccessSummary, ScanResult, SecurityReport,
     },
 };
 
@@ -36,6 +36,15 @@ pub fn record_scan(
 /// Records a scan that failed before producing a scan result.
 pub fn record_scan_failure(target_path: &Path, reason: &str) -> DustResult<()> {
     history::record_scan_failure(target_path, reason)
+}
+
+/// Records a failed scan together with its bounded partial access summary.
+pub fn record_scan_failure_with_summary(
+    target_path: &Path,
+    reason: &str,
+    access_summary: &ScanAccessSummary,
+) -> DustResult<()> {
+    history::record_scan_failure_with_summary(target_path, reason, access_summary)
 }
 
 /// Records a cleanup that failed before producing a cleanup result.

--- a/crates/dustfril-core/src/error.rs
+++ b/crates/dustfril-core/src/error.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::models::ScanAccessSummary;
+
 /// Errors returned by the core scanning, analysis, and cleanup APIs.
 #[derive(Debug)]
 pub enum DustError {
@@ -9,6 +11,12 @@ pub enum DustError {
     InvalidPath(std::path::PathBuf),
     /// Indicates an unrecoverable scan failure.
     ScanFailed,
+    /// Indicates a scan failure with the partial access summary collected
+    /// before traversal stopped.
+    ScanAccess {
+        source: Box<Self>,
+        access_summary: ScanAccessSummary,
+    },
     /// Indicates an unrecoverable analysis failure.
     AnalysisFailed,
     /// Indicates an unrecoverable cleanup failure.
@@ -40,6 +48,7 @@ impl fmt::Display for DustError {
             DustError::ScanFailed => {
                 write!(f, "Scan failed")
             }
+            DustError::ScanAccess { source, .. } => source.fmt(f),
             DustError::AnalysisFailed => {
                 write!(f, "Analysis failed")
             }
@@ -69,6 +78,17 @@ impl std::error::Error for DustError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io(error) => Some(error),
+            Self::ScanAccess { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl DustError {
+    /// Returns the partial access summary attached to a failed scan, if any.
+    pub fn scan_access_summary(&self) -> Option<&ScanAccessSummary> {
+        match self {
+            Self::ScanAccess { access_summary, .. } => Some(access_summary),
             _ => None,
         }
     }
@@ -118,5 +138,18 @@ mod tests {
         let error = DustError::Manifest("package.json is invalid".to_owned());
 
         assert_eq!(error.to_string(), "Manifest error: package.json is invalid");
+    }
+
+    #[test]
+    fn scan_access_error_preserves_source_and_summary() {
+        let summary = ScanAccessSummary::new("/workspace");
+        let error = DustError::ScanAccess {
+            source: Box::new(DustError::Io(io::Error::other("permission denied"))),
+            access_summary: summary.clone(),
+        };
+
+        assert_eq!(error.to_string(), "I/O error: permission denied");
+        assert!(std::error::Error::source(&error).is_some());
+        assert_eq!(error.scan_access_summary(), Some(&summary));
     }
 }

--- a/crates/dustfril-core/src/fs/walk.rs
+++ b/crates/dustfril-core/src/fs/walk.rs
@@ -4,13 +4,29 @@ use std::{
 };
 use walkdir::WalkDir;
 
-use crate::error::{DustError, DustResult};
+use crate::{
+    error::{DustError, DustResult},
+    models::ScanAccessSummary,
+};
 
 /// Collect all directories in a filesystem tree.
 ///
 /// Invalid or symbolic-link roots and traversal errors are returned instead of
 /// being silently omitted from the result.
 pub fn walk_dirs(root: &Path) -> DustResult<Vec<PathBuf>> {
+    walk_dirs_with_summary(root, &mut ScanAccessSummary::default())
+}
+
+/// Collects directories while recording traversal access in an existing
+/// scan-level summary.
+///
+/// The traversal does not follow symbolic links. A traversal error remains an
+/// error, preserving the scanner's existing failure semantics, but is added to
+/// the in-memory summary before it is returned.
+pub fn walk_dirs_with_summary(
+    root: &Path,
+    summary: &mut ScanAccessSummary,
+) -> DustResult<Vec<PathBuf>> {
     match fs::symlink_metadata(root) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
             return Err(DustError::InvalidPath(root.to_path_buf()));
@@ -23,17 +39,36 @@ pub fn walk_dirs(root: &Path) -> DustResult<Vec<PathBuf>> {
         Err(error) => return Err(DustError::Io(error)),
     }
 
-    WalkDir::new(root)
-        .into_iter()
-        .map(|entry| {
-            let entry = entry.map_err(|error| DustError::Io(io::Error::other(error)))?;
-            Ok(entry
-                .file_type()
-                .is_dir()
-                .then(|| entry.path().to_path_buf()))
-        })
-        .filter_map(|entry| entry.transpose())
-        .collect()
+    let mut directories = Vec::new();
+
+    for entry in WalkDir::new(root).into_iter() {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                let reason = error.to_string();
+                if let Some(path) = error.path() {
+                    summary.record_failure(path, &reason);
+                } else {
+                    summary.record_failure(root, &reason);
+                }
+                return Err(DustError::Io(io::Error::other(error)));
+            }
+        };
+
+        let file_type = entry.file_type();
+
+        if file_type.is_symlink() {
+            summary.record_symlink_skipped();
+            continue;
+        }
+
+        if file_type.is_dir() {
+            summary.record_directory();
+            directories.push(entry.path().to_path_buf());
+        }
+    }
+
+    Ok(directories)
 }
 
 #[cfg(test)]
@@ -53,6 +88,20 @@ mod tests {
         assert!(dirs.iter().any(|path| path == temp_dir.path()));
         assert!(dirs.iter().any(|path| path == &temp_dir.path().join("a")));
         assert!(dirs.iter().any(|path| path == &nested));
+    }
+
+    #[test]
+    fn walk_dirs_with_summary_counts_visited_directories() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::create_dir(temp_dir.path().join("nested")).unwrap();
+        let mut summary = ScanAccessSummary::new(temp_dir.path());
+
+        let dirs = walk_dirs_with_summary(temp_dir.path(), &mut summary).unwrap();
+
+        assert_eq!(dirs.len(), 2);
+        assert_eq!(summary.directories_visited, 2);
+        assert_eq!(summary.symlinks_skipped, 0);
+        assert_eq!(summary.failures, 0);
     }
 
     #[test]
@@ -93,5 +142,22 @@ mod tests {
             walk_dirs(&link),
             Err(DustError::InvalidPath(path)) if path == link
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_dirs_with_summary_counts_skipped_symbolic_links() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = TempDir::new().unwrap();
+        let target = temp_dir.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, temp_dir.path().join("link")).unwrap();
+        let mut summary = ScanAccessSummary::new(temp_dir.path());
+
+        walk_dirs_with_summary(temp_dir.path(), &mut summary).unwrap();
+
+        assert_eq!(summary.directories_visited, 2);
+        assert_eq!(summary.symlinks_skipped, 1);
     }
 }

--- a/crates/dustfril-core/src/history/mod.rs
+++ b/crates/dustfril-core/src/history/mod.rs
@@ -210,7 +210,7 @@ mod tests {
     use super::*;
     use crate::models::{
         ActivityKind, ActivityResult, Artifact, CleanupFailure, CleanupFailureReason, Ecosystem,
-        RiskLevel, SecurityFinding, SecurityFindingKind, SecurityReport,
+        RiskLevel, ScanAccessSummary, SecurityFinding, SecurityFindingKind, SecurityReport,
     };
 
     fn cleanup_result() -> CleanupResult {
@@ -346,6 +346,7 @@ mod tests {
     fn scan_activity_contains_target_summary() {
         let scan = ScanResult {
             artifacts: vec![Artifact::new("target".into(), Ecosystem::Rust)],
+            ..ScanResult::default()
         };
 
         let activity = ActivityRecord::scan(Path::new("/workspace"), &scan, 4096);
@@ -354,6 +355,53 @@ mod tests {
         assert_eq!(activity.result.details["path"], "/workspace");
         assert_eq!(activity.result.details["artifacts"], 1);
         assert_eq!(activity.result.details["size"], 4096);
+    }
+
+    #[test]
+    fn scan_access_summary_survives_history_reload() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("history.json");
+        let mut access_summary = ScanAccessSummary::new("/workspace");
+        access_summary.directories_visited = 2;
+        access_summary.files_inspected = 1;
+        access_summary.metadata_files_inspected = 1;
+        access_summary.artifact_candidates = 1;
+
+        let scan = ScanResult {
+            artifacts: vec![Artifact::new("/workspace/target".into(), Ecosystem::Rust)],
+            access_summary,
+        };
+        record_to(
+            &path,
+            ActivityRecord::scan(Path::new("/workspace"), &scan, 1024),
+        )
+        .unwrap();
+
+        let records = load_unlocked(&path).unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].result.details["accessSummary"]["directoriesVisited"],
+            2
+        );
+        assert_eq!(
+            records[0].result.details["accessSummary"]["artifactCandidates"],
+            1
+        );
+    }
+
+    #[test]
+    fn scan_history_does_not_persist_unrelated_source_contents() {
+        let workspace = TempDir::new().unwrap();
+        let source_contents = "unique source contents must stay out of history";
+        std::fs::write(workspace.path().join("source.rs"), source_contents).unwrap();
+        let scan = crate::api::scan(workspace.path(), &[]).unwrap();
+        let activity = ActivityRecord::scan(workspace.path(), &scan, 0);
+
+        let serialized = serde_json::to_string(&activity).unwrap();
+
+        assert!(!serialized.contains(source_contents));
+        assert!(!serialized.contains("source.rs"));
     }
 
     #[test]

--- a/crates/dustfril-core/src/history/mod.rs
+++ b/crates/dustfril-core/src/history/mod.rs
@@ -12,8 +12,8 @@ use serde_json::Value;
 use crate::{
     error::{DustError, DustResult},
     models::{
-        ActivityRecord, CleanupHistoryEntry, CleanupResult, DeleteMode, Ecosystem, ScanResult,
-        SecurityReport,
+        ActivityRecord, CleanupHistoryEntry, CleanupResult, DeleteMode, Ecosystem,
+        ScanAccessSummary, ScanResult, SecurityReport,
     },
 };
 
@@ -58,6 +58,20 @@ pub fn record_scan(
 /// Records a scan that failed before producing a scan result.
 pub fn record_scan_failure(target_path: &Path, reason: &str) -> DustResult<()> {
     record(ActivityRecord::scan_failure(target_path, reason))
+}
+
+/// Records a failed scan together with the bounded summary collected before
+/// traversal stopped.
+pub fn record_scan_failure_with_summary(
+    target_path: &Path,
+    reason: &str,
+    access_summary: &ScanAccessSummary,
+) -> DustResult<()> {
+    record(ActivityRecord::scan_failure_with_summary(
+        target_path,
+        reason,
+        access_summary,
+    ))
 }
 
 /// Records a cleanup that failed before producing a cleanup result.
@@ -387,6 +401,34 @@ mod tests {
         assert_eq!(
             records[0].result.details["accessSummary"]["artifactCandidates"],
             1
+        );
+    }
+
+    #[test]
+    fn failed_scan_access_summary_survives_history_reload() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("history.json");
+        let mut access_summary = ScanAccessSummary::new("/workspace");
+        access_summary.record_failure(Path::new("/workspace/restricted"), "permission denied");
+
+        record_to(
+            &path,
+            ActivityRecord::scan_failure_with_summary(
+                Path::new("/workspace"),
+                "I/O error: permission denied",
+                &access_summary,
+            ),
+        )
+        .unwrap();
+
+        let records = load_unlocked(&path).unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert!(!records[0].result.success);
+        assert_eq!(records[0].result.details["accessSummary"]["failures"], 1);
+        assert_eq!(
+            records[0].result.details["accessSummary"]["failureSamples"][0]["path"],
+            "restricted"
         );
     }
 

--- a/crates/dustfril-core/src/models/history.rs
+++ b/crates/dustfril-core/src/models/history.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::models::{
-    CleanupResult, DeleteMode, Ecosystem, RiskLevel, ScanResult, SecurityReport,
+    CleanupResult, DeleteMode, Ecosystem, RiskLevel, ScanAccessSummary, ScanResult, SecurityReport,
     effective_security_ecosystems,
 };
 
@@ -49,12 +49,15 @@ impl ActivityResult {
         scan: &ScanResult,
         total_size_bytes: u64,
     ) -> Self {
+        let access_summary = scan_access_summary_details(target_path, &scan.access_summary);
+
         Self::new(
             true,
             json!({
-                "path": target_path.display().to_string(),
+                "path": sanitize_path(target_path),
                 "artifacts": scan.artifacts.len(),
                 "size": total_size_bytes,
+                "accessSummary": access_summary,
             }),
         )
     }
@@ -64,7 +67,7 @@ impl ActivityResult {
         Self::new(
             false,
             json!({
-                "path": target_path.display().to_string(),
+                "path": sanitize_path(target_path),
                 "artifacts": 0,
                 "size": 0,
                 "reason": sanitize_text(reason),
@@ -315,6 +318,36 @@ fn sanitize_path(path: &Path) -> String {
     sanitize_text(&path.display().to_string())
 }
 
+fn scan_access_summary_details(target_path: &Path, summary: &ScanAccessSummary) -> Value {
+    let summary = summary.bounded();
+    let root = if summary.root.as_os_str().is_empty() {
+        target_path
+    } else {
+        &summary.root
+    };
+    let failure_samples = summary
+        .failure_samples
+        .iter()
+        .map(|failure| {
+            json!({
+                "path": sanitize_path(&failure.path),
+                "reason": sanitize_text(&failure.reason),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "root": sanitize_path(root),
+        "directoriesVisited": summary.directories_visited,
+        "filesInspected": summary.files_inspected,
+        "metadataFilesInspected": summary.metadata_files_inspected,
+        "artifactCandidates": summary.artifact_candidates,
+        "symlinksSkipped": summary.symlinks_skipped,
+        "failures": summary.failures,
+        "failureSamples": failure_samples,
+    })
+}
+
 /// Redacts common credential-shaped values while retaining useful context.
 fn sanitize_text(value: &str) -> String {
     let value = redact_inline_assignments(value);
@@ -530,6 +563,57 @@ mod tests {
         assert_eq!(result.details["findingCount"], 0);
         assert_eq!(result.details["highestRisk"], "None");
         assert_eq!(result.details["reason"], "Manifest error: token=[REDACTED]");
+    }
+
+    #[test]
+    fn scan_activity_persists_bounded_access_summary_without_contents() {
+        let root = Path::new("/workspace");
+        let mut access_summary = ScanAccessSummary::new(root);
+        access_summary.directories_visited = 4;
+        access_summary.files_inspected = 2;
+        access_summary.metadata_files_inspected = 2;
+        access_summary.artifact_candidates = 1;
+        access_summary.symlinks_skipped = 3;
+
+        for index in 0..(crate::models::MAX_SCAN_FAILURE_SAMPLES + 2) {
+            access_summary.record_failure(
+                &root.join(format!("diagnostics/failure-{index}")),
+                "permission denied",
+            );
+        }
+
+        let scan = ScanResult {
+            artifacts: vec![],
+            access_summary,
+        };
+        let activity = ActivityRecord::scan(root, &scan, 0);
+        let serialized = serde_json::to_string(&activity).unwrap();
+
+        assert_eq!(
+            activity.result.details["accessSummary"]["root"],
+            "/workspace"
+        );
+        assert_eq!(
+            activity.result.details["accessSummary"]["directoriesVisited"],
+            4
+        );
+        assert_eq!(
+            activity.result.details["accessSummary"]["metadataFilesInspected"],
+            2
+        );
+        assert_eq!(
+            activity.result.details["accessSummary"]["failures"],
+            (crate::models::MAX_SCAN_FAILURE_SAMPLES + 2) as u64
+        );
+        assert_eq!(
+            activity.result.details["accessSummary"]["failureSamples"]
+                .as_array()
+                .unwrap()
+                .len(),
+            crate::models::MAX_SCAN_FAILURE_SAMPLES
+        );
+        assert!(serialized.contains("failure-0"));
+        assert!(!serialized.contains("source contents"));
     }
 
     #[test]

--- a/crates/dustfril-core/src/models/history.rs
+++ b/crates/dustfril-core/src/models/history.rs
@@ -75,6 +75,25 @@ impl ActivityResult {
         )
     }
 
+    /// Builds the result payload for a failed scan with its partial access
+    /// summary retained.
+    pub fn from_scan_failure_with_summary(
+        target_path: &Path,
+        reason: &str,
+        access_summary: &ScanAccessSummary,
+    ) -> Self {
+        Self::new(
+            false,
+            json!({
+                "path": sanitize_path(target_path),
+                "artifacts": 0,
+                "size": 0,
+                "reason": sanitize_text(reason),
+                "accessSummary": scan_access_summary_details(target_path, access_summary),
+            }),
+        )
+    }
+
     /// Builds the result payload for a cleanup attempt, including partial failures.
     pub fn from_cleanup(mode: DeleteMode, result: &CleanupResult) -> Self {
         let failed_paths: Vec<Value> = result
@@ -208,6 +227,17 @@ impl ActivityRecord {
         Self::new(
             ActivityKind::Scan,
             ActivityResult::from_scan_failure(target_path, reason),
+        )
+    }
+
+    pub fn scan_failure_with_summary(
+        target_path: &Path,
+        reason: &str,
+        access_summary: &ScanAccessSummary,
+    ) -> Self {
+        Self::new(
+            ActivityKind::Scan,
+            ActivityResult::from_scan_failure_with_summary(target_path, reason, access_summary),
         )
     }
 

--- a/crates/dustfril-core/src/models/scan.rs
+++ b/crates/dustfril-core/src/models/scan.rs
@@ -3,6 +3,11 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+/// Maximum number of representative scan failures retained in an access
+/// summary. The total failure count remains authoritative when more failures
+/// occur.
+pub const MAX_SCAN_FAILURE_SAMPLES: usize = 8;
+
 /// Supported project ecosystems.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Ecosystem {
@@ -43,11 +48,124 @@ pub(crate) fn effective_security_ecosystems(selected: &[Ecosystem]) -> Vec<Ecosy
     effective
 }
 
+/// A bounded summary of filesystem access performed by one artifact scan.
+///
+/// `files_inspected` counts regular metadata files that the artifact detector
+/// actually checked. It intentionally does not count every unrelated file
+/// encountered by directory enumeration. At present the artifact detector
+/// checks supported project metadata files, so `metadata_files_inspected` is
+/// the same count; the separate fields leave room for future content-aware
+/// detectors without changing the contract.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanAccessSummary {
+    /// Workspace root used for the scan.
+    pub root: PathBuf,
+    /// Directories successfully returned by the existing directory traversal.
+    pub directories_visited: u64,
+    /// Regular files whose metadata/content was actually inspected by a
+    /// detector.
+    pub files_inspected: u64,
+    /// Supported project metadata files inspected by a detector.
+    pub metadata_files_inspected: u64,
+    /// Artifact directories discovered by the detectors.
+    pub artifact_candidates: u64,
+    /// Symbolic links skipped by the non-following traversal policy.
+    pub symlinks_skipped: u64,
+    /// Total traversal or detector-access failures observed.
+    pub failures: u64,
+    /// Bounded representative failures. This is not a complete failure log.
+    pub failure_samples: Vec<ScanAccessFailure>,
+}
+
+impl Default for ScanAccessSummary {
+    fn default() -> Self {
+        Self {
+            root: PathBuf::new(),
+            directories_visited: 0,
+            files_inspected: 0,
+            metadata_files_inspected: 0,
+            artifact_candidates: 0,
+            symlinks_skipped: 0,
+            failures: 0,
+            failure_samples: Vec::new(),
+        }
+    }
+}
+
+impl ScanAccessSummary {
+    /// Starts an access summary for a workspace root.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            ..Self::default()
+        }
+    }
+
+    /// Records a directory returned by the existing traversal.
+    pub(crate) fn record_directory(&mut self) {
+        self.directories_visited = self.directories_visited.saturating_add(1);
+    }
+
+    /// Records a supported metadata file whose metadata was inspected.
+    pub(crate) fn record_metadata_file(&mut self) {
+        self.files_inspected = self.files_inspected.saturating_add(1);
+        self.metadata_files_inspected = self.metadata_files_inspected.saturating_add(1);
+    }
+
+    /// Records an artifact candidate found by a detector.
+    pub(crate) fn record_artifact_candidate(&mut self) {
+        self.artifact_candidates = self.artifact_candidates.saturating_add(1);
+    }
+
+    /// Records a symbolic link omitted by the traversal policy.
+    pub(crate) fn record_symlink_skipped(&mut self) {
+        self.symlinks_skipped = self.symlinks_skipped.saturating_add(1);
+    }
+
+    /// Records a failure while retaining only a bounded diagnostic sample.
+    pub(crate) fn record_failure(&mut self, path: &std::path::Path, reason: &str) {
+        self.failures = self.failures.saturating_add(1);
+
+        if self.failure_samples.len() < MAX_SCAN_FAILURE_SAMPLES {
+            let sample_path = path.strip_prefix(&self.root).unwrap_or(path).to_path_buf();
+            self.failure_samples.push(ScanAccessFailure {
+                path: sample_path,
+                reason: reason.to_owned(),
+            });
+        }
+    }
+
+    /// Returns a copy safe to include in persisted activity details.
+    ///
+    /// Scanner-created summaries are already bounded, but applying the limit
+    /// again protects the persistence boundary if a caller constructs a
+    /// `ScanResult` manually.
+    pub(crate) fn bounded(&self) -> Self {
+        let mut bounded = self.clone();
+        bounded.failure_samples.truncate(MAX_SCAN_FAILURE_SAMPLES);
+        bounded
+    }
+}
+
+/// One representative traversal or detector-access failure.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanAccessFailure {
+    /// Path relative to the scan root when it can be made relative.
+    pub path: PathBuf,
+    /// Filesystem error description.
+    pub reason: String,
+}
+
 /// Result of scanning a filesystem tree for removable artifacts.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ScanResult {
     /// Artifact paths discovered during the scan.
     pub artifacts: Vec<Artifact>,
+    /// Bounded filesystem access summary collected during this scan.
+    #[serde(default)]
+    pub access_summary: ScanAccessSummary,
 }
 
 /// A removable artifact discovered for a supported ecosystem.
@@ -83,6 +201,17 @@ mod tests {
 
         assert_eq!(artifact.path, PathBuf::from("target"));
         assert_eq!(artifact.ecosystem, Ecosystem::Rust);
+    }
+
+    #[test]
+    fn scan_result_deserializes_legacy_payload_without_access_summary() {
+        let result: ScanResult = serde_json::from_value(serde_json::json!({
+            "artifacts": []
+        }))
+        .unwrap();
+
+        assert!(result.artifacts.is_empty());
+        assert_eq!(result.access_summary, ScanAccessSummary::default());
     }
 
     #[test]

--- a/crates/dustfril-core/src/scanner/detector.rs
+++ b/crates/dustfril-core/src/scanner/detector.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use crate::models::{Artifact, Ecosystem};
+use crate::models::{Artifact, Ecosystem, ScanAccessSummary};
 
 /// Registered detectors for all supported ecosystems.
 pub static DETECTORS: &[&dyn Detector] = &[&RustDetector, &NodeDetector, &JavaDetector];
@@ -8,7 +8,11 @@ pub static DETECTORS: &[&dyn Detector] = &[&RustDetector, &NodeDetector, &JavaDe
 /// Matches project roots and returns removable artifact directories.
 pub trait Detector: Sync {
     /// Returns true if this directory is a project of this ecosystem.
+    #[allow(dead_code)]
     fn matches(&self, root: &Path) -> bool;
+
+    /// Recognized project metadata names checked by this detector.
+    fn metadata_paths(&self) -> &[&str];
 
     /// Artifact directory names managed by this detector.
     fn artifact_paths(&self) -> &[&str];
@@ -16,15 +20,52 @@ pub trait Detector: Sync {
     /// Ecosystem handled by this detector.
     fn ecosystem(&self) -> Ecosystem;
 
+    /// Matches a project while recording only metadata files actually found
+    /// and inspected by the detector.
+    fn matches_with_summary(&self, root: &Path, summary: &mut ScanAccessSummary) -> bool {
+        self.metadata_paths().iter().any(|name| {
+            let path = root.join(name);
+            match fs::symlink_metadata(&path) {
+                Ok(metadata) if metadata.file_type().is_symlink() => false,
+                Ok(metadata) if metadata.is_file() => {
+                    summary.record_metadata_file();
+                    true
+                }
+                Ok(_) => false,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+                Err(error) => {
+                    summary.record_failure(&path, &error.to_string());
+                    false
+                }
+            }
+        })
+    }
+
     /// Finds removable artifacts inside the project.
+    #[allow(dead_code)]
     fn artifacts(&self, root: &Path) -> Vec<Artifact> {
+        self.artifacts_with_summary(root, None)
+    }
+
+    /// Finds artifacts and records detector-access failures in the scan
+    /// summary when one is supplied.
+    fn artifacts_with_summary(
+        &self,
+        root: &Path,
+        mut summary: Option<&mut ScanAccessSummary>,
+    ) -> Vec<Artifact> {
         self.artifact_paths()
             .iter()
             .map(|name| root.join(name))
-            .filter(|path| {
-                fs::symlink_metadata(path)
-                    .map(|metadata| metadata.is_dir())
-                    .unwrap_or(false)
+            .filter(|path| match fs::symlink_metadata(path) {
+                Ok(metadata) => metadata.is_dir(),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+                Err(error) => {
+                    if let Some(summary) = summary.as_deref_mut() {
+                        summary.record_failure(path, &error.to_string());
+                    }
+                    false
+                }
             })
             .map(|path| Artifact::new(path, self.ecosystem()))
             .collect()
@@ -58,6 +99,10 @@ impl Detector for RustDetector {
         root.join("Cargo.toml").is_file()
     }
 
+    fn metadata_paths(&self) -> &[&str] {
+        &["Cargo.toml"]
+    }
+
     fn artifact_paths(&self) -> &[&str] {
         &["target"]
     }
@@ -73,6 +118,10 @@ pub struct NodeDetector;
 impl Detector for NodeDetector {
     fn matches(&self, root: &Path) -> bool {
         root.join("package.json").is_file()
+    }
+
+    fn metadata_paths(&self) -> &[&str] {
+        &["package.json"]
     }
 
     fn artifact_paths(&self) -> &[&str] {
@@ -91,6 +140,10 @@ impl Detector for JavaDetector {
         root.join("pom.xml").is_file()
             || root.join("build.gradle").is_file()
             || root.join("build.gradle.kts").is_file()
+    }
+
+    fn metadata_paths(&self) -> &[&str] {
+        &["pom.xml", "build.gradle", "build.gradle.kts"]
     }
 
     fn artifact_paths(&self) -> &[&str] {

--- a/crates/dustfril-core/src/scanner/detector.rs
+++ b/crates/dustfril-core/src/scanner/detector.rs
@@ -25,8 +25,7 @@ pub trait Detector: Sync {
     fn matches_with_summary(&self, root: &Path, summary: &mut ScanAccessSummary) -> bool {
         self.metadata_paths().iter().any(|name| {
             let path = root.join(name);
-            match fs::symlink_metadata(&path) {
-                Ok(metadata) if metadata.file_type().is_symlink() => false,
+            match fs::metadata(&path) {
                 Ok(metadata) if metadata.is_file() => {
                     summary.record_metadata_file();
                     true

--- a/crates/dustfril-core/src/scanner/scan.rs
+++ b/crates/dustfril-core/src/scanner/scan.rs
@@ -2,23 +2,30 @@ use std::path::Path;
 
 use crate::{
     error::DustResult,
-    fs::walk_dirs,
-    models::{Ecosystem, ScanResult},
+    fs::walk_dirs_with_summary,
+    models::{Ecosystem, ScanAccessSummary, ScanResult},
     scanner::detector::{self},
 };
 
 pub fn scan(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<ScanResult> {
     let detectors = detector::select_detectors(ecosystems);
 
-    let mut result = ScanResult::default();
+    let mut result = ScanResult {
+        access_summary: ScanAccessSummary::new(root),
+        ..ScanResult::default()
+    };
 
-    for dir in walk_dirs(root)? {
+    for dir in walk_dirs_with_summary(root, &mut result.access_summary)? {
         for detector in &detectors {
-            if !detector.matches(&dir) {
+            if !detector.matches_with_summary(&dir, &mut result.access_summary) {
                 continue;
             }
 
-            result.artifacts.extend(detector.artifacts(&dir));
+            let artifacts = detector.artifacts_with_summary(&dir, Some(&mut result.access_summary));
+            for _ in &artifacts {
+                result.access_summary.record_artifact_candidate();
+            }
+            result.artifacts.extend(artifacts);
         }
     }
 

--- a/crates/dustfril-core/src/scanner/scan.rs
+++ b/crates/dustfril-core/src/scanner/scan.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::{
-    error::DustResult,
+    error::{DustError, DustResult},
     fs::walk_dirs_with_summary,
     models::{Ecosystem, ScanAccessSummary, ScanResult},
     scanner::detector::{self},
@@ -15,7 +15,18 @@ pub fn scan(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<ScanResult> {
         ..ScanResult::default()
     };
 
-    for dir in walk_dirs_with_summary(root, &mut result.access_summary)? {
+    let directories = match walk_dirs_with_summary(root, &mut result.access_summary) {
+        Ok(directories) => directories,
+        Err(source @ DustError::InvalidPath(_)) => return Err(source),
+        Err(source) => {
+            return Err(DustError::ScanAccess {
+                source: Box::new(source),
+                access_summary: result.access_summary,
+            });
+        }
+    };
+
+    for dir in directories {
         for detector in &detectors {
             if !detector.matches_with_summary(&dir, &mut result.access_summary) {
                 continue;

--- a/crates/dustfril-core/src/scanner/tests.rs
+++ b/crates/dustfril-core/src/scanner/tests.rs
@@ -1,7 +1,7 @@
 use tempfile::TempDir;
 
 use crate::{
-    models::Ecosystem,
+    models::{Ecosystem, MAX_SCAN_FAILURE_SAMPLES},
     scanner::{
         detector::{Detector, RustDetector},
         scan,
@@ -36,6 +36,13 @@ fn scan_returns_empty_when_no_projects() {
     let result = scan(temp_dir.path(), &[]).unwrap();
 
     assert!(result.artifacts.is_empty());
+    assert_eq!(result.access_summary.root, temp_dir.path());
+    assert_eq!(result.access_summary.directories_visited, 1);
+    assert_eq!(result.access_summary.files_inspected, 0);
+    assert_eq!(result.access_summary.metadata_files_inspected, 0);
+    assert_eq!(result.access_summary.artifact_candidates, 0);
+    assert_eq!(result.access_summary.symlinks_skipped, 0);
+    assert_eq!(result.access_summary.failures, 0);
 }
 
 #[test]
@@ -52,6 +59,10 @@ fn scan_detects_rust_project() {
 
     assert_eq!(artifact.ecosystem, Ecosystem::Rust);
     assert_eq!(artifact.path, target);
+    assert_eq!(result.access_summary.directories_visited, 2);
+    assert_eq!(result.access_summary.files_inspected, 1);
+    assert_eq!(result.access_summary.metadata_files_inspected, 1);
+    assert_eq!(result.access_summary.artifact_candidates, 1);
 }
 
 #[test]
@@ -65,6 +76,10 @@ fn scan_detects_node_project() {
     assert_eq!(result.artifacts.len(), 1);
     assert_eq!(result.artifacts[0].ecosystem, Ecosystem::Node);
     assert_eq!(result.artifacts[0].path, node_modules);
+    assert_eq!(result.access_summary.directories_visited, 2);
+    assert_eq!(result.access_summary.files_inspected, 1);
+    assert_eq!(result.access_summary.metadata_files_inspected, 1);
+    assert_eq!(result.access_summary.artifact_candidates, 1);
 }
 
 #[test]
@@ -78,6 +93,10 @@ fn scan_detects_java_project() {
     assert_eq!(result.artifacts.len(), 1);
     assert_eq!(result.artifacts[0].ecosystem, Ecosystem::Java);
     assert_eq!(result.artifacts[0].path, build);
+    assert_eq!(result.access_summary.directories_visited, 2);
+    assert_eq!(result.access_summary.files_inspected, 1);
+    assert_eq!(result.access_summary.metadata_files_inspected, 1);
+    assert_eq!(result.access_summary.artifact_candidates, 1);
 }
 
 #[test]
@@ -86,16 +105,19 @@ fn scan_detects_multiple_projects() {
 
     let rust = temp_dir.path().join("rust");
     let node = temp_dir.path().join("node");
+    let java = temp_dir.path().join("java");
 
     std::fs::create_dir_all(&rust).unwrap();
     std::fs::create_dir_all(&node).unwrap();
+    std::fs::create_dir_all(&java).unwrap();
 
     let rust_target = create_rust_artifact(&rust);
     let node_modules = create_node_artifact(&node);
+    let java_build = create_java_artifact(&java);
 
     let result = scan(temp_dir.path(), &[]).unwrap();
 
-    assert_eq!(result.artifacts.len(), 2);
+    assert_eq!(result.artifacts.len(), 3);
 
     assert!(
         result
@@ -110,6 +132,16 @@ fn scan_detects_multiple_projects() {
             .iter()
             .any(|a| a.ecosystem == Ecosystem::Node && a.path == node_modules)
     );
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|a| a.ecosystem == Ecosystem::Java && a.path == java_build)
+    );
+    assert_eq!(result.access_summary.directories_visited, 7);
+    assert_eq!(result.access_summary.files_inspected, 3);
+    assert_eq!(result.access_summary.metadata_files_inspected, 3);
+    assert_eq!(result.access_summary.artifact_candidates, 3);
 }
 
 #[test]
@@ -170,6 +202,46 @@ fn rust_detector_reports_target_as_safe_artifact() {
     assert_eq!(detector.artifact_paths(), &["target"]);
 }
 
+#[test]
+fn nested_unsupported_files_are_not_counted_as_inspected_content() {
+    let temp_dir = TempDir::new().unwrap();
+    let nested = temp_dir.path().join("nested");
+    std::fs::create_dir(&nested).unwrap();
+    std::fs::write(
+        nested.join("source.rs"),
+        "source contents must not be persisted",
+    )
+    .unwrap();
+    std::fs::write(nested.join("notes.txt"), "unrelated contents").unwrap();
+
+    let result = scan(temp_dir.path(), &[]).unwrap();
+
+    assert_eq!(result.access_summary.directories_visited, 2);
+    assert_eq!(result.access_summary.files_inspected, 0);
+    assert_eq!(result.access_summary.metadata_files_inspected, 0);
+    assert_eq!(result.access_summary.artifact_candidates, 0);
+}
+
+#[test]
+fn access_summary_failure_samples_are_bounded() {
+    let root = TempDir::new().unwrap();
+    let mut summary = crate::models::ScanAccessSummary::new(root.path());
+
+    for index in 0..(MAX_SCAN_FAILURE_SAMPLES + 3) {
+        summary.record_failure(
+            &root.path().join(format!("failure-{index}")),
+            "permission denied",
+        );
+    }
+
+    assert_eq!(summary.failures, (MAX_SCAN_FAILURE_SAMPLES + 3) as u64);
+    assert_eq!(summary.failure_samples.len(), MAX_SCAN_FAILURE_SAMPLES);
+    assert_eq!(
+        summary.failure_samples[0].path,
+        std::path::Path::new("failure-0")
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn scanner_does_not_return_symbolic_link_artifacts() {
@@ -183,4 +255,6 @@ fn scanner_does_not_return_symbolic_link_artifacts() {
     let result = scan(root.path(), &[Ecosystem::Rust]).unwrap();
 
     assert!(result.artifacts.is_empty());
+    assert_eq!(result.access_summary.symlinks_skipped, 1);
+    assert_eq!(result.access_summary.artifact_candidates, 0);
 }

--- a/crates/dustfril-core/src/scanner/tests.rs
+++ b/crates/dustfril-core/src/scanner/tests.rs
@@ -258,3 +258,25 @@ fn scanner_does_not_return_symbolic_link_artifacts() {
     assert_eq!(result.access_summary.symlinks_skipped, 1);
     assert_eq!(result.access_summary.artifact_candidates, 0);
 }
+
+#[cfg(unix)]
+#[test]
+fn scanner_follows_symbolic_linked_project_manifests() {
+    use std::os::unix::fs::symlink;
+
+    let root = TempDir::new().unwrap();
+    let manifest_root = TempDir::new().unwrap();
+    let manifest = manifest_root.path().join("Cargo.toml");
+    std::fs::write(&manifest, "[package]").unwrap();
+    let target = root.path().join("target");
+    std::fs::create_dir(&target).unwrap();
+    symlink(&manifest, root.path().join("Cargo.toml")).unwrap();
+
+    let result = scan(root.path(), &[Ecosystem::Rust]).unwrap();
+
+    assert_eq!(result.artifacts.len(), 1);
+    assert_eq!(result.artifacts[0].path, target);
+    assert_eq!(result.access_summary.files_inspected, 1);
+    assert_eq!(result.access_summary.metadata_files_inspected, 1);
+    assert_eq!(result.access_summary.symlinks_skipped, 1);
+}


### PR DESCRIPTION
## What

Adds a Core-owned, bounded filesystem access summary to each explicit artifact scan and persists it in the existing Scan activity record. The CLI prints the summary and the desktop activity history renders it.

## Why

Closes #71

The summary is collected during the existing traversal and records visited directories, inspected supported metadata files, artifact candidates, skipped symlinks, and bounded representative failures. It does not create per-file logs or persist source contents.

## Validation

- [x] cargo check --workspace
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace
- [x] cargo llvm-cov --workspace --all-features --summary-only
- [x] npm run build (apps/dustfril-tauri)