### PR TITLE
Refine Workspace and History information hierarchy

### DIFF
--- a/apps/dustfril-cli/src/commands/clean.rs
+++ b/apps/dustfril-cli/src/commands/clean.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 
 pub fn dry_run(args: &CleanArgs) -> bool {
-    let plan = match build_cleanup_plan(args) {
-        Ok(plan) => plan,
+    let (_, plan) = match build_cleanup_plan(args) {
+        Ok(result) => result,
         Err(e) => {
             eprintln!("Cleanup preview failed: {}", e);
             return false;
@@ -39,8 +39,8 @@ pub fn execute(args: &CleanArgs) -> bool {
         DeleteMode::default()
     };
 
-    let plan = match build_cleanup_plan(args) {
-        Ok(plan) => plan,
+    let (target_path, plan) = match build_cleanup_plan(args) {
+        Ok(result) => result,
         Err(e) => {
             if let Err(history_error) = history::record_cleanup_failure(mode, &e.to_string()) {
                 eprintln!("Failed to record cleanup failure history: {history_error}");
@@ -52,7 +52,7 @@ pub fn execute(args: &CleanArgs) -> bool {
 
     if plan.candidates.is_empty() {
         let result = CleanupResult::default();
-        history::record(mode, &result)
+        history::record_for_workspace(&target_path, &plan, mode, &result)
             .unwrap_or_else(|e| eprintln!("Failed to record cleanup history: {e}"));
         println!("No cleanup candidates found.");
         return true;
@@ -75,14 +75,16 @@ pub fn execute(args: &CleanArgs) -> bool {
     let result = match api::clean::execute(&plan, mode) {
         Ok(res) => res,
         Err(e) => {
-            if let Err(history_error) = history::record_cleanup_failure(mode, &e.to_string()) {
+            if let Err(history_error) =
+                history::record_failure_for_workspace(&target_path, mode, &e.to_string())
+            {
                 eprintln!("Failed to record cleanup failure history: {history_error}");
             }
             eprintln!("Cleanup failed: {}", e);
             return false;
         }
     };
-    history::record(mode, &result)
+    history::record_for_workspace(&target_path, &plan, mode, &result)
         .unwrap_or_else(|e| eprintln!("Failed to record cleanup history: {}", e));
 
     print_cleanup_result(&result);
@@ -94,7 +96,7 @@ fn cleanup_succeeded(result: &CleanupResult) -> bool {
     result.failed_paths.is_empty()
 }
 
-fn build_cleanup_plan(args: &CleanArgs) -> Result<CleanupPlan, DustError> {
+fn build_cleanup_plan(args: &CleanArgs) -> Result<(std::path::PathBuf, CleanupPlan), DustError> {
     let path = resolve_path(&args.path_args.path)?;
 
     if !validate_path(&path) {
@@ -107,7 +109,7 @@ fn build_cleanup_plan(args: &CleanArgs) -> Result<CleanupPlan, DustError> {
     let analysis = api::analyze(scan)?;
     let plan = api::clean::build_plan_from_analysis(analysis)?;
 
-    Ok(plan)
+    Ok((path, plan))
 }
 
 fn confirm_cleanup() -> io::Result<bool> {

--- a/apps/dustfril-cli/src/history.rs
+++ b/apps/dustfril-cli/src/history.rs
@@ -1,14 +1,26 @@
 use dustfril_core::api;
 
-pub fn record(
+pub fn record_scan_failure(target_path: &std::path::Path, reason: &str) -> std::io::Result<()> {
+    api::history::record_scan_failure(target_path, reason)
+        .map_err(|error| std::io::Error::other(error.to_string()))
+}
+
+pub fn record_for_workspace(
+    target_path: &std::path::Path,
+    plan: &dustfril_core::models::CleanupPlan,
     mode: dustfril_core::models::DeleteMode,
     result: &dustfril_core::models::CleanupResult,
 ) -> std::io::Result<()> {
-    api::history::record(mode, result).map_err(|error| std::io::Error::other(error.to_string()))
+    api::history::record_cleanup_with_context(target_path, &plan.candidates, mode, result)
+        .map_err(|error| std::io::Error::other(error.to_string()))
 }
 
-pub fn record_scan_failure(target_path: &std::path::Path, reason: &str) -> std::io::Result<()> {
-    api::history::record_scan_failure(target_path, reason)
+pub fn record_failure_for_workspace(
+    target_path: &std::path::Path,
+    mode: dustfril_core::models::DeleteMode,
+    reason: &str,
+) -> std::io::Result<()> {
+    api::history::record_cleanup_failure_with_context(target_path, mode, reason)
         .map_err(|error| std::io::Error::other(error.to_string()))
 }
 

--- a/apps/dustfril-tauri/package-lock.json
+++ b/apps/dustfril-tauri/package-lock.json
@@ -18,11 +18,75 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.3",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "jsdom": "^30.0.1",
         "typescript": "~5.8.3",
-        "vite": "^7.3.6"
+        "vite": "^7.3.6",
+        "vitest": "^4.1.11"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -259,6 +323,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -305,6 +379,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -723,6 +950,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1099,6 +1344,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.2",
@@ -1602,6 +1854,99 @@
         "@tauri-apps/api": "^2.11.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1646,6 +1991,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1694,6 +2057,164 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
@@ -1705,6 +2226,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -1762,10 +2293,41 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1775,6 +2337,35 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1794,6 +2385,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1802,6 +2410,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.376",
@@ -1822,6 +2438,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.2",
@@ -1874,6 +2510,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1921,6 +2577,36 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -1936,6 +2622,57 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2222,6 +2959,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2229,6 +2977,23 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -2265,6 +3030,40 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2312,6 +3111,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -2333,10 +3158,42 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2387,6 +3244,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2403,6 +3273,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2411,6 +3288,40 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.3.2",
@@ -2431,6 +3342,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2447,6 +3375,62 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -2459,6 +3443,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2565,6 +3559,178 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/apps/dustfril-tauri/package.json
+++ b/apps/dustfril-tauri/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "test": "vitest run",
     "preview": "vite preview",
     "tauri": "tauri"
   },
@@ -20,10 +21,14 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.3",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "jsdom": "^30.0.1",
     "typescript": "~5.8.3",
-    "vite": "^7.3.6"
+    "vite": "^7.3.6",
+    "vitest": "^4.1.11"
   }
 }

--- a/apps/dustfril-tauri/src-tauri/src/history.rs
+++ b/apps/dustfril-tauri/src-tauri/src/history.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use dustfril_core::{
     api,
     models::{
-        ActivityKind, ActivityRecord, CleanupResult, DeleteMode, Ecosystem, ScanResult,
-        SecurityReport,
+        ActivityKind, ActivityRecord, CleanupCandidate, CleanupResult, DeleteMode, Ecosystem,
+        ScanResult, SecurityReport,
     },
 };
 use serde::Serialize;
@@ -20,9 +20,25 @@ pub struct ActivityRecordDto {
     pub result: dustfril_core::models::ActivityResult,
 }
 
-/// Records a cleanup operation for the desktop activity log.
-pub fn record(mode: DeleteMode, result: &CleanupResult) -> Result<(), String> {
-    api::history::record_cleanup(mode, result).map_err(|error| error.to_string())
+/// Records cleanup history with the workspace and analyzed candidates used by
+/// the desktop cleanup review.
+pub fn record_with_context(
+    target_path: &Path,
+    candidates: &[CleanupCandidate],
+    mode: DeleteMode,
+    result: &CleanupResult,
+) -> Result<(), String> {
+    api::history::record_cleanup_with_context(target_path, candidates, mode, result)
+        .map_err(|error| error.to_string())
+}
+
+pub fn record_failure_with_context(
+    target_path: &Path,
+    mode: DeleteMode,
+    reason: &str,
+) -> Result<(), String> {
+    api::history::record_cleanup_failure_with_context(target_path, mode, reason)
+        .map_err(|error| error.to_string())
 }
 
 /// Records a completed scan for the desktop activity log.
@@ -51,10 +67,6 @@ pub fn record_scan_failure_with_summary(
 }
 
 /// Records a cleanup that failed before producing a cleanup result.
-pub fn record_cleanup_failure(mode: DeleteMode, reason: &str) -> Result<(), String> {
-    api::history::record_cleanup_failure(mode, reason).map_err(|error| error.to_string())
-}
-
 /// Records one explicit security scan for the desktop activity log.
 pub fn record_security_scan(
     target_path: &Path,

--- a/apps/dustfril-tauri/src-tauri/src/lib.rs
+++ b/apps/dustfril-tauri/src-tauri/src/lib.rs
@@ -469,17 +469,18 @@ async fn execute_cleanup(request: ExecuteCleanupRequest) -> Result<CleanupResult
             Ok(result) => result,
             Err(error) => {
                 if let Err(history_error) =
-                    history::record_cleanup_failure(mode, &error.to_string())
+                    history::record_failure_with_context(&root, mode, &error.to_string())
                 {
                     report_failed_activity_record("cleanup", history_error);
                 }
                 return Err(error.to_string());
             }
         };
-        let history_warning = match history::record(mode, &result) {
-            Ok(()) => None,
-            Err(error) => Some(format_history_warning("cleanup", error)),
-        };
+        let history_warning =
+            match history::record_with_context(&root, &plan.candidates, mode, &result) {
+                Ok(()) => None,
+                Err(error) => Some(format_history_warning("cleanup", error)),
+            };
 
         Ok(CleanupResultResponse {
             deleted_paths: result

--- a/apps/dustfril-tauri/src/components/CleanupDialog/CleanupDialog.test.tsx
+++ b/apps/dustfril-tauri/src/components/CleanupDialog/CleanupDialog.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CleanupDialog } from './CleanupDialog';
+
+describe('CleanupDialog safety context', () => {
+  const commonProps = {
+    open: true,
+    itemCount: 1,
+    totalBytes: 1024,
+    selectedItems: [],
+    busy: false,
+    onCancel: () => undefined,
+    onConfirm: () => undefined,
+  };
+
+  it('warns at the permanent action boundary only', () => {
+    const { rerender } = render(<CleanupDialog {...commonProps} deleteMode="Trash" />);
+
+    expect(screen.getByText(/moved to the system Trash/)).toBeInTheDocument();
+    expect(screen.queryByText(/cannot be undone/)).not.toBeInTheDocument();
+
+    rerender(<CleanupDialog {...commonProps} deleteMode="Permanent" />);
+
+    expect(screen.getByText(/cannot be undone/)).toBeInTheDocument();
+  });
+});

--- a/apps/dustfril-tauri/src/components/HistoryList/HistoryList.test.tsx
+++ b/apps/dustfril-tauri/src/components/HistoryList/HistoryList.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { HistoryList } from './HistoryList';
+import type { ActivityRecord } from '../../types/workflow';
+
+const scanEntry: ActivityRecord = {
+  id: 'scan-1',
+  timestampMs: Date.UTC(2026, 8, 3, 4, 5),
+  kind: 'Scan',
+  result: {
+    success: true,
+    details: {
+      path: '/Users/mars112/code/dustfril',
+      artifacts: 2,
+      size: 11 * 1024 ** 3,
+      accessSummary: {
+        root: '/Users/mars112/code/dustfril',
+        directoriesVisited: 363,
+        filesInspected: 7,
+        metadataFilesInspected: 7,
+        artifactCandidates: 2,
+        symlinksSkipped: 0,
+        failures: 0,
+        failureSamples: [],
+      },
+    },
+  },
+};
+
+const cleanupEntry: ActivityRecord = {
+  id: 'cleanup-1',
+  timestampMs: Date.UTC(2026, 8, 3, 4, 10),
+  kind: 'Cleanup',
+  result: {
+    success: false,
+    details: {
+      target: '/Users/mars112/code',
+      mode: 'trash',
+      freed: 2.3 * 1024 ** 3,
+      items: [
+        {
+          path: '/Users/mars112/code/dustfril/target',
+          project: 'dustfril',
+          status: 'succeeded',
+          size: 2.3 * 1024 ** 3,
+        },
+        {
+          path: '/Users/mars112/code/project/node_modules',
+          project: 'project',
+          status: 'failed',
+          reason: 'NotFound',
+        },
+      ],
+      deleted: ['/Users/mars112/code/dustfril/target'],
+      failed: [{ path: '/Users/mars112/code/project/node_modules', reason: 'NotFound' }],
+    },
+  },
+};
+
+const permanentCleanupEntry: ActivityRecord = {
+  ...cleanupEntry,
+  id: 'cleanup-2',
+  result: {
+    ...cleanupEntry.result,
+    success: true,
+    details: {
+      ...cleanupEntry.result.details,
+      mode: 'permanent',
+      items: cleanupEntry.result.details.items?.slice(0, 1) ?? [],
+      failed: [],
+    },
+  },
+};
+
+describe('HistoryList', () => {
+  it('renders compact operation rows and keeps diagnostics in the drawer', () => {
+    render(<HistoryList entries={[scanEntry]} />);
+
+    expect(screen.getByText('Sep 3, 1:05 PM')).toBeInTheDocument();
+    expect(screen.getByText('Scan')).toBeInTheDocument();
+    expect(screen.getByText('dustfril')).toBeInTheDocument();
+    expect(screen.getByText(/2 artifacts · 11 GB/)).toBeInTheDocument();
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.queryByText('Directories')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Inspect Scan activity/ }));
+
+    expect(screen.getByRole('heading', { name: 'Scan details' })).toBeInTheDocument();
+    expect(screen.getByText('/Users/mars112/code/dustfril')).toBeInTheDocument();
+    expect(screen.getByText('Directories')).toBeInTheDocument();
+    expect(screen.getByText('363')).toBeInTheDocument();
+    expect(screen.getByText('Files inspected')).toBeInTheDocument();
+    expect(screen.getByText('Metadata files')).toBeInTheDocument();
+    expect(screen.getByText('Artifact candidates')).toBeInTheDocument();
+    expect(screen.getByText('Symlinks skipped')).toBeInTheDocument();
+    expect(screen.getByText('Failures')).toBeInTheDocument();
+  });
+
+  it('updates the drawer for another row, exposes cleanup detail, and closes cleanly', () => {
+    render(<HistoryList entries={[scanEntry, cleanupEntry]} />);
+
+    expect(screen.getByText('Partial failure')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Inspect Scan activity/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Inspect Cleanup activity/ }));
+
+    expect(screen.getByRole('heading', { name: 'Cleanup details' })).toBeInTheDocument();
+    expect(screen.getByText('Move to Trash')).toBeInTheDocument();
+    expect(screen.getByText('Affected targets')).toBeInTheDocument();
+    expect(screen.getByText('/Users/mars112/code/dustfril/target')).toBeInTheDocument();
+    expect(screen.queryByText('Scan access')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close history details' }));
+    expect(screen.queryByRole('heading', { name: 'Cleanup details' })).not.toBeInTheDocument();
+    expect(screen.getByText('Partial failure')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Inspect Scan activity/ }));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('heading', { name: 'Scan details' })).not.toBeInTheDocument();
+  });
+
+  it('labels permanent cleanup details distinctly from Trash cleanup', () => {
+    render(<HistoryList entries={[permanentCleanupEntry]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Inspect Cleanup activity/ }));
+
+    expect(screen.getByText('Delete permanently')).toBeInTheDocument();
+    expect(screen.queryByText('Move to Trash')).not.toBeInTheDocument();
+    expect(screen.getByText('Deleted permanently')).toBeInTheDocument();
+  });
+});

--- a/apps/dustfril-tauri/src/components/HistoryList/HistoryList.test.tsx
+++ b/apps/dustfril-tauri/src/components/HistoryList/HistoryList.test.tsx
@@ -72,18 +72,56 @@ const permanentCleanupEntry: ActivityRecord = {
   },
 };
 
+const failedCleanupEntry: ActivityRecord = {
+  ...cleanupEntry,
+  id: 'cleanup-failed',
+  result: {
+    success: false,
+    details: {
+      ...cleanupEntry.result.details,
+      items: cleanupEntry.result.details.items?.slice(1) ?? [],
+      deleted: [],
+      failed: [{ path: '/Users/mars112/code/project/node_modules', reason: 'NotFound' }],
+    },
+  },
+};
+
+const securityEntry: ActivityRecord = {
+  id: 'security-1',
+  timestampMs: Date.UTC(2026, 8, 3, 4, 20),
+  kind: 'Security',
+  result: {
+    success: true,
+    details: {
+      path: '/Users/mars112/code/dustfril',
+      ecosystems: [],
+      findingCount: 0,
+      highestRisk: 'None',
+      findings: [],
+    },
+  },
+};
+
 describe('HistoryList', () => {
   it('renders compact operation rows and keeps diagnostics in the drawer', () => {
     render(<HistoryList entries={[scanEntry]} />);
 
-    expect(screen.getByText('Sep 3, 1:05 PM')).toBeInTheDocument();
+    const expectedTime = new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(scanEntry.timestampMs));
+    expect(screen.getByText(expectedTime)).toBeInTheDocument();
     expect(screen.getByText('Scan')).toBeInTheDocument();
     expect(screen.getByText('dustfril')).toBeInTheDocument();
     expect(screen.getByText(/2 artifacts · 11 GB/)).toBeInTheDocument();
     expect(screen.getByText('Success')).toBeInTheDocument();
     expect(screen.queryByText('Directories')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Inspect Scan activity/ }));
+    const row = screen.getByRole('row', { name: /Inspect Scan activity/ });
+    expect(row).toHaveAttribute('tabindex', '0');
+    fireEvent.keyDown(row, { key: 'Enter' });
 
     expect(screen.getByRole('heading', { name: 'Scan details' })).toBeInTheDocument();
     expect(screen.getByText('/Users/mars112/code/dustfril')).toBeInTheDocument();
@@ -100,8 +138,8 @@ describe('HistoryList', () => {
     render(<HistoryList entries={[scanEntry, cleanupEntry]} />);
 
     expect(screen.getByText('Partial failure')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /Inspect Scan activity/ }));
-    fireEvent.click(screen.getByRole('button', { name: /Inspect Cleanup activity/ }));
+    fireEvent.click(screen.getByRole('row', { name: /Inspect Scan activity/ }));
+    fireEvent.click(screen.getByRole('row', { name: /Inspect Cleanup activity/ }));
 
     expect(screen.getByRole('heading', { name: 'Cleanup details' })).toBeInTheDocument();
     expect(screen.getByText('Move to Trash')).toBeInTheDocument();
@@ -113,7 +151,7 @@ describe('HistoryList', () => {
     expect(screen.queryByRole('heading', { name: 'Cleanup details' })).not.toBeInTheDocument();
     expect(screen.getByText('Partial failure')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Inspect Scan activity/ }));
+    fireEvent.click(screen.getByRole('row', { name: /Inspect Scan activity/ }));
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(screen.queryByRole('heading', { name: 'Scan details' })).not.toBeInTheDocument();
   });
@@ -121,10 +159,26 @@ describe('HistoryList', () => {
   it('labels permanent cleanup details distinctly from Trash cleanup', () => {
     render(<HistoryList entries={[permanentCleanupEntry]} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Inspect Cleanup activity/ }));
+    fireEvent.click(screen.getByRole('row', { name: /Inspect Cleanup activity/ }));
 
     expect(screen.getByText('Delete permanently')).toBeInTheDocument();
     expect(screen.queryByText('Move to Trash')).not.toBeInTheDocument();
     expect(screen.getByText('Deleted permanently')).toBeInTheDocument();
+  });
+
+  it('keeps all-failed cleanup operations distinct from partial failures', () => {
+    render(<HistoryList entries={[failedCleanupEntry]} />);
+
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(screen.queryByText('Partial failure')).not.toBeInTheDocument();
+  });
+
+  it('preserves the recorded empty security ecosystem scope', () => {
+    render(<HistoryList entries={[securityEntry]} />);
+
+    fireEvent.click(screen.getByRole('row', { name: /Inspect Security activity/ }));
+
+    expect(screen.getByText('Ecosystems').parentElement).toHaveTextContent('None');
+    expect(screen.queryByText('All')).not.toBeInTheDocument();
   });
 });

--- a/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
+++ b/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
@@ -45,25 +45,27 @@ export function HistoryList(props: HistoryListProps) {
   }
 
   return (
-    <div className="history-list-container">
-      <div className="history-table" role="table" aria-label="Activity history">
-        <div className="history-row history-row-header" role="row">
-          <span role="columnheader">Time</span>
-          <span role="columnheader">Action</span>
-          <span role="columnheader">Target</span>
-          <span role="columnheader">Result</span>
-          <span role="columnheader">Status</span>
-          <span aria-hidden="true" />
-        </div>
-        <div className="history-table-body">
-          {props.entries.map((entry, index) => (
-            <HistoryRow
-              key={`${entry.id}-${index}`}
-              entry={entry}
-              selected={entry.id === selectedEntryId}
-              onSelect={() => setSelectedEntryId(entry.id)}
-            />
-          ))}
+    <div className="history-list-layout">
+      <div className="history-list-scroll">
+        <div className="history-table" role="table" aria-label="Activity history">
+          <div className="history-row history-row-header" role="row">
+            <span role="columnheader">Time</span>
+            <span role="columnheader">Action</span>
+            <span role="columnheader">Target</span>
+            <span role="columnheader">Result</span>
+            <span role="columnheader">Status</span>
+            <span aria-hidden="true" />
+          </div>
+          <div className="history-table-body">
+            {props.entries.map((entry, index) => (
+              <HistoryRow
+                key={`${entry.id}-${index}`}
+                entry={entry}
+                selected={entry.id === selectedEntryId}
+                onSelect={() => setSelectedEntryId(entry.id)}
+              />
+            ))}
+          </div>
         </div>
       </div>
 
@@ -89,28 +91,39 @@ function HistoryRow({
   const status = historyStatusLabel(entry);
 
   return (
-    <button
-      type="button"
-      className={`history-row history-row-button${selected ? ' history-row-active' : ''}`}
+    <div
+      className={`history-row history-row-interactive${selected ? ' history-row-active' : ''}`}
+      role="row"
+      tabIndex={0}
       onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
       aria-label={`Inspect ${entry.kind} activity for ${historyTargetLabel(entry)}`}
     >
-      <span className="history-time">{formatHistoryDate(entry.timestampMs)}</span>
-      <span className={`history-kind history-kind-${entry.kind.toLowerCase()}`}>
+      <span className="history-time" role="cell">
+        {formatHistoryDate(entry.timestampMs)}
+      </span>
+      <span className={`history-kind history-kind-${entry.kind.toLowerCase()}`} role="cell">
         <span className="history-kind-mark" aria-hidden="true" />
         {entry.kind}
       </span>
-      <span className="history-target" title={historyTargetLabel(entry)}>
+      <span className="history-target" role="cell" title={historyTargetLabel(entry)}>
         {historyTargetLabel(entry)}
       </span>
-      <span className="history-result" title={historyResultLabel(entry)}>
+      <span className="history-result" role="cell" title={historyResultLabel(entry)}>
         {historyResultLabel(entry)}
       </span>
-      <span className={`history-status ${historyStatusClass(status)}`}>{status}</span>
-      <span className="history-chevron" aria-hidden="true">
+      <span className={`history-status ${historyStatusClass(status)}`} role="cell">
+        {status}
+      </span>
+      <span className="history-chevron" role="cell" aria-hidden="true">
         ›
       </span>
-    </button>
+    </div>
   );
 }
 
@@ -269,10 +282,7 @@ function SecurityDetails({ details }: { details: ActivityDetails }) {
     <>
       <dl className="inspector-details history-drawer-details">
         <Detail label="Target" value={details.path ?? 'Unknown'} />
-        <Detail
-          label="Ecosystems"
-          value={details.ecosystems?.length ? details.ecosystems.join(', ') : 'All'}
-        />
+        <Detail label="Ecosystems" value={securityEcosystemLabel(details.ecosystems)} />
         <Detail label="Findings" value={String(details.findingCount ?? findings.length)} />
         <Detail label="Highest risk" value={details.highestRisk ?? 'None'} />
       </dl>
@@ -354,7 +364,8 @@ function cleanupModeLabel(mode: ActivityDetails['mode']) {
 }
 
 export function historyStatusLabel(entry: ActivityRecord) {
-  if (historyFailureCount(entry) > 0) {
+  const failureCount = historyFailureCount(entry);
+  if (failureCount > 0 && (entry.kind !== 'Cleanup' || cleanupSuccessCount(entry) > 0)) {
     return 'Partial failure';
   }
 
@@ -378,6 +389,14 @@ function historyFailureCount(entry: ActivityRecord) {
   }
 
   return 0;
+}
+
+function cleanupSuccessCount(entry: ActivityRecord) {
+  if (entry.kind !== 'Cleanup') {
+    return 0;
+  }
+
+  return cleanupItems(entry.result.details).filter((item) => item.status === 'succeeded').length;
 }
 
 function historyTargetLabel(entry: ActivityRecord) {
@@ -408,6 +427,14 @@ function firstCleanupPath(details: ActivityDetails) {
 
 function conciseTargetName(path: string) {
   return path === 'Unknown' ? path : leafName(path);
+}
+
+function securityEcosystemLabel(ecosystems: string[] | undefined) {
+  if (ecosystems === undefined) {
+    return 'All';
+  }
+
+  return ecosystems.length ? ecosystems.join(', ') : 'None';
 }
 
 function historyResultLabel(entry: ActivityRecord) {

--- a/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
+++ b/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
@@ -1,5 +1,13 @@
-import type { ActivityDetails, ActivityRecord } from '../../types/workflow';
+import { useEffect, useState } from 'react';
+import type {
+  ActivityDetails,
+  ActivityRecord,
+  CleanupActivityItem,
+  ScanAccessSummary,
+  SecurityActivityFinding,
+} from '../../types/workflow';
 import { formatBytes, formatDate } from '../../lib/format';
+import { leafName } from '../../model/presentation';
 import { EmptyState } from '../EmptyState/EmptyState';
 
 type HistoryListProps = {
@@ -7,198 +15,434 @@ type HistoryListProps = {
 };
 
 export function HistoryList(props: HistoryListProps) {
+  const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
+  const selectedEntry =
+    props.entries.find((entry) => entry.id === selectedEntryId) ?? null;
+
+  useEffect(() => {
+    if (selectedEntryId && !selectedEntry) {
+      setSelectedEntryId(null);
+    }
+  }, [selectedEntry, selectedEntryId]);
+
+  useEffect(() => {
+    if (!selectedEntry) {
+      return;
+    }
+
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setSelectedEntryId(null);
+      }
+    }
+
+    window.addEventListener('keydown', closeOnEscape);
+    return () => window.removeEventListener('keydown', closeOnEscape);
+  }, [selectedEntry]);
+
   if (!props.entries.length) {
     return <EmptyState message="No activity history yet. Operations will appear here." />;
   }
 
   return (
-    <div className="history-list">
-      {props.entries.map((entry, index) => (
-        <article
-          key={`${entry.id}-${index}`}
-          className="history-entry"
-        >
-          <div className="history-entry-header">
-            <div>
-              <p className="history-entry-title">
-                {entry.kind} · {formatDate(entry.timestampMs)}
-              </p>
-              <p className="history-entry-subtitle">
-                Result: {entry.result.success ? 'Succeeded' : 'Failed'}
-              </p>
-            </div>
-            <p
-              className={`history-badge ${
-                entry.result.success
-                  ? 'history-badge-success'
-                  : 'history-badge-failure'
-              }`}
-            >
-              {entry.result.success ? 'Success' : 'Failure'}
-            </p>
-          </div>
+    <div className="history-list-container">
+      <div className="history-table" role="table" aria-label="Activity history">
+        <div className="history-row history-row-header" role="row">
+          <span role="columnheader">Time</span>
+          <span role="columnheader">Action</span>
+          <span role="columnheader">Target</span>
+          <span role="columnheader">Result</span>
+          <span role="columnheader">Status</span>
+          <span aria-hidden="true" />
+        </div>
+        <div className="history-table-body">
+          {props.entries.map((entry, index) => (
+            <HistoryRow
+              key={`${entry.id}-${index}`}
+              entry={entry}
+              selected={entry.id === selectedEntryId}
+              onSelect={() => setSelectedEntryId(entry.id)}
+            />
+          ))}
+        </div>
+      </div>
 
-          {entry.kind === 'Scan' ? <ScanDetails entry={entry} /> : null}
-          {entry.kind === 'Cleanup' ? <CleanupDetails entry={entry} /> : null}
-          {entry.kind === 'Security' ? <SecurityDetails entry={entry} /> : null}
-        </article>
-      ))}
+      {selectedEntry ? (
+        <HistoryDetailsDrawer
+          entry={selectedEntry}
+          onClose={() => setSelectedEntryId(null)}
+        />
+      ) : null}
     </div>
   );
 }
 
-function ScanDetails({ entry }: { entry: ActivityRecord }) {
-  const details = entry.result.details;
+function HistoryRow({
+  entry,
+  selected,
+  onSelect,
+}: {
+  entry: ActivityRecord;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const status = historyStatusLabel(entry);
+
+  return (
+    <button
+      type="button"
+      className={`history-row history-row-button${selected ? ' history-row-active' : ''}`}
+      onClick={onSelect}
+      aria-label={`Inspect ${entry.kind} activity for ${historyTargetLabel(entry)}`}
+    >
+      <span className="history-time">{formatHistoryDate(entry.timestampMs)}</span>
+      <span className={`history-kind history-kind-${entry.kind.toLowerCase()}`}>
+        <span className="history-kind-mark" aria-hidden="true" />
+        {entry.kind}
+      </span>
+      <span className="history-target" title={historyTargetLabel(entry)}>
+        {historyTargetLabel(entry)}
+      </span>
+      <span className="history-result" title={historyResultLabel(entry)}>
+        {historyResultLabel(entry)}
+      </span>
+      <span className={`history-status ${historyStatusClass(status)}`}>{status}</span>
+      <span className="history-chevron" aria-hidden="true">
+        ›
+      </span>
+    </button>
+  );
+}
+
+function HistoryDetailsDrawer({
+  entry,
+  onClose,
+}: {
+  entry: ActivityRecord;
+  onClose: () => void;
+}) {
+  const title = `${entry.kind} details`;
+  const status = historyStatusLabel(entry);
+
+  return (
+    <aside className="inspector-pane workspace-drawer history-drawer" aria-label="History details">
+      <div className="inspector-header">
+        <span className="eyebrow">History details</span>
+        <button
+          type="button"
+          className="inspector-close"
+          onClick={onClose}
+          aria-label="Close history details"
+        >
+          ×
+        </button>
+      </div>
+      <div className="inspector-content">
+        <div className="history-drawer-title">
+          <span className={`history-kind history-kind-${entry.kind.toLowerCase()}`}>
+            <span className="history-kind-mark" aria-hidden="true" />
+            {entry.kind}
+          </span>
+          <h2>{title}</h2>
+          <p>{formatDate(entry.timestampMs)}</p>
+          <span className={`history-status ${historyStatusClass(status)}`}>{status}</span>
+        </div>
+
+        {entry.kind === 'Scan' ? <ScanDetails details={entry.result.details} /> : null}
+        {entry.kind === 'Cleanup' ? <CleanupDetails details={entry.result.details} /> : null}
+        {entry.kind === 'Security' ? <SecurityDetails details={entry.result.details} /> : null}
+      </div>
+    </aside>
+  );
+}
+
+function ScanDetails({ details }: { details: ActivityDetails }) {
+  const summary = details.accessSummary;
 
   return (
     <>
-      <div className="history-details-grid">
+      <dl className="inspector-details history-drawer-details">
         <Detail label="Target" value={details.path ?? 'Unknown'} />
         <Detail label="Artifacts" value={String(details.artifacts ?? 0)} />
-        <Detail label="Total Size" value={formatBytes(details.size ?? 0)} />
-      </div>
-      {details.accessSummary ? <ScanAccessDetails summary={details.accessSummary} /> : null}
-      {details.reason ? <p className="mt-4 text-sm text-rose-200">{details.reason}</p> : null}
+        <Detail label="Total size" value={formatBytes(details.size ?? 0)} />
+      </dl>
+      {details.reason ? <FailureReason value={details.reason} /> : null}
+      {summary ? <ScanAccessDetails summary={summary} /> : null}
     </>
   );
 }
 
-function ScanAccessDetails({
-  summary,
-}: {
-  summary: NonNullable<ActivityDetails['accessSummary']>;
-}) {
+function ScanAccessDetails({ summary }: { summary: ScanAccessSummary }) {
   return (
-    <div className="history-access-summary">
-      <p className="eyebrow">Scan access summary</p>
-      <div className="history-details-grid">
+    <section className="history-drawer-section" aria-labelledby="scan-access-heading">
+      <p className="eyebrow" id="scan-access-heading">
+        Scan access
+      </p>
+      <dl className="inspector-details history-drawer-details history-access-details">
         <Detail label="Directories" value={String(summary.directoriesVisited)} />
-        <Detail label="Files Inspected" value={String(summary.filesInspected)} />
-        <Detail label="Metadata Files" value={String(summary.metadataFilesInspected)} />
-        <Detail label="Artifact Candidates" value={String(summary.artifactCandidates)} />
-        <Detail label="Symlinks Skipped" value={String(summary.symlinksSkipped)} />
+        <Detail label="Files inspected" value={String(summary.filesInspected)} />
+        <Detail label="Metadata files" value={String(summary.metadataFilesInspected)} />
+        <Detail label="Artifact candidates" value={String(summary.artifactCandidates)} />
+        <Detail label="Symlinks skipped" value={String(summary.symlinksSkipped)} />
         <Detail label="Failures" value={String(summary.failures)} />
-      </div>
+      </dl>
       {summary.failureSamples.length ? (
-        <div className="history-failure-list">
-          <p className="eyebrow">Representative failures</p>
-          <ul>
-            {summary.failureSamples.map((failure) => (
-            <li key={`${failure.path}-${failure.reason}`}>
-                {failure.path}: {failure.reason}
-              </li>
-            ))}
-          </ul>
-        </div>
+        <FailureList
+          label="Representative failures"
+          items={summary.failureSamples.map((failure) => `${failure.path}: ${failure.reason}`)}
+        />
       ) : null}
+    </section>
+  );
+}
+
+function CleanupDetails({ details }: { details: ActivityDetails }) {
+  const items = cleanupItems(details);
+  const succeededCount = items.filter((item) => item.status === 'succeeded').length;
+  const failedCount = items.filter((item) => item.status === 'failed').length;
+  const affectedCount = succeededCount + failedCount;
+
+  return (
+    <>
+      <dl className="inspector-details history-drawer-details">
+        {details.target ? <Detail label="Target / workspace" value={details.target} /> : null}
+        <Detail label="Mode" value={cleanupModeLabel(details.mode)} />
+        <Detail label="Items" value={String(affectedCount)} />
+        <Detail label="Size" value={formatBytes(details.freed ?? 0)} />
+        <Detail
+          label="Result"
+          value={`${succeededCount} succeeded · ${failedCount} failed`}
+        />
+      </dl>
+
+      {items.length ? (
+        <section className="history-drawer-section" aria-labelledby="cleanup-items-heading">
+          <p className="eyebrow" id="cleanup-items-heading">
+            Affected targets
+          </p>
+          <div className="history-cleanup-items">
+            {items.map((item, index) => (
+              <CleanupItem item={item} mode={details.mode} key={`${item.path}-${index}`} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {details.reason ? <FailureReason value={details.reason} /> : null}
+    </>
+  );
+}
+
+function CleanupItem({
+  item,
+  mode,
+}: {
+  item: CleanupActivityItem;
+  mode: ActivityDetails['mode'];
+}) {
+  const outcome = item.status === 'succeeded'
+    ? mode === 'trash'
+      ? 'Moved to Trash'
+      : 'Deleted permanently'
+    : `Failed${item.reason ? `: ${item.reason}` : ''}`;
+
+  return (
+    <div className="history-cleanup-item">
+      <div className="min-width-zero">
+        <strong>{item.project || leafName(item.path)}</strong>
+        <span title={item.path}>{item.path}</span>
+      </div>
+      <div className="history-cleanup-item-meta">
+        {item.size !== undefined ? <span>{formatBytes(item.size)}</span> : null}
+        <span className={item.status === 'failed' ? 'history-item-failed' : 'history-item-success'}>
+          {outcome}
+        </span>
+      </div>
     </div>
   );
 }
 
-function CleanupDetails({ entry }: { entry: ActivityRecord }) {
-  const details = entry.result.details;
-  const deleted = details.deleted ?? [];
-  const failed = details.failed ?? [];
-
-  return (
-    <>
-      <div className="history-details-grid">
-        <Detail label="Mode" value={details.mode ?? 'Unknown'} />
-        <Detail label="Freed" value={formatBytes(details.freed ?? 0)} />
-      </div>
-
-      {deleted.length ? (
-        <PathList label="Deleted" paths={deleted} />
-      ) : null}
-
-      {failed.length ? (
-      <div className="history-failure-list">
-          <p className="eyebrow">Failed</p>
-          <ul>
-            {failed.map((failure) => (
-              <li key={`${failure.path}-${failure.reason ?? ''}`}>
-                - {failure.path}
-                {failure.reason ? ` (${failure.reason})` : ''}
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-
-      {details.reason ? <p className="mt-4 text-sm text-rose-200">{details.reason}</p> : null}
-    </>
-  );
-}
-
-function SecurityDetails({ entry }: { entry: ActivityRecord }) {
-  const details = entry.result.details;
+function SecurityDetails({ details }: { details: ActivityDetails }) {
   const findings = details.findings ?? [];
 
   return (
     <>
-      <div className="history-details-grid">
+      <dl className="inspector-details history-drawer-details">
         <Detail label="Target" value={details.path ?? 'Unknown'} />
         <Detail
           label="Ecosystems"
-          value={
-            details.ecosystems
-              ? details.ecosystems.length
-                ? details.ecosystems.join(', ')
-                : 'None'
-              : 'All'
-          }
+          value={details.ecosystems?.length ? details.ecosystems.join(', ') : 'All'}
         />
         <Detail label="Findings" value={String(details.findingCount ?? findings.length)} />
-        <Detail label="Highest Risk" value={details.highestRisk ?? 'None'} />
-      </div>
+        <Detail label="Highest risk" value={details.highestRisk ?? 'None'} />
+      </dl>
 
-      {details.reason ? (
-        <p className="mt-4 text-sm text-rose-200">{details.reason}</p>
-      ) : null}
-
-      {findings.length ? (
-        <div className="history-finding-list">
-          <p className="eyebrow">Findings</p>
-          <ul>
-            {findings.map((finding, index) => (
-              <li
-                key={`${finding.rule}-${finding.source}-${index}`}
-                className="history-finding"
-              >
-                <p className="history-finding-title">
-                  {finding.rule} · {finding.risk}
-                </p>
-                <p className="history-finding-source">{finding.source}</p>
-                <p className="history-finding-reason">{finding.reason}</p>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
+      {details.reason ? <FailureReason value={details.reason} /> : null}
+      {findings.length ? <SecurityFindingList findings={findings} /> : null}
     </>
   );
 }
 
-function PathList({ label, paths }: { label: string; paths: string[] }) {
+function SecurityFindingList({ findings }: { findings: SecurityActivityFinding[] }) {
+  return (
+    <section className="history-drawer-section" aria-labelledby="history-findings-heading">
+      <p className="eyebrow" id="history-findings-heading">
+        Findings
+      </p>
+      <ul className="history-finding-list">
+        {findings.map((finding, index) => (
+          <li key={`${finding.rule}-${finding.source}-${index}`} className="history-finding">
+            <p className="history-finding-title">
+              {finding.rule} · {finding.risk}
+            </p>
+            <p className="history-finding-source">{finding.source}</p>
+            <p className="history-finding-reason">{finding.reason}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function FailureList({ label, items }: { label: string; items: string[] }) {
   return (
     <div className="history-failure-list">
       <p className="eyebrow">{label}</p>
       <ul>
-        {paths.map((path) => (
-          <li key={path}>
-            - {path}
-          </li>
+        {items.map((item, index) => (
+          <li key={`${item}-${index}`}>{item}</li>
         ))}
       </ul>
     </div>
   );
 }
 
+function FailureReason({ value }: { value: string }) {
+  return <p className="history-detail-reason">{value}</p>;
+}
+
 function Detail({ label, value }: { label: string; value: string }) {
   return (
-    <div className="history-detail">
+    <div>
       <dt>{label}</dt>
       <dd title={value}>{value}</dd>
     </div>
   );
+}
+
+function cleanupItems(details: ActivityDetails): CleanupActivityItem[] {
+  if (details.items?.length) {
+    return details.items;
+  }
+
+  return [
+    ...(details.deleted ?? []).map((path) => ({ path, status: 'succeeded' as const })),
+    ...(details.failed ?? []).map((failure) => ({
+      path: failure.path,
+      status: 'failed' as const,
+      reason: failure.reason,
+    })),
+  ];
+}
+
+function cleanupModeLabel(mode: ActivityDetails['mode']) {
+  return mode === 'trash'
+    ? 'Move to Trash'
+    : mode === 'permanent'
+      ? 'Delete permanently'
+      : 'Unknown';
+}
+
+export function historyStatusLabel(entry: ActivityRecord) {
+  if (historyFailureCount(entry) > 0) {
+    return 'Partial failure';
+  }
+
+  return entry.result.success ? 'Success' : 'Failed';
+}
+
+function historyStatusClass(status: string) {
+  return status === 'Success' ? 'history-status-success' : 'history-status-failure';
+}
+
+function historyFailureCount(entry: ActivityRecord) {
+  if (entry.kind === 'Scan') {
+    return entry.result.details.accessSummary?.failures ?? 0;
+  }
+
+  if (entry.kind === 'Cleanup') {
+    const recordedFailures = entry.result.details.failed?.length ?? 0;
+    const contextualFailures =
+      entry.result.details.items?.filter((item) => item.status === 'failed').length ?? 0;
+    return Math.max(recordedFailures, contextualFailures);
+  }
+
+  return 0;
+}
+
+function historyTargetLabel(entry: ActivityRecord) {
+  const details = entry.result.details;
+
+  if (entry.kind === 'Cleanup') {
+    const projects = Array.from(
+      new Set(
+        (details.items ?? [])
+          .map((item) => item.project)
+          .filter((project): project is string => Boolean(project)),
+      ),
+    );
+    if (projects.length === 1) {
+      return projects[0];
+    }
+    if (projects.length > 1) {
+      return `${projects[0]} + ${projects.length - 1}`;
+    }
+  }
+
+  return conciseTargetName(details.target ?? details.path ?? firstCleanupPath(details));
+}
+
+function firstCleanupPath(details: ActivityDetails) {
+  return details.deleted?.[0] ?? details.failed?.[0]?.path ?? 'Unknown';
+}
+
+function conciseTargetName(path: string) {
+  return path === 'Unknown' ? path : leafName(path);
+}
+
+function historyResultLabel(entry: ActivityRecord) {
+  const details = entry.result.details;
+
+  switch (entry.kind) {
+    case 'Scan': {
+      const count = details.artifacts ?? 0;
+      const failures = details.accessSummary?.failures ?? 0;
+      return `${count} artifact${count === 1 ? '' : 's'} · ${formatBytes(details.size ?? 0)}${
+        failures ? ` · ${failures} failure${failures === 1 ? '' : 's'}` : ''
+      }`;
+    }
+    case 'Cleanup': {
+      const items = cleanupItems(details);
+      const succeeded = items.filter((item) => item.status === 'succeeded').length;
+      const failed = items.filter((item) => item.status === 'failed').length;
+      const verb = details.mode === 'trash' ? 'moved to Trash' : 'deleted';
+      const result = `${succeeded} item${succeeded === 1 ? '' : 's'} · ${formatBytes(
+        details.freed ?? 0,
+      )} ${verb}`;
+      return failed ? `${result} · ${failed} failed` : result;
+    }
+    case 'Security': {
+      const count = details.findingCount ?? details.findings?.length ?? 0;
+      return `${count} finding${count === 1 ? '' : 's'} · ${details.highestRisk ?? 'None'} risk`;
+    }
+  }
+}
+
+function formatHistoryDate(timestampMs: number) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(timestampMs));
 }

--- a/apps/dustfril-tauri/src/components/Sidebar/Sidebar.test.tsx
+++ b/apps/dustfril-tauri/src/components/Sidebar/Sidebar.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Sidebar, type SidebarEntry } from './Sidebar';
+
+const entries: SidebarEntry[] = [
+  {
+    key: 'overview',
+    title: 'Overview',
+    description: 'Summary',
+    section: 'favorites',
+    count: null,
+  },
+  {
+    key: 'workspace',
+    title: 'Workspace',
+    description: 'Artifacts',
+    section: 'favorites',
+    count: 2,
+  },
+  {
+    key: 'history',
+    title: 'History',
+    description: 'Activity',
+    section: 'favorites',
+    count: 3,
+  },
+];
+
+describe('Sidebar information hierarchy', () => {
+  it('does not render a permanent Trash guidance note', () => {
+    render(
+      <Sidebar
+        entries={entries}
+        activeCategory="workspace"
+        onCategoryChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('navigation', { name: 'Primary navigation' })).toBeInTheDocument();
+    expect(screen.queryByText('Trash is the default cleanup mode.')).not.toBeInTheDocument();
+  });
+});

--- a/apps/dustfril-tauri/src/components/Sidebar/Sidebar.tsx
+++ b/apps/dustfril-tauri/src/components/Sidebar/Sidebar.tsx
@@ -37,10 +37,6 @@ export function Sidebar(props: SidebarProps) {
         })}
       </nav>
 
-      <div className="sidebar-note">
-        <span className="sidebar-note-dot" aria-hidden="true" />
-        <span>Trash is the default cleanup mode.</span>
-      </div>
     </aside>
   );
 }

--- a/apps/dustfril-tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/AppShell.tsx
@@ -60,7 +60,6 @@ export function AppShell() {
               lastAnalysisAtMs={app.lastAnalysisAtMs}
               busy={app.busyAction !== null}
               analysisReady={app.analysisResult !== null}
-              statusMessage={app.statusMessage}
               error={app.error}
               onSelectItem={app.setSelectedItemId}
               onCloseInspector={() => app.setSelectedItemId(null)}

--- a/apps/dustfril-tauri/src/features/app-shell/views/HistoryView.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/views/HistoryView.tsx
@@ -15,9 +15,7 @@ export function HistoryView(props: HistoryViewProps) {
           <h1>Activity</h1>
         </div>
       </div>
-      <div className="history-list-scroll">
-        <HistoryList entries={props.entries} />
-      </div>
+      <HistoryList entries={props.entries} />
     </div>
   );
 }

--- a/apps/dustfril-tauri/src/features/app-shell/views/HistoryView.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/views/HistoryView.tsx
@@ -13,7 +13,6 @@ export function HistoryView(props: HistoryViewProps) {
         <div className="min-width-zero">
           <p className="eyebrow">History</p>
           <h1>Activity</h1>
-          <p className="heading-path">Scans, cleanup operations, results, and failures.</p>
         </div>
       </div>
       <div className="history-list-scroll">

--- a/apps/dustfril-tauri/src/features/app-shell/views/WorkspaceView.test.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/views/WorkspaceView.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WorkspaceView } from './WorkspaceView';
+import type { ArtifactAnalysis } from '../../../types/workflow';
+
+const artifact: ArtifactAnalysis = {
+  path: '/workspace/dustfril/target',
+  ecosystem: 'Rust',
+  project: {
+    root: '/workspace/dustfril',
+    displayName: 'dustfril',
+    ecosystem: 'Rust',
+  },
+  sizeBytes: 1024,
+  lastModifiedMs: null,
+  ageDays: 30,
+  recommendation: 'Keep',
+};
+
+function renderWorkspace(deleteMode: 'Trash' | 'Permanent' = 'Trash') {
+  return render(
+    <WorkspaceView
+      artifacts={[artifact]}
+      artifactCount={1}
+      candidates={[]}
+      reclaimableBytes={0}
+      selectedItemId={artifact.path}
+      selectedPaths={[]}
+      deleteMode={deleteMode}
+      deleteModes={['Trash', 'Permanent']}
+      cleanupAgeDays={30}
+      lastAnalysisAtMs={Date.UTC(2026, 8, 3)}
+      busy={false}
+      analysisReady
+      error={null}
+      onSelectItem={vi.fn()}
+      onCloseInspector={vi.fn()}
+      onTogglePath={vi.fn()}
+      onDeleteModeChange={vi.fn()}
+      onCleanupAgeChange={vi.fn()}
+    />,
+  );
+}
+
+describe('WorkspaceView information hierarchy', () => {
+  it('keeps policy and cleanup controls without permanent recommendation or Trash copy', () => {
+    renderWorkspace();
+
+    expect(screen.getByText('Cleanup recommendations')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cleanup age')).toHaveValue('30');
+    expect(screen.getByRole('columnheader', { name: 'Project' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Artifact' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Size' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Modified' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Move to Trash' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete permanently' })).toBeInTheDocument();
+    expect(screen.queryByText(/Review recommendations based on inactivity age/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Trash is the default cleanup mode.')).not.toBeInTheDocument();
+    expect(screen.queryByText(/cannot be undone/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the existing artifact inspector available on demand', () => {
+    renderWorkspace();
+
+    expect(screen.getByRole('complementary', { name: 'Artifact inspector' })).toBeInTheDocument();
+    expect(screen.getAllByText('/workspace/dustfril/target').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/dustfril-tauri/src/features/app-shell/views/WorkspaceView.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/views/WorkspaceView.tsx
@@ -29,7 +29,6 @@ type WorkspaceViewProps = {
   lastAnalysisAtMs: number | null;
   busy: boolean;
   analysisReady: boolean;
-  statusMessage: string;
   error: string | null;
   onSelectItem: (path: string) => void;
   onCloseInspector: () => void;
@@ -95,12 +94,6 @@ export function WorkspaceView(props: WorkspaceViewProps) {
         </div>
       ) : null}
 
-      {!props.error && props.analysisReady ? (
-        <div className="workspace-notice" role="status">
-          {props.statusMessage}
-        </div>
-      ) : null}
-
       <div className="workspace-layout">
         <section className="results-pane" aria-label="Workspace artifacts">
           <div className="results-toolbar">
@@ -159,6 +152,7 @@ export function WorkspaceView(props: WorkspaceViewProps) {
                 key={mode}
                 type="button"
                 className={props.deleteMode === mode ? 'mode-active' : ''}
+                aria-pressed={props.deleteMode === mode}
                 onClick={() => props.onDeleteModeChange(mode)}
               >
                 {mode === 'Trash' ? 'Move to Trash' : 'Delete permanently'}

--- a/apps/dustfril-tauri/src/styles/style.css
+++ b/apps/dustfril-tauri/src/styles/style.css
@@ -988,16 +988,15 @@ button:disabled {
 }
 
 .history-list-scroll {
-  position: relative;
-  min-height: 0;
-  flex: 1;
+  position: absolute;
+  inset: 0;
   overflow: auto;
 }
 
-.history-list-container {
+.history-list-layout {
   position: relative;
-  height: 100%;
-  min-height: 100%;
+  min-height: 0;
+  flex: 1;
 }
 
 .history-table {
@@ -1035,20 +1034,20 @@ button:disabled {
   text-transform: uppercase;
 }
 
-.history-row-button {
+.history-row-interactive {
   width: 100%;
   border: 0;
   background: #222427;
-  font: inherit;
+  cursor: pointer;
   text-align: left;
 }
 
-.history-row-button:hover,
+.history-row-interactive:hover,
 .history-row-active {
   background: rgba(102, 185, 220, 0.1);
 }
 
-.history-row-button:focus-visible {
+.history-row-interactive:focus-visible {
   box-shadow: inset 0 0 0 1px #6ac9ec;
 }
 

--- a/apps/dustfril-tauri/src/styles/style.css
+++ b/apps/dustfril-tauri/src/styles/style.css
@@ -305,27 +305,6 @@ button:disabled {
   color: #d9e7ee;
 }
 
-.sidebar-note {
-  display: flex;
-  align-items: flex-start;
-  gap: 7px;
-  margin: auto 8px 0;
-  padding-top: 18px;
-  color: #78818e;
-  font-size: 11px;
-  line-height: 1.45;
-}
-
-.sidebar-note-dot {
-  width: 6px;
-  height: 6px;
-  flex: 0 0 auto;
-  margin-top: 4px;
-  border-radius: 50%;
-  background: #65c6e7;
-  box-shadow: 0 0 7px rgba(101, 198, 231, 0.6);
-}
-
 .main-pane {
   min-width: 0;
   min-height: 0;
@@ -1009,87 +988,294 @@ button:disabled {
 }
 
 .history-list-scroll {
+  position: relative;
   min-height: 0;
   flex: 1;
-  overflow-y: auto;
+  overflow: auto;
 }
 
-.history-list {
+.history-list-container {
+  position: relative;
+  height: 100%;
+  min-height: 100%;
+}
+
+.history-table {
+  min-width: 680px;
+}
+
+.history-view .content-heading {
+  padding-bottom: 10px;
+}
+
+.history-row {
   display: grid;
-  gap: 9px;
+  grid-template-columns: minmax(126px, 1.05fr) minmax(92px, 0.7fr) minmax(120px, 0.95fr) minmax(205px, 1.9fr) minmax(100px, 0.75fr) 20px;
+  align-items: center;
+  min-width: 0;
+  min-height: 56px;
+  padding: 0 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+  color: #c7ced7;
+  font-size: 12px;
+  outline: 0;
 }
 
-.history-entry {
-  padding: 13px 14px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 7px;
+.history-row-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  min-height: 31px;
+  border-bottom-color: rgba(255, 255, 255, 0.09);
+  background: #25272a;
+  color: #828c99;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.history-row-button {
+  width: 100%;
+  border: 0;
   background: #222427;
+  font: inherit;
+  text-align: left;
 }
 
-.history-entry-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 10px;
+.history-row-button:hover,
+.history-row-active {
+  background: rgba(102, 185, 220, 0.1);
 }
 
-.history-entry-title {
-  margin: 0;
-  color: #e9eef4;
-  font-size: 13px;
+.history-row-button:focus-visible {
+  box-shadow: inset 0 0 0 1px #6ac9ec;
+}
+
+.history-time,
+.history-result,
+.history-status {
+  min-width: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.history-time {
+  overflow: hidden;
+  color: #aeb8c4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-kind {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  color: #d4dce5;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.history-kind-mark {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #9b8ce8;
+  box-shadow: 0 0 7px rgba(155, 140, 232, 0.45);
+}
+
+.history-kind-cleanup .history-kind-mark {
+  background: #63c5e8;
+  box-shadow: 0 0 7px rgba(99, 197, 232, 0.45);
+}
+
+.history-kind-security .history-kind-mark {
+  background: #e8b968;
+  box-shadow: 0 0 7px rgba(232, 185, 104, 0.4);
+}
+
+.history-target,
+.history-result {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-target {
+  color: #f0f4f8;
+  font-size: 12px;
   font-weight: 650;
 }
 
-.history-entry-subtitle {
-  margin: 4px 0 0;
-  color: #818b98;
+.history-result {
+  color: #aeb9c5;
   font-size: 11px;
 }
 
-.history-badge {
+.history-status {
+  display: inline-flex;
+  width: fit-content;
   min-height: 21px;
-  margin: 0;
-  padding: 3px 7px;
+  align-items: center;
+  padding: 0 7px;
   border: 1px solid transparent;
   border-radius: 5px;
   font-size: 10px;
   font-weight: 700;
+  white-space: nowrap;
 }
 
-.history-badge-success {
+.history-status-success {
   border-color: rgba(103, 207, 153, 0.25);
   background: rgba(64, 172, 111, 0.11);
   color: #b6e7cc;
 }
 
-.history-badge-failure {
+.history-status-failure {
   border-color: rgba(240, 112, 112, 0.28);
   background: rgba(191, 68, 68, 0.12);
   color: #f0b7b7;
 }
 
-.history-details-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
-  margin-top: 12px;
+.history-chevron {
+  color: #8b96a3;
+  font-size: 20px;
+  line-height: 1;
+  text-align: right;
 }
 
-.history-detail {
+.history-drawer {
+  width: min(480px, calc(100% - 20px));
+}
+
+.history-drawer-title {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 7px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.history-drawer-title h2 {
+  margin: 0;
+  color: #f4f7fa;
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.history-drawer-title p {
+  margin: 0;
+  color: #8f99a6;
+  font-size: 11px;
+}
+
+.history-drawer-details {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 16px;
+}
+
+.history-drawer-details > div {
   min-width: 0;
+}
+
+.history-drawer-details dd {
+  overflow-wrap: anywhere;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.history-drawer-section {
+  margin-top: 20px;
+}
+
+.history-access-details {
+  margin-top: 9px;
+}
+
+.history-access-details > div {
   padding: 8px 9px;
   border-radius: 5px;
   background: rgba(255, 255, 255, 0.045);
 }
 
-.history-access-summary,
+.history-cleanup-items {
+  display: grid;
+  gap: 7px;
+  margin-top: 9px;
+}
+
+.history-cleanup-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 10px;
+  padding: 9px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.history-cleanup-item strong,
+.history-cleanup-item span {
+  display: block;
+  min-width: 0;
+}
+
+.history-cleanup-item strong {
+  overflow: hidden;
+  color: #e4eaf0;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-cleanup-item > div:first-child > span {
+  margin-top: 4px;
+  overflow-wrap: anywhere;
+  color: #84909d;
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.history-cleanup-item-meta {
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+  color: #b7c0ca;
+  font-size: 10px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.history-item-success {
+  color: #a9dfc0;
+}
+
+.history-item-failed,
+.history-detail-reason {
+  color: #e8abab;
+}
+
+.history-detail-reason {
+  margin: 16px 0 0;
+  padding: 9px;
+  border: 1px solid rgba(240, 112, 112, 0.2);
+  border-radius: 5px;
+  background: rgba(191, 68, 68, 0.09);
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
 .history-failure-list,
 .history-finding-list {
   margin-top: 12px;
 }
 
 .history-failure-list ul,
-.history-finding-list ul {
+.history-finding-list {
   display: grid;
   gap: 4px;
   margin: 5px 0 0;
@@ -1100,9 +1286,8 @@ button:disabled {
 }
 
 .history-failure-list li {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  line-height: 1.4;
 }
 
 .history-finding {
@@ -1414,10 +1599,6 @@ button:disabled {
     padding: 0 7px;
   }
 
-  .sidebar-note {
-    display: none;
-  }
-
   .workspace-view,
   .overview-view,
   .history-view {
@@ -1453,6 +1634,10 @@ button:disabled {
   }
 
   .workspace-drawer {
+    width: min(420px, calc(100% - 14px));
+  }
+
+  .history-drawer {
     width: min(420px, calc(100% - 14px));
   }
 

--- a/apps/dustfril-tauri/src/test/setup.ts
+++ b/apps/dustfril-tauri/src/test/setup.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => cleanup());

--- a/apps/dustfril-tauri/src/types/workflow.ts
+++ b/apps/dustfril-tauri/src/types/workflow.ts
@@ -164,6 +164,16 @@ export type ActivityFailure = {
   reason?: string;
 };
 
+export type CleanupActivityItem = {
+  path: string;
+  status: 'succeeded' | 'failed';
+  project?: string;
+  projectRoot?: string;
+  ecosystem?: Ecosystem;
+  size?: number;
+  reason?: string;
+};
+
 export type ScanAccessFailure = {
   path: string;
   reason: string;
@@ -182,6 +192,7 @@ export type ScanAccessSummary = {
 
 export type ActivityDetails = {
   path?: string;
+  target?: string;
   artifacts?: number;
   size?: number;
   accessSummary?: ScanAccessSummary;
@@ -189,6 +200,7 @@ export type ActivityDetails = {
   deleted?: string[];
   failed?: ActivityFailure[];
   freed?: number;
+  items?: CleanupActivityItem[];
   ecosystems?: Ecosystem[];
   findingCount?: number;
   highestRisk?: RiskLevel;

--- a/apps/dustfril-tauri/vitest.config.ts
+++ b/apps/dustfril-tauri/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+  },
+});

--- a/crates/dustfril-core/src/api/history.rs
+++ b/crates/dustfril-core/src/api/history.rs
@@ -4,8 +4,8 @@ use crate::{
     error::DustResult,
     history,
     models::{
-        ActivityRecord, CleanupHistoryEntry, CleanupResult, DeleteMode, Ecosystem,
-        ScanAccessSummary, ScanResult, SecurityReport,
+        ActivityRecord, CleanupCandidate, CleanupHistoryEntry, CleanupResult, DeleteMode,
+        Ecosystem, ScanAccessSummary, ScanResult, SecurityReport,
     },
 };
 
@@ -22,6 +22,17 @@ pub fn record_activity(activity: ActivityRecord) -> DustResult<()> {
 /// Records a cleanup operation while preserving the original API shape.
 pub fn record_cleanup(mode: DeleteMode, result: &CleanupResult) -> DustResult<()> {
     history::record_cleanup(mode, result)
+}
+
+/// Records cleanup details with the workspace and analyzed candidates that
+/// were available to the caller at execution time.
+pub fn record_cleanup_with_context(
+    target_path: &Path,
+    candidates: &[CleanupCandidate],
+    mode: DeleteMode,
+    result: &CleanupResult,
+) -> DustResult<()> {
+    history::record_cleanup_with_context(target_path, candidates, mode, result)
 }
 
 /// Records a scan operation and its detected artifact summary.
@@ -50,6 +61,15 @@ pub fn record_scan_failure_with_summary(
 /// Records a cleanup that failed before producing a cleanup result.
 pub fn record_cleanup_failure(mode: DeleteMode, reason: &str) -> DustResult<()> {
     history::record_cleanup_failure(mode, reason)
+}
+
+/// Records a cleanup preparation failure with its workspace target.
+pub fn record_cleanup_failure_with_context(
+    target_path: &Path,
+    mode: DeleteMode,
+    reason: &str,
+) -> DustResult<()> {
+    history::record_cleanup_failure_with_context(target_path, mode, reason)
 }
 
 /// Records one explicit security scan in the unified activity history.

--- a/crates/dustfril-core/src/history/mod.rs
+++ b/crates/dustfril-core/src/history/mod.rs
@@ -12,8 +12,8 @@ use serde_json::Value;
 use crate::{
     error::{DustError, DustResult},
     models::{
-        ActivityRecord, CleanupHistoryEntry, CleanupResult, DeleteMode, Ecosystem,
-        ScanAccessSummary, ScanResult, SecurityReport,
+        ActivityRecord, CleanupCandidate, CleanupHistoryEntry, CleanupResult, DeleteMode,
+        Ecosystem, ScanAccessSummary, ScanResult, SecurityReport,
     },
 };
 
@@ -44,6 +44,22 @@ pub fn record(activity: ActivityRecord) -> DustResult<()> {
 /// Records a cleanup operation in the unified activity history.
 pub fn record_cleanup(mode: DeleteMode, result: &CleanupResult) -> DustResult<()> {
     record(ActivityRecord::cleanup(mode, result))
+}
+
+/// Records a cleanup operation together with the workspace and analyzed item
+/// metadata that make the event useful when reviewing history later.
+pub fn record_cleanup_with_context(
+    target_path: &Path,
+    candidates: &[CleanupCandidate],
+    mode: DeleteMode,
+    result: &CleanupResult,
+) -> DustResult<()> {
+    record(ActivityRecord::cleanup_with_context(
+        target_path,
+        mode,
+        candidates,
+        result,
+    ))
 }
 
 /// Records a scan operation in the unified activity history.
@@ -77,6 +93,19 @@ pub fn record_scan_failure_with_summary(
 /// Records a cleanup that failed before producing a cleanup result.
 pub fn record_cleanup_failure(mode: DeleteMode, reason: &str) -> DustResult<()> {
     record(ActivityRecord::cleanup_failure(mode, reason))
+}
+
+/// Records a cleanup preparation failure while retaining its workspace target.
+pub fn record_cleanup_failure_with_context(
+    target_path: &Path,
+    mode: DeleteMode,
+    reason: &str,
+) -> DustResult<()> {
+    record(ActivityRecord::cleanup_failure_with_context(
+        target_path,
+        mode,
+        reason,
+    ))
 }
 
 /// Records one explicit security scan in the unified activity history.
@@ -223,8 +252,9 @@ mod tests {
 
     use super::*;
     use crate::models::{
-        ActivityKind, ActivityResult, Artifact, CleanupFailure, CleanupFailureReason, Ecosystem,
-        RiskLevel, ScanAccessSummary, SecurityFinding, SecurityFindingKind, SecurityReport,
+        ActivityKind, ActivityResult, Artifact, CleanupCandidate, CleanupFailure,
+        CleanupFailureReason, CleanupRecommendation, Ecosystem, ProjectIdentity, RiskLevel,
+        ScanAccessSummary, SecurityFinding, SecurityFindingKind, SecurityReport,
     };
 
     fn cleanup_result() -> CleanupResult {
@@ -453,6 +483,45 @@ mod tests {
         assert!(!activity.result.success);
         assert_eq!(activity.result.details["deleted"][0], "target");
         assert_eq!(activity.result.details["failed"][0]["path"], "node_modules");
+    }
+
+    #[test]
+    fn contextual_cleanup_details_survive_history_reload() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("history.json");
+        let candidate = CleanupCandidate {
+            path: temp.path().join("dustfril/target"),
+            ecosystem: Ecosystem::Rust,
+            project: ProjectIdentity::new(temp.path().join("dustfril"), Ecosystem::Rust),
+            size_bytes: 4096,
+            age_days: Some(90),
+            recommendation: CleanupRecommendation::SafeToClean,
+        };
+        let result = CleanupResult {
+            deleted_paths: vec![candidate.path.clone()],
+            failed_paths: Vec::new(),
+            freed_size_bytes: candidate.size_bytes,
+        };
+
+        record_to(
+            &path,
+            ActivityRecord::cleanup_with_context(
+                temp.path(),
+                DeleteMode::Trash,
+                &[candidate],
+                &result,
+            ),
+        )
+        .unwrap();
+
+        let records = load_unlocked(&path).unwrap();
+
+        assert_eq!(
+            records[0].result.details["target"],
+            temp.path().display().to_string()
+        );
+        assert_eq!(records[0].result.details["items"][0]["size"], 4096);
+        assert_eq!(records[0].result.details["items"][0]["status"], "succeeded");
     }
 
     #[test]

--- a/crates/dustfril-core/src/models/history.rs
+++ b/crates/dustfril-core/src/models/history.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::models::{
-    CleanupResult, DeleteMode, Ecosystem, RiskLevel, ScanAccessSummary, ScanResult, SecurityReport,
-    effective_security_ecosystems,
+    CleanupCandidate, CleanupResult, DeleteMode, Ecosystem, RiskLevel, ScanAccessSummary,
+    ScanResult, SecurityReport, effective_security_ecosystems,
 };
 
 /// The kind of operation represented by an activity record.
@@ -118,6 +118,30 @@ impl ActivityResult {
         )
     }
 
+    /// Builds a cleanup result with the workspace and analyzed item identity
+    /// that was available at execution time. The additional fields are
+    /// additive JSON details so older history records remain valid.
+    pub fn from_cleanup_with_context(
+        target_path: &Path,
+        mode: DeleteMode,
+        candidates: &[CleanupCandidate],
+        result: &CleanupResult,
+    ) -> Self {
+        let mut details = Self::from_cleanup(mode, result).details;
+        if let Value::Object(object) = &mut details {
+            object.insert(
+                "target".to_owned(),
+                Value::String(sanitize_path(target_path)),
+            );
+            object.insert(
+                "items".to_owned(),
+                Value::Array(cleanup_item_details(candidates, result)),
+            );
+        }
+
+        Self::new(result.failed_paths.is_empty(), details)
+    }
+
     /// Builds the result payload for a cleanup that failed before a result
     /// could be produced.
     pub fn from_cleanup_failure(mode: DeleteMode, reason: &str) -> Self {
@@ -131,6 +155,25 @@ impl ActivityResult {
                 "reason": sanitize_text(reason),
             }),
         )
+    }
+
+    /// Builds a failed cleanup result with the workspace target retained when
+    /// preparation failed before any analyzed candidates were available.
+    pub fn from_cleanup_failure_with_context(
+        target_path: &Path,
+        mode: DeleteMode,
+        reason: &str,
+    ) -> Self {
+        let mut details = Self::from_cleanup_failure(mode, reason).details;
+        if let Value::Object(object) = &mut details {
+            object.insert(
+                "target".to_owned(),
+                Value::String(sanitize_path(target_path)),
+            );
+            object.insert("items".to_owned(), Value::Array(Vec::new()));
+        }
+
+        Self::new(false, details)
     }
 
     /// Builds a safe, structured result payload for a completed security scan.
@@ -248,10 +291,33 @@ impl ActivityRecord {
         )
     }
 
+    pub fn cleanup_with_context(
+        target_path: &Path,
+        mode: DeleteMode,
+        candidates: &[CleanupCandidate],
+        result: &CleanupResult,
+    ) -> Self {
+        Self::new(
+            ActivityKind::Cleanup,
+            ActivityResult::from_cleanup_with_context(target_path, mode, candidates, result),
+        )
+    }
+
     pub fn cleanup_failure(mode: DeleteMode, reason: &str) -> Self {
         Self::new(
             ActivityKind::Cleanup,
             ActivityResult::from_cleanup_failure(mode, reason),
+        )
+    }
+
+    pub fn cleanup_failure_with_context(
+        target_path: &Path,
+        mode: DeleteMode,
+        reason: &str,
+    ) -> Self {
+        Self::new(
+            ActivityKind::Cleanup,
+            ActivityResult::from_cleanup_failure_with_context(target_path, mode, reason),
         )
     }
 
@@ -321,6 +387,65 @@ fn paths_to_values(paths: &[PathBuf]) -> Vec<Value> {
         .iter()
         .map(|path| Value::String(path.display().to_string()))
         .collect()
+}
+
+fn cleanup_item_details(candidates: &[CleanupCandidate], result: &CleanupResult) -> Vec<Value> {
+    let mut items = Vec::with_capacity(result.deleted_paths.len() + result.failed_paths.len());
+
+    for path in &result.deleted_paths {
+        items.push(cleanup_item_detail(
+            candidates.iter().find(|candidate| candidate.path == *path),
+            path,
+            "succeeded",
+            None,
+        ));
+    }
+
+    for failure in &result.failed_paths {
+        items.push(cleanup_item_detail(
+            candidates
+                .iter()
+                .find(|candidate| candidate.path == failure.path),
+            &failure.path,
+            "failed",
+            Some(failure.reason.to_string()),
+        ));
+    }
+
+    items
+}
+
+fn cleanup_item_detail(
+    candidate: Option<&CleanupCandidate>,
+    path: &Path,
+    status: &str,
+    reason: Option<String>,
+) -> Value {
+    let mut detail = serde_json::Map::new();
+    detail.insert("path".to_owned(), Value::String(sanitize_path(path)));
+    detail.insert("status".to_owned(), Value::String(status.to_owned()));
+
+    if let Some(candidate) = candidate {
+        detail.insert(
+            "project".to_owned(),
+            Value::String(sanitize_text(&candidate.project.display_name)),
+        );
+        detail.insert(
+            "projectRoot".to_owned(),
+            Value::String(sanitize_path(&candidate.project.root)),
+        );
+        detail.insert(
+            "ecosystem".to_owned(),
+            Value::String(candidate.ecosystem.to_string()),
+        );
+        detail.insert("size".to_owned(), Value::from(candidate.size_bytes));
+    }
+
+    if let Some(reason) = reason {
+        detail.insert("reason".to_owned(), Value::String(sanitize_text(&reason)));
+    }
+
+    Value::Object(detail)
 }
 
 fn ecosystem_labels(ecosystems: &[Ecosystem]) -> Vec<&'static str> {
@@ -664,5 +789,58 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn cleanup_activity_context_preserves_workspace_project_and_item_metadata() {
+        let candidate = CleanupCandidate {
+            path: "/workspace/dustfril/target".into(),
+            ecosystem: Ecosystem::Rust,
+            project: crate::models::ProjectIdentity::new(
+                "/workspace/dustfril".into(),
+                Ecosystem::Rust,
+            ),
+            size_bytes: 2048,
+            age_days: Some(60),
+            recommendation: crate::models::CleanupRecommendation::SafeToClean,
+        };
+        let result = CleanupResult {
+            deleted_paths: vec![candidate.path.clone()],
+            failed_paths: Vec::new(),
+            freed_size_bytes: candidate.size_bytes,
+        };
+
+        let activity = ActivityRecord::cleanup_with_context(
+            Path::new("/workspace"),
+            DeleteMode::Trash,
+            &[candidate],
+            &result,
+        );
+
+        assert_eq!(activity.result.details["target"], "/workspace");
+        assert_eq!(activity.result.details["items"][0]["project"], "dustfril");
+        assert_eq!(
+            activity.result.details["items"][0]["projectRoot"],
+            "/workspace/dustfril"
+        );
+        assert_eq!(activity.result.details["items"][0]["size"], 2048);
+        assert_eq!(activity.result.details["items"][0]["status"], "succeeded");
+    }
+
+    #[test]
+    fn failed_cleanup_context_retains_workspace_target() {
+        let activity = ActivityRecord::cleanup_failure_with_context(
+            Path::new("/workspace"),
+            DeleteMode::Permanent,
+            "analysis expired",
+        );
+
+        assert!(!activity.result.success);
+        assert_eq!(activity.result.details["target"], "/workspace");
+        assert_eq!(
+            activity.result.details["items"].as_array().unwrap().len(),
+            0
+        );
+        assert_eq!(activity.result.details["reason"], "analysis expired");
     }
 }


### PR DESCRIPTION
## Summary
- Remove redundant Workspace recommendation and sidebar Trash copy.
- Keep permanent-delete warning at Review Cleanup confirmation.
- Replace large History diagnostic cards with compact accessible rows and an Inspector-style details drawer.
- Preserve scan diagnostics and enrich new cleanup history records with workspace and per-item context.

## Restore investigation
Restore is intentionally deferred. The current trash dependency has no equivalent public macOS restore/list API for the default Finder-backed flow, and history does not persist an OS trash-item identity. A fake Restore action would not provide safe cross-platform conflict or missing-item handling.

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace: 27 CLI, 283 core, and 18 Tauri tests passed
- npm test: 4 files, 7 tests passed
- npm run build
- git diff --check

Desktop visual launch was attempted but port 1420 was already occupied by another DustFril process, which was left untouched.