### PR TITLE
Validate bounded workspace monitoring

### DIFF
--- a/crates/dustfril-core/src/artifact_snapshot.rs
+++ b/crates/dustfril-core/src/artifact_snapshot.rs
@@ -418,10 +418,18 @@ mod tests {
     }
 
     fn snapshot(workspace: &Path, path: &str, size_bytes: u64, timestamp: i64) -> ArtifactSnapshot {
+        let artifact_path = workspace.join(path);
         ArtifactSnapshot::from_analysis_at(
             fs::canonicalize(workspace).unwrap().display().to_string(),
             workspace,
-            &analysis(path, size_bytes),
+            &AnalysisResult {
+                artifacts: vec![analyzed_artifact(
+                    artifact_path,
+                    Ecosystem::Rust,
+                    size_bytes,
+                )],
+                total_size_bytes: size_bytes,
+            },
             Utc.timestamp_opt(timestamp, 0).single().unwrap(),
         )
     }
@@ -574,6 +582,73 @@ mod tests {
         assert_eq!(reloaded.len(), 2);
         assert_eq!(reloaded[0].artifacts[0].size_bytes, 10);
         assert_eq!(reloaded[1].artifacts[0].size_bytes, 20);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_and_symlink_workspace_access_share_snapshot_history() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().unwrap();
+        let workspace = root.path().join("workspace");
+        let link = root.path().join("workspace-link");
+        fs::create_dir_all(workspace.join("target")).unwrap();
+        symlink(&workspace, &link).unwrap();
+        let store = ArtifactSnapshotStore::new(root.path().join("snapshots.json"));
+
+        store
+            .record_snapshot(snapshot(&workspace, "target", 10, 1))
+            .unwrap();
+        let result = store
+            .record_snapshot(snapshot(&link, "target", 15, 2))
+            .unwrap();
+
+        assert_eq!(result.status, ArtifactSnapshotStatus::Compared);
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].kind, ArtifactChangeKind::SizeIncreased);
+        assert_eq!(store.load_workspace(&link).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn moved_workspace_starts_a_new_history_instead_of_guessing_identity() {
+        let root = TempDir::new().unwrap();
+        let original = root.path().join("original");
+        let moved = root.path().join("moved");
+        fs::create_dir_all(original.join("target")).unwrap();
+        fs::create_dir_all(moved.join("target")).unwrap();
+        let store = ArtifactSnapshotStore::new(root.path().join("snapshots.json"));
+
+        store
+            .record_snapshot(snapshot(&original, "target", 10, 1))
+            .unwrap();
+        let moved_result = store
+            .record_snapshot(snapshot(&moved, "target", 10, 2))
+            .unwrap();
+
+        assert_eq!(moved_result.status, ArtifactSnapshotStatus::BaselineCreated);
+        assert_eq!(store.load_workspace(&original).unwrap().len(), 1);
+        assert_eq!(store.load_workspace(&moved).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn snapshot_reuses_analysis_metadata_without_rewalking_artifact_paths() {
+        let workspace = TempDir::new().unwrap();
+        let target = workspace.path().join("target");
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("artifact.bin"), b"saved analysis").unwrap();
+        fs::write(workspace.path().join("Cargo.toml"), "[package]").unwrap();
+
+        let scan = crate::api::scan(workspace.path(), &[Ecosystem::Rust]).unwrap();
+        let analysis = crate::api::analyze(scan).unwrap();
+        assert_eq!(analysis.artifacts[0].size_bytes, 14);
+
+        fs::remove_file(target.join("artifact.bin")).unwrap();
+
+        let store = ArtifactSnapshotStore::new(workspace.path().join("snapshots.json"));
+        let result = store.record(workspace.path(), &analysis).unwrap();
+
+        assert_eq!(result.snapshot.artifacts[0].size_bytes, 14);
+        assert_eq!(result.snapshot.artifacts[0].path, Path::new("target"));
     }
 
     #[test]

--- a/crates/dustfril-core/src/models/artifact_snapshot.rs
+++ b/crates/dustfril-core/src/models/artifact_snapshot.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Ordering,
-    fmt,
+    fmt, fs,
     path::{Path, PathBuf},
 };
 
@@ -256,8 +256,26 @@ pub(crate) fn is_scanner_owned_artifact(ecosystem: Ecosystem, path: &Path) -> bo
 }
 
 fn relative_artifact_path(workspace_path: &Path, artifact_path: &Path) -> PathBuf {
-    let workspace = lexical_normalize(workspace_path);
-    let artifact = lexical_normalize(artifact_path);
+    // Existing scanner callers pass real paths, but canonicalizing here keeps
+    // the public model stable when a caller supplies a symlinked workspace.
+    // Missing paths still use lexical normalization so pure model callers do
+    // not need to create the artifact tree just to build a snapshot.
+    let lexical_workspace = lexical_normalize(workspace_path);
+    let lexical_artifact = lexical_normalize(artifact_path);
+
+    if let Ok(relative) = lexical_artifact.strip_prefix(&lexical_workspace)
+        && !relative.as_os_str().is_empty()
+    {
+        return relative.to_path_buf();
+    }
+
+    let (workspace, artifact) = match (
+        fs::canonicalize(workspace_path),
+        fs::canonicalize(artifact_path),
+    ) {
+        (Ok(workspace), Ok(artifact)) => (workspace, artifact),
+        _ => (lexical_workspace, lexical_artifact),
+    };
 
     artifact
         .strip_prefix(&workspace)
@@ -294,6 +312,7 @@ fn lexical_normalize(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use chrono::TimeZone;
+    use tempfile::TempDir;
 
     use super::*;
     use crate::models::{Artifact, ArtifactAnalysis, CleanupRecommendation};
@@ -416,5 +435,33 @@ mod tests {
             }
             .has_changes()
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_workspace_uses_canonical_relative_artifact_identity() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().unwrap();
+        let workspace = root.path().join("workspace");
+        let link = root.path().join("workspace-link");
+        std::fs::create_dir_all(workspace.join("target")).unwrap();
+        symlink(&workspace, &link).unwrap();
+
+        let analysis = AnalysisResult {
+            artifacts: vec![artifact(
+                &workspace.join("target").display().to_string(),
+                Ecosystem::Rust,
+                10,
+            )],
+            total_size_bytes: 10,
+        };
+        let snapshot = ArtifactSnapshot::from_analysis(&link, &analysis);
+
+        assert_eq!(
+            snapshot.workspace_id,
+            fs::canonicalize(&workspace).unwrap().display().to_string()
+        );
+        assert_eq!(snapshot.artifacts[0].path, Path::new("target"));
     }
 }

--- a/docs/workspace-monitoring-validation.md
+++ b/docs/workspace-monitoring-validation.md
@@ -1,0 +1,56 @@
+# Workspace Monitoring Validation
+
+Final validation report for #117 and the close gate for #73, run against
+`upstream/main` containing #134 (bounded scan-access summaries) and #135
+(generated-artifact snapshots).
+
+## Final validation report
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Per-file persistent logging avoided | PASS | Scan instrumentation keeps aggregate counters and at most eight representative failure samples; activity history stores one bounded scan summary and snapshot state stores at most 32 snapshots per workspace. No per-file access log exists. |
+| Aggregate access summary | PASS | Existing traversal records directories, supported metadata files actually inspected, artifact candidates, skipped symlinks, and total failures. Deterministic Rust/Node/Java, mixed-workspace, unsupported-file, and symlink fixtures assert the counters. |
+| Sensitive-data avoidance | PASS | Scan history persists counters and bounded sanitized diagnostics only. Source contents and unrelated source paths are excluded by regression tests; snapshot models contain artifact metadata, not file contents, dependency trees, or hashes. |
+| Artifact-only snapshot semantics | PASS | Snapshot construction filters to scanner-owned Rust `target/`, Node `node_modules/`, and Java `build/` artifacts. `Cargo.lock`, manifests, and ordinary source paths are excluded. |
+| Cargo.lock/source-file exclusion | PASS | Core model tests explicitly include `Cargo.lock` and `src/main.rs` alongside `target/`; only `target/` is retained. |
+| Existing analysis reused | PASS | `ArtifactSnapshot::from_analysis` and the store consume `AnalysisResult` metadata without walking artifact paths. A regression test removes an artifact file after analysis and verifies the recorded size remains the analyzed value. |
+| Artifact delta semantics | PASS | Pure comparison tests cover `New`, `Removed`, `SizeIncreased`, `SizeDecreased`, and `Unchanged`, with exact signed byte deltas and deterministic ordering. Equal size makes no content-change claim. |
+| Project identity isolation | PASS | Canonical workspace IDs isolate projects with identical artifact names; canonical and symlink access share state, while a moved directory starts a new history. |
+| Persistence safety | PASS | Snapshot state is versioned, validated, atomically replaced, reloadable across restarts, and rejects malformed/unsupported state without replacing it. |
+| History growth sanity | PASS | Snapshot retention is deterministic and capped at 32 entries per workspace; bounded access diagnostics cap samples at eight while retaining total failure counts. |
+| Auxiliary failure behavior | PASS | Snapshot write failures are surfaced as warnings by CLI/Tauri scan flows while the completed scan/analyze result remains available; failed writes clean temporary files and preserve the prior destination. |
+| Artifact-cleaner regression | PASS | Rust/Node/Java scan and analysis fixtures, cleanup planning/execution safety tests, and activity-history tests remain green. |
+
+## Identity and metadata notes
+
+- Workspace identity is the canonical workspace path. A root symbolic link is
+  rejected by the existing scanner safety policy; snapshot lookup through a
+  symbolic link resolves to the canonical workspace. A moved directory is
+  intentionally treated as a new workspace rather than matched heuristically.
+- Artifact `last_modified` is the latest successfully-read modification time
+  across the artifact root and recursively visited contents. `age_days` is
+  derived from that value. Size history compares bytes only and is not content
+  integrity.
+- Snapshot state is local to the OS app-data directory and is separate from
+  operation history. No cloud or telemetry path is involved.
+
+## Blocking findings
+
+None.
+
+## Follow-ups
+
+None.
+
+## Quality gates
+
+- `cargo fmt --all -- --check` — PASS
+- `cargo clippy --workspace --all-targets -- -D warnings` — PASS
+- `cargo test --workspace` — PASS
+- `cargo llvm-cov --workspace --all-features --summary-only` — PASS
+- `npm run build` in `apps/dustfril-tauri` — PASS
+- `git diff --check` — PASS
+
+## Epic #73 recommendation
+
+CLOSE


### PR DESCRIPTION
## Summary

- add deterministic validation coverage for analysis reuse, canonical/symlink identity, and moved-workspace isolation
- keep artifact snapshot paths stable when canonicalization is needed
- add the final validation report for bounded monitoring and artifact growth

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 27 CLI, 244 Core, 13 Tauri tests passed
- `cargo llvm-cov --workspace --all-features --summary-only` — 76.64% line coverage
- `npm run build` in `apps/dustfril-tauri`
- `git diff --check`

See [docs/workspace-monitoring-validation.md](docs/workspace-monitoring-validation.md) for the final PASS/FAIL report.

Closes #117
Closes #73