### PR TITLE
Refine Overview, Workspace, and History screens

### DIFF
--- a/apps/dustfril-tauri/src/components/HistoryList/HistoryList.test.tsx
+++ b/apps/dustfril-tauri/src/components/HistoryList/HistoryList.test.tsx
@@ -181,4 +181,32 @@ describe('HistoryList', () => {
     expect(screen.getByText('Ecosystems').parentElement).toHaveTextContent('None');
     expect(screen.queryByText('All')).not.toBeInTheDocument();
   });
+
+  it('sorts every history column and keeps the details drawer tied to its event id', () => {
+    render(<HistoryList entries={[scanEntry, cleanupEntry, securityEntry]} />);
+
+    expect(screen.getByRole('columnheader', { name: 'Time' })).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+    expect(screen.getAllByRole('button')).toHaveLength(5);
+
+    fireEvent.click(screen.getByRole('row', { name: /Inspect Cleanup activity/ }));
+    expect(screen.getByRole('heading', { name: 'Cleanup details' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Target' }));
+    expect(screen.getByRole('heading', { name: 'Cleanup details' })).toBeInTheDocument();
+    expect(screen.getByText('/Users/mars112/code/dustfril/target')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Target' })).toHaveAttribute(
+      'aria-sort',
+      'ascending',
+    );
+    expect(screen.getByRole('columnheader', { name: 'Time' })).toHaveAttribute('aria-sort', 'none');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Target' }));
+    expect(screen.getByRole('columnheader', { name: 'Target' })).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+  });
 });

--- a/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
+++ b/apps/dustfril-tauri/src/components/HistoryList/HistoryList.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { SortableHeader } from '../SortableHeader/SortableHeader';
 import type {
   ActivityDetails,
   ActivityRecord,
@@ -7,8 +8,18 @@ import type {
   SecurityActivityFinding,
 } from '../../types/workflow';
 import { formatBytes, formatDate } from '../../lib/format';
+import {
+  cleanupItems,
+  cleanupModeLabel,
+  historyResultLabel,
+  historyStatusLabel,
+  historyTargetLabel,
+} from '../../model/activity';
 import { leafName } from '../../model/presentation';
+import { sortActivityRecords, type HistorySortColumn, type HistorySortState } from '../../model/sorting';
 import { EmptyState } from '../EmptyState/EmptyState';
+
+export { historyStatusLabel } from '../../model/activity';
 
 type HistoryListProps = {
   entries: ActivityRecord[];
@@ -16,8 +27,20 @@ type HistoryListProps = {
 
 export function HistoryList(props: HistoryListProps) {
   const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
+  const [sort, setSort] = useState<HistorySortState>({ column: 'time', direction: 'desc' });
   const selectedEntry =
     props.entries.find((entry) => entry.id === selectedEntryId) ?? null;
+  const sortedEntries = useMemo(
+    () => sortActivityRecords(props.entries, sort),
+    [props.entries, sort],
+  );
+
+  function handleSort(column: HistorySortColumn) {
+    setSort((current) => ({
+      column,
+      direction: current.column === column && current.direction === 'asc' ? 'desc' : 'asc',
+    }));
+  }
 
   useEffect(() => {
     if (selectedEntryId && !selectedEntry) {
@@ -49,17 +72,42 @@ export function HistoryList(props: HistoryListProps) {
       <div className="history-list-scroll">
         <div className="history-table" role="table" aria-label="Activity history">
           <div className="history-row history-row-header" role="row">
-            <span role="columnheader">Time</span>
-            <span role="columnheader">Action</span>
-            <span role="columnheader">Target</span>
-            <span role="columnheader">Result</span>
-            <span role="columnheader">Status</span>
+            <SortableHeader
+              label="Time"
+              active={sort.column === 'time'}
+              direction={sort.direction}
+              onSort={() => handleSort('time')}
+            />
+            <SortableHeader
+              label="Action"
+              active={sort.column === 'action'}
+              direction={sort.direction}
+              onSort={() => handleSort('action')}
+            />
+            <SortableHeader
+              label="Target"
+              active={sort.column === 'target'}
+              direction={sort.direction}
+              onSort={() => handleSort('target')}
+            />
+            <SortableHeader
+              label="Result"
+              active={sort.column === 'result'}
+              direction={sort.direction}
+              onSort={() => handleSort('result')}
+            />
+            <SortableHeader
+              label="Status"
+              active={sort.column === 'status'}
+              direction={sort.direction}
+              onSort={() => handleSort('status')}
+            />
             <span aria-hidden="true" />
           </div>
           <div className="history-table-body">
-            {props.entries.map((entry, index) => (
+            {sortedEntries.map((entry) => (
               <HistoryRow
-                key={`${entry.id}-${index}`}
+                key={entry.id}
                 entry={entry}
                 selected={entry.id === selectedEntryId}
                 onSelect={() => setSelectedEntryId(entry.id)}
@@ -340,93 +388,8 @@ function Detail({ label, value }: { label: string; value: string }) {
   );
 }
 
-function cleanupItems(details: ActivityDetails): CleanupActivityItem[] {
-  if (details.items?.length) {
-    return details.items;
-  }
-
-  return [
-    ...(details.deleted ?? []).map((path) => ({ path, status: 'succeeded' as const })),
-    ...(details.failed ?? []).map((failure) => ({
-      path: failure.path,
-      status: 'failed' as const,
-      reason: failure.reason,
-    })),
-  ];
-}
-
-function cleanupModeLabel(mode: ActivityDetails['mode']) {
-  return mode === 'trash'
-    ? 'Move to Trash'
-    : mode === 'permanent'
-      ? 'Delete permanently'
-      : 'Unknown';
-}
-
-export function historyStatusLabel(entry: ActivityRecord) {
-  const failureCount = historyFailureCount(entry);
-  if (failureCount > 0 && (entry.kind !== 'Cleanup' || cleanupSuccessCount(entry) > 0)) {
-    return 'Partial failure';
-  }
-
-  return entry.result.success ? 'Success' : 'Failed';
-}
-
 function historyStatusClass(status: string) {
   return status === 'Success' ? 'history-status-success' : 'history-status-failure';
-}
-
-function historyFailureCount(entry: ActivityRecord) {
-  if (entry.kind === 'Scan') {
-    return entry.result.details.accessSummary?.failures ?? 0;
-  }
-
-  if (entry.kind === 'Cleanup') {
-    const recordedFailures = entry.result.details.failed?.length ?? 0;
-    const contextualFailures =
-      entry.result.details.items?.filter((item) => item.status === 'failed').length ?? 0;
-    return Math.max(recordedFailures, contextualFailures);
-  }
-
-  return 0;
-}
-
-function cleanupSuccessCount(entry: ActivityRecord) {
-  if (entry.kind !== 'Cleanup') {
-    return 0;
-  }
-
-  return cleanupItems(entry.result.details).filter((item) => item.status === 'succeeded').length;
-}
-
-function historyTargetLabel(entry: ActivityRecord) {
-  const details = entry.result.details;
-
-  if (entry.kind === 'Cleanup') {
-    const projects = Array.from(
-      new Set(
-        (details.items ?? [])
-          .map((item) => item.project)
-          .filter((project): project is string => Boolean(project)),
-      ),
-    );
-    if (projects.length === 1) {
-      return projects[0];
-    }
-    if (projects.length > 1) {
-      return `${projects[0]} + ${projects.length - 1}`;
-    }
-  }
-
-  return conciseTargetName(details.target ?? details.path ?? firstCleanupPath(details));
-}
-
-function firstCleanupPath(details: ActivityDetails) {
-  return details.deleted?.[0] ?? details.failed?.[0]?.path ?? 'Unknown';
-}
-
-function conciseTargetName(path: string) {
-  return path === 'Unknown' ? path : leafName(path);
 }
 
 function securityEcosystemLabel(ecosystems: string[] | undefined) {
@@ -437,33 +400,6 @@ function securityEcosystemLabel(ecosystems: string[] | undefined) {
   return ecosystems.length ? ecosystems.join(', ') : 'None';
 }
 
-function historyResultLabel(entry: ActivityRecord) {
-  const details = entry.result.details;
-
-  switch (entry.kind) {
-    case 'Scan': {
-      const count = details.artifacts ?? 0;
-      const failures = details.accessSummary?.failures ?? 0;
-      return `${count} artifact${count === 1 ? '' : 's'} · ${formatBytes(details.size ?? 0)}${
-        failures ? ` · ${failures} failure${failures === 1 ? '' : 's'}` : ''
-      }`;
-    }
-    case 'Cleanup': {
-      const items = cleanupItems(details);
-      const succeeded = items.filter((item) => item.status === 'succeeded').length;
-      const failed = items.filter((item) => item.status === 'failed').length;
-      const verb = details.mode === 'trash' ? 'moved to Trash' : 'deleted';
-      const result = `${succeeded} item${succeeded === 1 ? '' : 's'} · ${formatBytes(
-        details.freed ?? 0,
-      )} ${verb}`;
-      return failed ? `${result} · ${failed} failed` : result;
-    }
-    case 'Security': {
-      const count = details.findingCount ?? details.findings?.length ?? 0;
-      return `${count} finding${count === 1 ? '' : 's'} · ${details.highestRisk ?? 'None'} risk`;
-    }
-  }
-}
 
 function formatHistoryDate(timestampMs: number) {
   return new Intl.DateTimeFormat(undefined, {

--- a/apps/dustfril-tauri/src/components/SortableHeader/SortableHeader.tsx
+++ b/apps/dustfril-tauri/src/components/SortableHeader/SortableHeader.tsx
@@ -1,0 +1,32 @@
+import type { SortDirection } from '../../model/sorting';
+
+type SortableHeaderProps = {
+  label: string;
+  active: boolean;
+  direction: SortDirection;
+  onSort: () => void;
+};
+
+export function SortableHeader(props: SortableHeaderProps) {
+  return (
+    <div
+      role="columnheader"
+      aria-sort={props.active ? (props.direction === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <button
+        type="button"
+        className="sortable-header"
+        aria-label={props.label}
+        title={`Sort by ${props.label}`}
+        onClick={props.onSort}
+      >
+        <span>{props.label}</span>
+        {props.active ? (
+          <span className="sort-indicator" aria-hidden="true">
+            {props.direction === 'asc' ? '↑' : '↓'}
+          </span>
+        ) : null}
+      </button>
+    </div>
+  );
+}

--- a/apps/dustfril-tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/AppShell.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppShell } from './AppShell';
+import { analyzeWorkspace } from '../../lib/tauri';
+
+vi.mock('../../lib/tauri', () => ({
+  analyzeWorkspace: vi.fn(),
+  chooseWorkspaceFolder: vi.fn(),
+  defaultRoot: vi.fn().mockResolvedValue('/workspace'),
+  executeCleanup: vi.fn(),
+  loadActivityHistory: vi.fn().mockResolvedValue([]),
+}));
+
+const analyzedArtifact = {
+  path: '/workspace/dustfril/target',
+  ecosystem: 'Rust' as const,
+  project: {
+    root: '/workspace/dustfril',
+    displayName: 'dustfril',
+    ecosystem: 'Rust' as const,
+  },
+  sizeBytes: 11 * 1024 ** 3,
+  lastModifiedMs: Date.UTC(2026, 8, 1),
+  ageDays: 30,
+  recommendation: 'Keep' as const,
+};
+
+describe('AppShell Overview navigation', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('opens the exact Overview artifact in Workspace without selecting it', async () => {
+    vi.mocked(analyzeWorkspace).mockResolvedValue({
+      analysis: {
+        artifacts: [analyzedArtifact],
+        totalSizeBytes: analyzedArtifact.sizeBytes,
+      },
+      cleanupPlan: {
+        analysisId: 'analysis-1',
+        candidates: [
+          {
+            path: analyzedArtifact.path,
+            ecosystem: analyzedArtifact.ecosystem,
+            project: analyzedArtifact.project,
+            sizeBytes: analyzedArtifact.sizeBytes,
+            ageDays: analyzedArtifact.ageDays,
+            recommendation: analyzedArtifact.recommendation,
+            selectedByDefault: false,
+          },
+        ],
+        reclaimableSizeBytes: 0,
+      },
+    });
+
+    render(<AppShell />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Analyze Workspace' })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: 'Analyze Workspace' }));
+    await waitFor(() => expect(screen.getByText('Cleanup recommendations')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Overview' }));
+    expect(screen.queryByRole('button', { name: 'Review Cleanup' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^History/ }));
+    expect(screen.queryByRole('button', { name: 'Review Cleanup' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^Workspace/ }));
+    expect(screen.getByRole('button', { name: 'Review Cleanup' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Overview' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect dustfril target' }));
+
+    expect(screen.getByRole('button', { name: /^Workspace/ })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('complementary', { name: 'Artifact inspector' })).toBeInTheDocument();
+    expect(screen.getAllByText('/workspace/dustfril/target').length).toBeGreaterThan(0);
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+});

--- a/apps/dustfril-tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/AppShell.tsx
@@ -1,6 +1,5 @@
 import { CleanupDialog } from '../../components/CleanupDialog/CleanupDialog';
 import { Sidebar } from '../../components/Sidebar/Sidebar';
-import { formatBytes } from '../../lib/format';
 import { pathBreadcrumb } from '../../model/presentation';
 import { AppHeader } from './components/AppHeader';
 import { useAppState } from './hooks/useAppState';
@@ -10,7 +9,6 @@ import { WorkspaceView } from './views/WorkspaceView';
 
 export function AppShell() {
   const app = useAppState();
-  const historyCount = app.sidebarEntries.find((entry) => entry.key === 'history')?.count ?? 0;
 
   return (
     <main className="app-shell">
@@ -36,13 +34,13 @@ export function AppShell() {
             <OverviewView
               root={app.root}
               analysisReady={app.analysisResult !== null}
-              artifactCount={app.summary.artifactCount}
-              reclaimableBytes={app.summary.reclaimableBytes}
-              lastAnalysisAtMs={app.lastAnalysisAtMs}
-              historyCount={historyCount}
-              discoveredEcosystems={app.discoveredEcosystems}
-              statusMessage={app.statusMessage}
+              artifacts={app.analysisResult?.artifacts ?? []}
+              candidates={app.cleanupPlan?.candidates ?? []}
+              reclaimableBytes={app.cleanupPlan?.reclaimableSizeBytes ?? 0}
+              historyEntries={app.historyEntries}
               error={app.error}
+              onInspectArtifact={app.openWorkspaceArtifact}
+              onOpenHistory={() => app.setActiveCategory('history')}
             />
           ) : null}
 
@@ -54,6 +52,8 @@ export function AppShell() {
               reclaimableBytes={app.cleanupPlan?.reclaimableSizeBytes ?? 0}
               selectedItemId={app.selectedItemId}
               selectedPaths={app.selectedCleanupPaths}
+              selectedCandidateBytes={app.selectedCandidateBytes}
+              canReviewCleanup={app.canReviewCleanup}
               deleteMode={app.deleteMode}
               deleteModes={app.deleteModes}
               cleanupAgeDays={app.cleanupAgeDays}
@@ -66,6 +66,7 @@ export function AppShell() {
               onTogglePath={app.toggleCleanupPath}
               onDeleteModeChange={app.setDeleteMode}
               onCleanupAgeChange={app.handleCleanupAgeChange}
+              onRequestCleanup={app.handleRequestCleanup}
             />
           ) : null}
 
@@ -85,17 +86,6 @@ export function AppShell() {
           ) : (
             <span>No workspace selected</span>
           )}
-        </div>
-        <div className="statusbar-selection">
-          <span>Selected size {formatBytes(app.selectedCandidateBytes)}</span>
-          <button
-            type="button"
-            className="review-button"
-            onClick={app.handleRequestCleanup}
-            disabled={!app.canReviewCleanup}
-          >
-            Review Cleanup
-          </button>
         </div>
       </footer>
 

--- a/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/dustfril-tauri/src/features/app-shell/hooks/useAppState.ts
@@ -16,12 +16,7 @@ import type {
   CleanupResultResponse,
   DeleteMode,
 } from '../../../types/workflow';
-import {
-  cleanupAgeOptions,
-  defaultCleanupAgeDays,
-  deleteModes,
-  ecosystems,
-} from '../../../types/workflow';
+import { cleanupAgeOptions, defaultCleanupAgeDays, deleteModes, ecosystems } from '../../../types/workflow';
 import { createWorkspaceSummary, filterArtifacts } from '../../../model/presentation';
 
 export function useAppState() {
@@ -34,7 +29,6 @@ export function useAppState() {
   const [error, setError] = useState<string | null>(null);
   const [analysisResult, setAnalysisResult] = useState<AnalysisResponse | null>(null);
   const [cleanupPlan, setCleanupPlan] = useState<CleanupPlanResponse | null>(null);
-  const [cleanupResult, setCleanupResult] = useState<CleanupResultResponse | null>(null);
   const [historyEntries, setHistoryEntries] = useState<ActivityRecord[]>([]);
   const [selectedCleanupPaths, setSelectedCleanupPaths] = useState<string[]>([]);
   const [cleanupAgeDays, setCleanupAgeDays] = useState<number>(defaultCleanupAgeDays);
@@ -83,14 +77,6 @@ export function useAppState() {
     [workspaceArtifacts, cleanupPlan?.reclaimableSizeBytes],
   );
 
-  const discoveredEcosystems = useMemo(
-    () =>
-      ecosystems.filter((ecosystem) =>
-        workspaceArtifacts.some((artifact) => artifact.ecosystem === ecosystem),
-      ),
-    [workspaceArtifacts],
-  );
-
   const sidebarEntries = useMemo<SidebarEntry[]>(
     () =>
       categoryConfigs.map((config) => ({
@@ -104,14 +90,6 @@ export function useAppState() {
       })),
     [historyEntries.length, workspaceArtifacts.length],
   );
-
-  const statusMessage = error
-    ? error
-      : cleanupResult
-      ? `Last cleanup freed ${formatBytes(cleanupResult.freedSizeBytes)} across ${cleanupResult.deletedPaths.length} path(s).`
-      : analysisResult
-        ? 'Review recommendations based on inactivity age. Trash is the default cleanup mode.'
-        : 'Choose a workspace folder, then analyze it to find development artifacts.';
 
   const canAnalyze = busyAction === null && root.length > 0;
   const canReviewCleanup =
@@ -152,7 +130,6 @@ export function useAppState() {
     setError(null);
     setAnalysisResult(null);
     setCleanupPlan(null);
-    setCleanupResult(null);
     setSelectedCleanupPaths([]);
     setSelectedItemId(null);
     setConfirmDialogOpen(false);
@@ -218,7 +195,6 @@ export function useAppState() {
           ? current
           : null,
       );
-      setCleanupResult(null);
       setCleanupAgeDays(policyAgeDays);
       setLastAnalysisAtMs(Date.now());
       setError(
@@ -254,6 +230,12 @@ export function useAppState() {
     );
   }
 
+  function openWorkspaceArtifact(path: string) {
+    setSearch('');
+    setSelectedItemId(path);
+    setActiveCategory('workspace');
+  }
+
   function handleRequestCleanup() {
     if (canReviewCleanup) {
       setConfirmDialogOpen(true);
@@ -278,7 +260,6 @@ export function useAppState() {
         deleteMode,
       );
 
-      setCleanupResult(result);
       setError(
         result.failedPaths.length
           ? formatCleanupFailure(result, result.historyWarning)
@@ -346,9 +327,7 @@ export function useAppState() {
     lastAnalysisAtMs,
     canAnalyze,
     canReviewCleanup,
-    statusMessage,
     summary,
-    discoveredEcosystems,
     deleteModes,
     setSearch,
     setActiveCategory,
@@ -356,6 +335,7 @@ export function useAppState() {
     setDeleteMode,
     setConfirmDialogOpen,
     toggleCleanupPath,
+    openWorkspaceArtifact,
     handleRootChange,
     handleChooseWorkspace,
     handleAnalyzeWorkspace,

--- a/apps/dustfril-tauri/src/features/app-shell/views/HistoryView.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/views/HistoryView.tsx
@@ -8,13 +8,6 @@ type HistoryViewProps = {
 export function HistoryView(props: HistoryViewProps) {
   return (
     <div className="history-view">
-      <div className="content-heading">
-        <div className="heading-icon heading-icon-history">◷</div>
-        <div className="min-width-zero">
-          <p className="eyebrow">History</p>
-          <h1>Activity</h1>
-        </div>
-      </div>
       <HistoryList entries={props.entries} />
     </div>
   );

--- a/apps/dustfril-tauri/src/features/app-shell/views/OverviewView.test.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/views/OverviewView.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { OverviewView } from './OverviewView';
+import type { ActivityRecord, ArtifactAnalysis, CleanupCandidate } from '../../../types/workflow';
+
+function artifact(
+  project: string,
+  name: string,
+  sizeBytes: number,
+  recommendation: ArtifactAnalysis['recommendation'],
+): ArtifactAnalysis {
+  return {
+    path: `/workspace/${project}/${name}`,
+    ecosystem: name === 'node_modules' ? 'Node' : 'Rust',
+    project: {
+      root: `/workspace/${project}`,
+      displayName: project,
+      ecosystem: name === 'node_modules' ? 'Node' : 'Rust',
+    },
+    sizeBytes,
+    lastModifiedMs: Date.UTC(2026, 8, 1),
+    ageDays: 30,
+    recommendation,
+  };
+}
+
+function candidate(item: ArtifactAnalysis): CleanupCandidate {
+  return {
+    path: item.path,
+    ecosystem: item.ecosystem,
+    project: item.project,
+    sizeBytes: item.sizeBytes,
+    ageDays: item.ageDays,
+    recommendation: item.recommendation,
+    selectedByDefault: item.recommendation === 'SafeToClean',
+  };
+}
+
+const artifacts = [
+  artifact('dustfril', 'target', 11 * 1024 ** 3, 'Keep'),
+  artifact('frilvault', 'target', 3.6 * 1024 ** 3, 'NeedsReview'),
+  artifact('portfolio', 'node_modules', 672 * 1024 ** 2, 'NeedsReview'),
+  artifact('copc-adapter', 'target', 271 * 1024 ** 2, 'Keep'),
+  artifact('viewer-web', 'node_modules', 200 * 1024 ** 2, 'SafeToClean'),
+  artifact('small-project', 'target', 10 * 1024 ** 2, 'SafeToClean'),
+];
+
+const cleanupEntry: ActivityRecord = {
+  id: 'cleanup-1',
+  timestampMs: Date.UTC(2026, 8, 2, 11, 42),
+  kind: 'Cleanup',
+  result: {
+    success: true,
+    details: {
+      target: '/workspace',
+      mode: 'trash',
+      freed: 1.8 * 1024 ** 3,
+      items: [{ path: '/workspace/dustfril/target', project: 'dustfril', status: 'succeeded' }],
+    },
+  },
+};
+
+const newerScan: ActivityRecord = {
+  id: 'scan-2',
+  timestampMs: Date.UTC(2026, 8, 3),
+  kind: 'Scan',
+  result: { success: true, details: { path: '/workspace', artifacts: 6, size: 16 * 1024 ** 3 } },
+};
+
+function renderOverview(overrides: Partial<ComponentProps<typeof OverviewView>> = {}) {
+  return render(
+    <OverviewView
+      root="/workspace/dustfril"
+      analysisReady
+      artifacts={artifacts}
+      candidates={artifacts.map(candidate)}
+      reclaimableBytes={210 * 1024 ** 2}
+      historyEntries={[cleanupEntry, newerScan]}
+      error={null}
+      onInspectArtifact={vi.fn()}
+      onOpenHistory={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe('OverviewView', () => {
+  it('projects recommendation state into compact actionable summaries', () => {
+    renderOverview();
+
+    expect(screen.getByText('Reclaimable now')).toBeInTheDocument();
+    expect(screen.getByText('210 MB')).toBeInTheDocument();
+    expect(screen.getAllByText('2 artifacts')).toHaveLength(2);
+    expect(screen.getByText('4.3 GB')).toBeInTheDocument();
+    expect(screen.getAllByText('2 artifacts', { selector: '.overview-summary-card > span' })).toHaveLength(2);
+    expect(screen.queryByText('Discovered ecosystems')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review recommendations based on inactivity age')).not.toBeInTheDocument();
+  });
+
+  it('shows the five largest artifacts and navigates with the stable path identity', () => {
+    const onInspectArtifact = vi.fn();
+    renderOverview({ onInspectArtifact });
+
+    expect(screen.getByText('Largest artifacts')).toBeInTheDocument();
+    expect(screen.getByText('11 GB')).toBeInTheDocument();
+    expect(screen.getByText('3.6 GB')).toBeInTheDocument();
+    expect(screen.queryByText('10 MB')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect dustfril target' }));
+    expect(onInspectArtifact).toHaveBeenCalledWith('/workspace/dustfril/target');
+  });
+
+  it('uses the latest cleanup rather than a newer scan and offers History entry navigation', () => {
+    const onOpenHistory = vi.fn();
+    renderOverview({ onOpenHistory });
+
+    expect(screen.getByText(/Move to Trash · Success/)).toBeInTheDocument();
+    expect(screen.getByText(/1 artifact · 1.8 GB/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'View history' }));
+    expect(onOpenHistory).toHaveBeenCalledOnce();
+  });
+
+  it('does not present zeroes as analysis when the workspace has not been scanned', () => {
+    renderOverview({
+      analysisReady: false,
+      artifacts: [],
+      candidates: [],
+      reclaimableBytes: 0,
+      historyEntries: [],
+    });
+
+    expect(screen.getAllByText('Not analyzed')).toHaveLength(2);
+    expect(screen.getByText('Analyze this workspace to see cleanup insights.')).toBeInTheDocument();
+    expect(screen.queryByText('0 B')).not.toBeInTheDocument();
+    expect(screen.getByText('No cleanup operations yet.')).toBeInTheDocument();
+  });
+});

--- a/apps/dustfril-tauri/src/features/app-shell/views/OverviewView.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/views/OverviewView.tsx
@@ -1,84 +1,197 @@
-import { FolderIcon } from '../../../components/icons';
+import { useMemo } from 'react';
+import { EmptyState } from '../../../components/EmptyState/EmptyState';
 import { formatBytes, formatCount, formatDate } from '../../../lib/format';
-import type { Ecosystem } from '../../../types/workflow';
+import { cleanupItemCount, cleanupModeLabel, historyStatusLabel } from '../../../model/activity';
+import { leafName, recommendationClass, recommendationLabel } from '../../../model/presentation';
+import { sortArtifacts } from '../../../model/sorting';
+import type { ActivityRecord, ArtifactAnalysis, CleanupCandidate } from '../../../types/workflow';
 
 type OverviewViewProps = {
   root: string;
   analysisReady: boolean;
-  artifactCount: number;
+  artifacts: ArtifactAnalysis[];
+  candidates: CleanupCandidate[];
   reclaimableBytes: number;
-  lastAnalysisAtMs: number | null;
-  historyCount: number;
-  discoveredEcosystems: Ecosystem[];
-  statusMessage: string;
+  historyEntries: ActivityRecord[];
   error: string | null;
+  onInspectArtifact: (path: string) => void;
+  onOpenHistory: () => void;
 };
 
 export function OverviewView(props: OverviewViewProps) {
+  const reclaimableCandidates = props.candidates.filter(
+    (candidate) => candidate.selectedByDefault,
+  );
+  const needsReviewArtifacts = props.artifacts.filter(
+    (artifact) => artifact.recommendation === 'NeedsReview',
+  );
+  const largestArtifacts = useMemo(
+    () => sortArtifacts(props.artifacts, { column: 'size', direction: 'desc' }).slice(0, 5),
+    [props.artifacts],
+  );
+  const lastCleanup = useMemo(
+    () =>
+      props.historyEntries
+        .filter((entry) => entry.kind === 'Cleanup')
+        .reduce<ActivityRecord | null>(
+          (latest, entry) =>
+            latest === null ||
+            entry.timestampMs > latest.timestampMs ||
+            (entry.timestampMs === latest.timestampMs && entry.id > latest.id)
+              ? entry
+              : latest,
+          null,
+        ),
+    [props.historyEntries],
+  );
+  const needsReviewBytes = needsReviewArtifacts.reduce(
+    (total, artifact) => total + artifact.sizeBytes,
+    0,
+  );
+
   return (
     <div className="overview-view">
-      <div className="content-heading">
-        <div className="heading-icon">
-          <FolderIcon />
-        </div>
-        <div className="min-width-zero">
-          <p className="eyebrow">Overview</p>
-          <h1>Workspace summary</h1>
-          <p className="heading-path" title={props.root}>
-            {props.root || 'No workspace selected'}
-          </p>
-        </div>
+      <div className="overview-intro">
+        <p className="eyebrow">Overview</p>
+        <h1>{props.root ? leafName(props.root) : 'Overview'}</h1>
+        <p className="overview-heading-path" title={props.root}>
+          {props.root || 'No workspace selected'}
+        </p>
       </div>
 
-      <div className="overview-grid">
-        <OverviewStat
-          label="Artifacts"
-          value={props.analysisReady ? formatCount(props.artifactCount) : 'Not analyzed'}
+      <div className="overview-summary-grid">
+        <OverviewSummaryCard
+          label="Reclaimable now"
+          bytes={props.reclaimableBytes}
+          count={reclaimableCandidates.length}
+          analysisReady={props.analysisReady}
         />
-        <OverviewStat
-          label="Reclaimable"
-          value={props.analysisReady ? formatBytes(props.reclaimableBytes) : 'Not analyzed'}
+        <OverviewSummaryCard
+          label="Needs review"
+          bytes={needsReviewBytes}
+          count={needsReviewArtifacts.length}
+          analysisReady={props.analysisReady}
         />
-        <OverviewStat
-          label="Last analysis"
-          value={props.lastAnalysisAtMs ? formatDate(props.lastAnalysisAtMs) : 'Not analyzed'}
-        />
-        <OverviewStat label="History entries" value={formatCount(props.historyCount)} />
       </div>
 
-      <section className="overview-section">
-        <div>
-          <p className="eyebrow">Discovered ecosystems</p>
-          <p className="overview-caption">
-            DustFril identifies supported project artifacts during analysis.
-          </p>
+      {!props.analysisReady ? (
+        <p className="overview-analysis-hint" role="status">
+          Analyze this workspace to see cleanup insights.
+        </p>
+      ) : null}
+
+      {props.error ? (
+        <div className="overview-notice overview-notice-warning" role="status">
+          {props.error}
         </div>
-        {props.discoveredEcosystems.length ? (
-          <div className="ecosystem-list">
-            {props.discoveredEcosystems.map((ecosystem) => (
-              <span key={ecosystem} className="ecosystem-pill">
-                {ecosystem}
-              </span>
+      ) : null}
+
+      <section className="overview-panel" aria-labelledby="largest-artifacts-heading">
+        <div className="overview-section-heading">
+          <div>
+            <p className="eyebrow" id="largest-artifacts-heading">
+              Largest artifacts
+            </p>
+            <p className="overview-caption">
+              The biggest normalized artifacts found in this workspace.
+            </p>
+          </div>
+        </div>
+        {!props.analysisReady ? (
+          <EmptyState compact message="Analyze this workspace to load artifacts." />
+        ) : largestArtifacts.length ? (
+          <div className="overview-artifact-table" role="table" aria-label="Largest artifacts">
+            <div className="overview-artifact-row overview-artifact-row-header" role="row">
+              <span role="columnheader">Project</span>
+              <span role="columnheader">Artifact</span>
+              <span role="columnheader">Size</span>
+              <span role="columnheader">Status</span>
+            </div>
+            {largestArtifacts.map((artifact) => (
+              <button
+                type="button"
+                className="overview-artifact-row overview-artifact-row-button"
+                key={artifact.path}
+                onClick={() => props.onInspectArtifact(artifact.path)}
+                aria-label={`Inspect ${artifact.project.displayName} ${leafName(artifact.path)}`}
+              >
+                <span>{artifact.project.displayName}</span>
+                <span>{leafName(artifact.path)}</span>
+                <span>{formatBytes(artifact.sizeBytes)}</span>
+                <span className={recommendationClass(artifact.recommendation)}>
+                  {recommendationLabel(artifact.recommendation)}
+                </span>
+              </button>
             ))}
           </div>
         ) : (
-          <p className="overview-muted">No analysis results yet.</p>
+          <EmptyState compact message="No supported development artifacts were found." />
         )}
       </section>
 
-      <section className={`overview-status${props.error ? ' overview-status-error' : ''}`} role="status">
-        <p className="eyebrow">Activity</p>
-        <p>{props.statusMessage}</p>
+      <section
+        className="overview-panel overview-last-cleanup"
+        aria-labelledby="last-cleanup-heading"
+      >
+        <div className="overview-section-heading">
+          <p className="eyebrow" id="last-cleanup-heading">
+            Last cleanup
+          </p>
+          <button type="button" className="overview-link" onClick={props.onOpenHistory}>
+            View history
+          </button>
+        </div>
+        {lastCleanup ? (
+          <LastCleanupSummary entry={lastCleanup} />
+        ) : (
+          <p className="overview-muted">No cleanup operations yet.</p>
+        )}
       </section>
     </div>
   );
 }
 
-function OverviewStat({ label, value }: { label: string; value: string }) {
+function OverviewSummaryCard({
+  label,
+  bytes,
+  count,
+  analysisReady,
+}: {
+  label: string;
+  bytes: number;
+  count: number;
+  analysisReady: boolean;
+}) {
   return (
-    <div className="overview-stat">
-      <span>{label}</span>
-      <strong>{value}</strong>
+    <article className="overview-summary-card">
+      <p className="eyebrow">{label}</p>
+      {analysisReady ? (
+        <>
+          <strong>{formatBytes(bytes)}</strong>
+          <span>
+            {formatCount(count)} artifact{count === 1 ? '' : 's'}
+          </span>
+        </>
+      ) : (
+        <strong className="overview-summary-unavailable">Not analyzed</strong>
+      )}
+    </article>
+  );
+}
+
+function LastCleanupSummary({ entry }: { entry: ActivityRecord }) {
+  const details = entry.result.details;
+  const itemCount = cleanupItemCount(details);
+
+  return (
+    <div className="last-cleanup-summary">
+      <strong>{formatDate(entry.timestampMs)}</strong>
+      <span>
+        {formatCount(itemCount)} artifact{itemCount === 1 ? '' : 's'} · {formatBytes(details.freed ?? 0)}
+      </span>
+      <span>
+        {cleanupModeLabel(details.mode)} · {historyStatusLabel(entry)}
+      </span>
     </div>
   );
 }

--- a/apps/dustfril-tauri/src/features/app-shell/views/WorkspaceView.test.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/views/WorkspaceView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { WorkspaceView } from './WorkspaceView';
 import type { ArtifactAnalysis } from '../../../types/workflow';
@@ -26,6 +26,8 @@ function renderWorkspace(deleteMode: 'Trash' | 'Permanent' = 'Trash') {
       reclaimableBytes={0}
       selectedItemId={artifact.path}
       selectedPaths={[]}
+      selectedCandidateBytes={0}
+      canReviewCleanup={false}
       deleteMode={deleteMode}
       deleteModes={['Trash', 'Permanent']}
       cleanupAgeDays={30}
@@ -38,6 +40,7 @@ function renderWorkspace(deleteMode: 'Trash' | 'Permanent' = 'Trash') {
       onTogglePath={vi.fn()}
       onDeleteModeChange={vi.fn()}
       onCleanupAgeChange={vi.fn()}
+      onRequestCleanup={vi.fn()}
     />,
   );
 }
@@ -53,8 +56,11 @@ describe('WorkspaceView information hierarchy', () => {
     expect(screen.getByRole('columnheader', { name: 'Size' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Modified' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Size' })).toHaveAttribute('aria-sort', 'descending');
     expect(screen.getByRole('button', { name: 'Move to Trash' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Delete permanently' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review Cleanup' })).toBeDisabled();
+    expect(screen.getByText('0 selected · 0 B')).toBeInTheDocument();
     expect(screen.queryByText(/Review recommendations based on inactivity age/)).not.toBeInTheDocument();
     expect(screen.queryByText('Trash is the default cleanup mode.')).not.toBeInTheDocument();
     expect(screen.queryByText(/cannot be undone/)).not.toBeInTheDocument();
@@ -65,5 +71,16 @@ describe('WorkspaceView information hierarchy', () => {
 
     expect(screen.getByRole('complementary', { name: 'Artifact inspector' })).toBeInTheDocument();
     expect(screen.getAllByText('/workspace/dustfril/target').length).toBeGreaterThan(0);
+  });
+
+  it('toggles the active sort direction and exposes only the active indicator', () => {
+    renderWorkspace();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Project' }));
+    expect(screen.getByRole('columnheader', { name: 'Project' })).toHaveAttribute('aria-sort', 'ascending');
+    expect(screen.getByRole('columnheader', { name: 'Size' })).toHaveAttribute('aria-sort', 'none');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Project' }));
+    expect(screen.getByRole('columnheader', { name: 'Project' })).toHaveAttribute('aria-sort', 'descending');
   });
 });

--- a/apps/dustfril-tauri/src/features/app-shell/views/WorkspaceView.tsx
+++ b/apps/dustfril-tauri/src/features/app-shell/views/WorkspaceView.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { EmptyState } from '../../../components/EmptyState/EmptyState';
 import { FolderIcon, ItemIcon } from '../../../components/icons';
+import { SortableHeader } from '../../../components/SortableHeader/SortableHeader';
 import { formatAge, formatBytes, formatCount, formatDate } from '../../../lib/format';
 import {
   artifactDetailLines,
@@ -15,6 +16,11 @@ import type {
   DeleteMode,
 } from '../../../types/workflow';
 import { cleanupAgeOptions } from '../../../types/workflow';
+import {
+  sortArtifacts,
+  type WorkspaceSortColumn,
+  type WorkspaceSortState,
+} from '../../../model/sorting';
 
 type WorkspaceViewProps = {
   artifacts: ArtifactAnalysis[];
@@ -23,6 +29,8 @@ type WorkspaceViewProps = {
   reclaimableBytes: number;
   selectedItemId: string | null;
   selectedPaths: string[];
+  selectedCandidateBytes: number;
+  canReviewCleanup: boolean;
   deleteMode: DeleteMode;
   deleteModes: DeleteMode[];
   cleanupAgeDays: number;
@@ -35,12 +43,25 @@ type WorkspaceViewProps = {
   onTogglePath: (path: string) => void;
   onDeleteModeChange: (mode: DeleteMode) => void;
   onCleanupAgeChange: (days: number) => void | Promise<void>;
+  onRequestCleanup: () => void;
 };
 
 export function WorkspaceView(props: WorkspaceViewProps) {
+  const [sort, setSort] = useState<WorkspaceSortState>({ column: 'size', direction: 'desc' });
   const candidatesByPath = new Map(props.candidates.map((candidate) => [candidate.path, candidate]));
   const selectedArtifact =
     props.artifacts.find((artifact) => artifact.path === props.selectedItemId) ?? null;
+  const sortedArtifacts = useMemo(
+    () => sortArtifacts(props.artifacts, sort),
+    [props.artifacts, sort],
+  );
+
+  function handleSort(column: WorkspaceSortColumn) {
+    setSort((current) => ({
+      column,
+      direction: current.column === column && current.direction === 'asc' ? 'desc' : 'asc',
+    }));
+  }
 
   useEffect(() => {
     if (!selectedArtifact) {
@@ -72,10 +93,6 @@ export function WorkspaceView(props: WorkspaceViewProps) {
                 {formatBytes(props.reclaimableBytes)}
               </strong>{' '}
               reclaimable
-            </span>
-            <span className="summary-separator">·</span>
-            <span>
-              <strong>{formatCount(props.selectedPaths.length)}</strong> selected
             </span>
             {props.lastAnalysisAtMs ? (
               <span className="summary-last-analysis">
@@ -123,11 +140,13 @@ export function WorkspaceView(props: WorkspaceViewProps) {
           </div>
 
           <WorkspaceResults
-            artifacts={props.artifacts}
+            artifacts={sortedArtifacts}
             candidatesByPath={candidatesByPath}
             selectedItemId={props.selectedItemId}
             selectedPaths={props.selectedPaths}
             analysisReady={props.analysisReady}
+            sort={sort}
+            onSort={handleSort}
             onSelectItem={props.onSelectItem}
             onTogglePath={props.onTogglePath}
           />
@@ -160,6 +179,19 @@ export function WorkspaceView(props: WorkspaceViewProps) {
             ))}
           </div>
         </div>
+        <div className="cleanup-selection-summary">
+          <span>
+            {formatCount(props.selectedPaths.length)} selected · {formatBytes(props.selectedCandidateBytes)}
+          </span>
+          <button
+            type="button"
+            className="review-button"
+            onClick={props.onRequestCleanup}
+            disabled={!props.canReviewCleanup}
+          >
+            Review Cleanup
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -171,6 +203,8 @@ type WorkspaceResultsProps = {
   selectedItemId: string | null;
   selectedPaths: string[];
   analysisReady: boolean;
+  sort: WorkspaceSortState;
+  onSort: (column: WorkspaceSortColumn) => void;
   onSelectItem: (path: string) => void;
   onTogglePath: (path: string) => void;
 };
@@ -198,13 +232,38 @@ function WorkspaceResults(props: WorkspaceResultsProps) {
     <div className="workspace-table" role="table" aria-label="Cleanup recommendations">
       <div className="result-row result-row-header" role="row">
         <span aria-hidden="true" />
-        <span role="columnheader">Project</span>
-        <span role="columnheader">Artifact</span>
-        <span role="columnheader">Size</span>
-        <span role="columnheader" className="modified-column">
-          Modified
-        </span>
-        <span role="columnheader">Status</span>
+        <SortableHeader
+          label="Project"
+          active={props.sort.column === 'project'}
+          direction={props.sort.direction}
+          onSort={() => props.onSort('project')}
+        />
+        <SortableHeader
+          label="Artifact"
+          active={props.sort.column === 'artifact'}
+          direction={props.sort.direction}
+          onSort={() => props.onSort('artifact')}
+        />
+        <SortableHeader
+          label="Size"
+          active={props.sort.column === 'size'}
+          direction={props.sort.direction}
+          onSort={() => props.onSort('size')}
+        />
+        <div className="modified-column">
+          <SortableHeader
+            label="Modified"
+            active={props.sort.column === 'modified'}
+            direction={props.sort.direction}
+            onSort={() => props.onSort('modified')}
+          />
+        </div>
+        <SortableHeader
+          label="Status"
+          active={props.sort.column === 'status'}
+          direction={props.sort.direction}
+          onSort={() => props.onSort('status')}
+        />
       </div>
       <div className="workspace-table-body">
         {props.artifacts.map((artifact) => {

--- a/apps/dustfril-tauri/src/model/activity.ts
+++ b/apps/dustfril-tauri/src/model/activity.ts
@@ -1,0 +1,190 @@
+import { formatBytes } from '../lib/format';
+import type {
+  ActivityDetails,
+  ActivityKind,
+  ActivityRecord,
+  CleanupActivityItem,
+} from '../types/workflow';
+import { leafName } from './presentation';
+
+export type HistoryResultSortKey = {
+  bytes: number;
+  itemCount: number;
+  fallbackText: string;
+};
+
+export function cleanupItems(details: ActivityDetails): CleanupActivityItem[] {
+  if (details.items?.length) {
+    return details.items;
+  }
+
+  return [
+    ...(details.deleted ?? []).map((path) => ({ path, status: 'succeeded' as const })),
+    ...(details.failed ?? []).map((failure) => ({
+      path: failure.path,
+      status: 'failed' as const,
+      reason: failure.reason,
+    })),
+  ];
+}
+
+export function cleanupItemCount(details: ActivityDetails) {
+  return cleanupItems(details).length;
+}
+
+export function cleanupModeLabel(mode: ActivityDetails['mode']) {
+  return mode === 'trash'
+    ? 'Move to Trash'
+    : mode === 'permanent'
+      ? 'Delete permanently'
+      : 'Unknown';
+}
+
+export function historyStatusLabel(entry: ActivityRecord) {
+  const failureCount = historyFailureCount(entry);
+  if (failureCount > 0 && (entry.kind !== 'Cleanup' || cleanupSuccessCount(entry) > 0)) {
+    return 'Partial failure';
+  }
+
+  return entry.result.success ? 'Success' : 'Failed';
+}
+
+export function historyStatusRank(entry: ActivityRecord) {
+  switch (historyStatusLabel(entry)) {
+    case 'Failed':
+      return 3;
+    case 'Partial failure':
+      return 2;
+    case 'Success':
+      return 1;
+  }
+}
+
+export function historyTargetLabel(entry: ActivityRecord) {
+  const details = entry.result.details;
+
+  if (entry.kind === 'Cleanup') {
+    const projects = Array.from(
+      new Set(
+        (details.items ?? [])
+          .map((item) => item.project)
+          .filter((project): project is string => Boolean(project)),
+      ),
+    );
+    projects.sort(compareText);
+    if (projects.length === 1) {
+      return projects[0];
+    }
+    if (projects.length > 1) {
+      return `${projects[0]} + ${projects.length - 1}`;
+    }
+  }
+
+  return conciseTargetName(details.target ?? details.path ?? firstCleanupPath(details));
+}
+
+export function historyResultLabel(entry: ActivityRecord) {
+  const details = entry.result.details;
+
+  switch (entry.kind) {
+    case 'Scan': {
+      const count = details.artifacts ?? 0;
+      const failures = details.accessSummary?.failures ?? 0;
+      return `${count} artifact${count === 1 ? '' : 's'} · ${formatBytes(details.size ?? 0)}${
+        failures ? ` · ${failures} failure${failures === 1 ? '' : 's'}` : ''
+      }`;
+    }
+    case 'Cleanup': {
+      const items = cleanupItems(details);
+      const succeeded = items.filter((item) => item.status === 'succeeded').length;
+      const failed = items.filter((item) => item.status === 'failed').length;
+      const verb = details.mode === 'trash' ? 'moved to Trash' : 'deleted';
+      const result = `${succeeded} item${succeeded === 1 ? '' : 's'} · ${formatBytes(
+        details.freed ?? 0,
+      )} ${verb}`;
+      return failed ? `${result} · ${failed} failed` : result;
+    }
+    case 'Security': {
+      const count = details.findingCount ?? details.findings?.length ?? 0;
+      return `${count} finding${count === 1 ? '' : 's'} · ${details.highestRisk ?? 'None'} risk`;
+    }
+  }
+}
+
+/**
+ * Numeric result data kept separate from the compact result label. This lets
+ * History sort heterogeneous operations without reverse-engineering UI text.
+ */
+export function historyResultSortKey(entry: ActivityRecord): HistoryResultSortKey {
+  const details = entry.result.details;
+
+  switch (entry.kind) {
+    case 'Scan':
+      return {
+        bytes: details.size ?? 0,
+        itemCount: details.artifacts ?? 0,
+        fallbackText: details.path ?? '',
+      };
+    case 'Cleanup': {
+      const items = cleanupItems(details);
+      return {
+        bytes: details.freed ?? 0,
+        itemCount: items.filter((item) => item.status === 'succeeded').length,
+        fallbackText: details.mode ?? '',
+      };
+    }
+    case 'Security':
+      return {
+        bytes: 0,
+        itemCount: details.findingCount ?? details.findings?.length ?? 0,
+        fallbackText: details.highestRisk ?? '',
+      };
+  }
+}
+
+export function historyActionSortKey(kind: ActivityKind) {
+  return kind;
+}
+
+function historyFailureCount(entry: ActivityRecord) {
+  if (entry.kind === 'Scan') {
+    return entry.result.details.accessSummary?.failures ?? 0;
+  }
+
+  if (entry.kind === 'Cleanup') {
+    const recordedFailures = entry.result.details.failed?.length ?? 0;
+    const contextualFailures =
+      entry.result.details.items?.filter((item) => item.status === 'failed').length ?? 0;
+    return Math.max(recordedFailures, contextualFailures);
+  }
+
+  return 0;
+}
+
+function cleanupSuccessCount(entry: ActivityRecord) {
+  return entry.kind === 'Cleanup'
+    ? cleanupItems(entry.result.details).filter((item) => item.status === 'succeeded').length
+    : 0;
+}
+
+function firstCleanupPath(details: ActivityDetails) {
+  return details.deleted?.[0] ?? details.failed?.[0]?.path ?? 'Unknown';
+}
+
+function conciseTargetName(path: string) {
+  return path === 'Unknown' ? path : leafName(path);
+}
+
+function compareText(left: string, right: string) {
+  const leftLower = left.toLowerCase();
+  const rightLower = right.toLowerCase();
+  return leftLower === rightLower
+    ? left === right
+      ? 0
+      : left < right
+        ? -1
+        : 1
+    : leftLower < rightLower
+      ? -1
+      : 1;
+}

--- a/apps/dustfril-tauri/src/model/sorting.test.ts
+++ b/apps/dustfril-tauri/src/model/sorting.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import type { ActivityRecord, ArtifactAnalysis } from '../types/workflow';
+import { sortActivityRecords, sortArtifacts } from './sorting';
+
+function artifact(
+  path: string,
+  project: string,
+  sizeBytes: number,
+  lastModifiedMs: number | null,
+  recommendation: ArtifactAnalysis['recommendation'],
+): ArtifactAnalysis {
+  return {
+    path: `/workspace/${project}/${path}`,
+    ecosystem: path === 'node_modules' ? 'Node' : 'Rust',
+    project: {
+      root: `/workspace/${project}`,
+      displayName: project,
+      ecosystem: path === 'node_modules' ? 'Node' : 'Rust',
+    },
+    sizeBytes,
+    lastModifiedMs,
+    ageDays: null,
+    recommendation,
+  };
+}
+
+function activity(
+  id: string,
+  timestampMs: number,
+  kind: ActivityRecord['kind'],
+  details: ActivityRecord['result']['details'],
+  success = true,
+): ActivityRecord {
+  return { id, timestampMs, kind, result: { success, details } };
+}
+
+describe('artifact sorting', () => {
+  const artifacts = [
+    artifact('target', 'Zeta', 672 * 1024 ** 2, 200, 'Keep'),
+    artifact('node_modules', 'alpha', 11 * 1024 ** 3, 100, 'NeedsReview'),
+    artifact('target', 'beta', 102 * 1024 ** 2, 300, 'SafeToClean'),
+  ];
+
+  it('sorts projects and artifacts case-insensitively in both directions', () => {
+    expect(sortArtifacts(artifacts, { column: 'project', direction: 'asc' }).map((item) => item.project.displayName)).toEqual([
+      'alpha',
+      'beta',
+      'Zeta',
+    ]);
+    expect(sortArtifacts(artifacts, { column: 'project', direction: 'desc' }).map((item) => item.project.displayName)).toEqual([
+      'Zeta',
+      'beta',
+      'alpha',
+    ]);
+
+    expect(sortArtifacts(artifacts, { column: 'artifact', direction: 'asc' }).map((item) => item.path)).toEqual([
+      '/workspace/alpha/node_modules',
+      '/workspace/beta/target',
+      '/workspace/Zeta/target',
+    ]);
+    expect(sortArtifacts(artifacts, { column: 'artifact', direction: 'desc' }).map((item) => item.path)).toEqual([
+      '/workspace/Zeta/target',
+      '/workspace/beta/target',
+      '/workspace/alpha/node_modules',
+    ]);
+  });
+
+  it('sorts size and modified values from their numeric data', () => {
+    expect(sortArtifacts(artifacts, { column: 'size', direction: 'desc' }).map((item) => item.sizeBytes)).toEqual([
+      11 * 1024 ** 3,
+      672 * 1024 ** 2,
+      102 * 1024 ** 2,
+    ]);
+    expect(sortArtifacts(artifacts, { column: 'modified', direction: 'asc' }).map((item) => item.lastModifiedMs)).toEqual([
+      100,
+      200,
+      300,
+    ]);
+  });
+
+  it('sorts status by cleanup priority and keeps equal values deterministic', () => {
+    expect(sortArtifacts(artifacts, { column: 'status', direction: 'desc' }).map((item) => item.recommendation)).toEqual([
+      'SafeToClean',
+      'NeedsReview',
+      'Keep',
+    ]);
+    expect(sortArtifacts(artifacts, { column: 'status', direction: 'asc' }).map((item) => item.recommendation)).toEqual([
+      'Keep',
+      'NeedsReview',
+      'SafeToClean',
+    ]);
+  });
+});
+
+describe('activity sorting', () => {
+  const entries = [
+    activity('scan-large', 100, 'Scan', { path: '/workspace/one', artifacts: 2, size: 11 * 1024 ** 3 }),
+    activity('cleanup-small', 300, 'Cleanup', {
+      target: '/workspace/one',
+      mode: 'trash',
+      freed: 672 * 1024 ** 2,
+      items: [{ path: '/workspace/one/target', status: 'succeeded' }],
+    }),
+    activity('scan-small', 200, 'Scan', { path: '/workspace/two', artifacts: 14, size: 102 * 1024 ** 2 }),
+    activity('cleanup-failed', 400, 'Cleanup', {
+      target: '/workspace/two',
+      mode: 'permanent',
+      freed: 672 * 1024 ** 2,
+      items: [{ path: '/workspace/two/target', status: 'failed' }],
+    }, false),
+  ];
+
+  it('sorts time, action, and result using semantic fields', () => {
+    expect(sortActivityRecords(entries, { column: 'time', direction: 'desc' }).map((entry) => entry.id)).toEqual([
+      'cleanup-failed',
+      'cleanup-small',
+      'scan-small',
+      'scan-large',
+    ]);
+    expect(sortActivityRecords(entries, { column: 'action', direction: 'asc' }).map((entry) => entry.kind)).toEqual([
+      'Cleanup',
+      'Cleanup',
+      'Scan',
+      'Scan',
+    ]);
+    expect(sortActivityRecords(entries, { column: 'result', direction: 'desc' }).map((entry) => entry.id)).toEqual([
+      'scan-large',
+      'cleanup-small',
+      'cleanup-failed',
+      'scan-small',
+    ]);
+  });
+
+  it('sorts status by operational severity', () => {
+    expect(sortActivityRecords(entries, { column: 'status', direction: 'desc' }).map((entry) => entry.id)).toEqual([
+      'cleanup-failed',
+      'scan-small',
+      'cleanup-small',
+      'scan-large',
+    ]);
+  });
+});

--- a/apps/dustfril-tauri/src/model/sorting.ts
+++ b/apps/dustfril-tauri/src/model/sorting.ts
@@ -1,0 +1,176 @@
+import type { ActivityRecord, ArtifactAnalysis, Recommendation } from '../types/workflow';
+import {
+  historyActionSortKey,
+  historyResultSortKey,
+  historyStatusRank,
+  historyTargetLabel,
+} from './activity';
+import { leafName } from './presentation';
+
+export type SortDirection = 'asc' | 'desc';
+
+export type WorkspaceSortColumn = 'project' | 'artifact' | 'size' | 'modified' | 'status';
+export type HistorySortColumn = 'time' | 'action' | 'target' | 'result' | 'status';
+
+export type WorkspaceSortState = {
+  column: WorkspaceSortColumn;
+  direction: SortDirection;
+};
+
+export type HistorySortState = {
+  column: HistorySortColumn;
+  direction: SortDirection;
+};
+
+export function sortArtifacts(
+  artifacts: ArtifactAnalysis[],
+  sort: WorkspaceSortState,
+): ArtifactAnalysis[] {
+  return artifacts
+    .map((artifact, index) => ({ artifact, index }))
+    .sort((left, right) => {
+      const comparison = compareArtifacts(left.artifact, right.artifact, sort.column);
+      return comparison
+        ? sort.direction === 'asc'
+          ? comparison
+          : -comparison
+        : left.index - right.index;
+    })
+    .map(({ artifact }) => artifact);
+}
+
+export function sortActivityRecords(
+  entries: ActivityRecord[],
+  sort: HistorySortState,
+): ActivityRecord[] {
+  return entries
+    .map((entry, index) => ({ entry, index }))
+    .sort((left, right) => {
+      const comparison = compareActivity(left.entry, right.entry, sort.column);
+      if (comparison) {
+        return sort.direction === 'asc' ? comparison : -comparison;
+      }
+
+      return compareText(left.entry.id, right.entry.id) || left.index - right.index;
+    })
+    .map(({ entry }) => entry);
+}
+
+function compareArtifacts(
+  left: ArtifactAnalysis,
+  right: ArtifactAnalysis,
+  column: WorkspaceSortColumn,
+) {
+  switch (column) {
+    case 'project':
+      return (
+        compareText(left.project.displayName, right.project.displayName) ||
+        compareText(left.project.root, right.project.root) ||
+        compareText(leafName(left.path), leafName(right.path)) ||
+        compareText(left.path, right.path)
+      );
+    case 'artifact':
+      return (
+        compareText(leafName(left.path), leafName(right.path)) ||
+        compareText(left.ecosystem, right.ecosystem) ||
+        compareText(left.project.displayName, right.project.displayName) ||
+        compareText(left.path, right.path)
+      );
+    case 'size':
+      return (
+        compareNumber(left.sizeBytes, right.sizeBytes) ||
+        compareText(left.project.displayName, right.project.displayName) ||
+        compareText(left.path, right.path)
+      );
+    case 'modified':
+      return (
+        compareNullableNumber(left.lastModifiedMs, right.lastModifiedMs) ||
+        compareText(left.project.displayName, right.project.displayName) ||
+        compareText(left.path, right.path)
+      );
+    case 'status':
+      return (
+        compareNumber(recommendationRank(left.recommendation), recommendationRank(right.recommendation)) ||
+        compareText(left.project.displayName, right.project.displayName) ||
+        compareText(left.path, right.path)
+      );
+  }
+}
+
+function compareActivity(left: ActivityRecord, right: ActivityRecord, column: HistorySortColumn) {
+  switch (column) {
+    case 'time':
+      return compareNumber(left.timestampMs, right.timestampMs);
+    case 'action':
+      return (
+        compareText(historyActionSortKey(left.kind), historyActionSortKey(right.kind)) ||
+        compareText(historyTargetLabel(left), historyTargetLabel(right)) ||
+        compareNumber(left.timestampMs, right.timestampMs)
+      );
+    case 'target':
+      return (
+        compareText(historyTargetLabel(left), historyTargetLabel(right)) ||
+        compareText(left.kind, right.kind) ||
+        compareNumber(left.timestampMs, right.timestampMs)
+      );
+    case 'result': {
+      const leftKey = historyResultSortKey(left);
+      const rightKey = historyResultSortKey(right);
+      return (
+        compareNumber(leftKey.bytes, rightKey.bytes) ||
+        compareNumber(leftKey.itemCount, rightKey.itemCount) ||
+        compareText(leftKey.fallbackText, rightKey.fallbackText) ||
+        compareNumber(left.timestampMs, right.timestampMs)
+      );
+    }
+    case 'status':
+      return (
+        compareNumber(historyStatusRank(left), historyStatusRank(right)) ||
+        compareText(historyTargetLabel(left), historyTargetLabel(right)) ||
+        compareNumber(left.timestampMs, right.timestampMs)
+      );
+  }
+}
+
+function recommendationRank(recommendation: Recommendation) {
+  switch (recommendation) {
+    case 'Keep':
+      return 1;
+    case 'NeedsReview':
+      return 2;
+    case 'SafeToClean':
+      return 3;
+  }
+}
+
+function compareNumber(left: number, right: number) {
+  return left === right ? 0 : left < right ? -1 : 1;
+}
+
+function compareNullableNumber(left: number | null, right: number | null) {
+  if (left === null && right === null) {
+    return 0;
+  }
+  if (left === null) {
+    return 1;
+  }
+  if (right === null) {
+    return -1;
+  }
+
+  return compareNumber(left, right);
+}
+
+function compareText(left: string, right: string) {
+  const leftLower = left.toLowerCase();
+  const rightLower = right.toLowerCase();
+  return leftLower === rightLower
+    ? left === right
+      ? 0
+      : left < right
+        ? -1
+        : 1
+    : leftLower < rightLower
+      ? -1
+      : 1;
+}

--- a/apps/dustfril-tauri/src/styles/style.css
+++ b/apps/dustfril-tauri/src/styles/style.css
@@ -334,6 +334,11 @@ button:disabled {
   padding: 0 24px 14px;
 }
 
+.overview-view {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
 .content-heading {
   display: flex;
   align-items: center;

--- a/apps/dustfril-tauri/src/styles/style.css
+++ b/apps/dustfril-tauri/src/styles/style.css
@@ -330,6 +330,10 @@ button:disabled {
   padding: 22px 24px 14px;
 }
 
+.history-view {
+  padding: 0 24px 14px;
+}
+
 .content-heading {
   display: flex;
   align-items: center;
@@ -567,6 +571,37 @@ button:disabled {
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
+}
+
+.sortable-header {
+  display: inline-flex;
+  width: 100%;
+  min-height: 30px;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  text-align: left;
+  text-transform: inherit;
+}
+
+.sortable-header:hover {
+  color: #c4d2dc;
+}
+
+.sortable-header:focus-visible {
+  outline: 1px solid #70cdee;
+  outline-offset: -2px;
+}
+
+.sort-indicator {
+  color: #9ddff5;
+  font-size: 12px;
+  line-height: 1;
 }
 
 .result-selection {
@@ -833,6 +868,7 @@ button:disabled {
   gap: 12px;
   min-height: 40px;
   flex: 0 0 auto;
+  flex-wrap: wrap;
   padding-top: 10px;
 }
 
@@ -841,6 +877,17 @@ button:disabled {
   align-items: center;
   gap: 9px;
   min-width: 0;
+}
+
+.cleanup-selection-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+  color: #b5bec9;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .mode-toggle {
@@ -913,60 +960,110 @@ button:disabled {
   height: 19px;
 }
 
-.overview-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1px;
+.overview-intro {
   flex: 0 0 auto;
-  overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 7px;
-  background: rgba(255, 255, 255, 0.08);
+  padding-bottom: 13px;
 }
 
-.overview-stat {
+.overview-intro h1 {
+  margin: 3px 0 0;
+  color: #f7f9fc;
+  font-size: 21px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+}
+
+.overview-heading-path {
+  max-width: 720px;
+  margin: 4px 0 0;
+  overflow: hidden;
+  color: #87919e;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overview-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  flex: 0 0 auto;
+}
+
+.overview-summary-card {
   display: flex;
   min-width: 0;
-  min-height: 76px;
-  justify-content: center;
+  min-height: 92px;
+  justify-content: space-between;
   flex-direction: column;
-  gap: 6px;
-  padding: 13px;
+  gap: 5px;
+  padding: 13px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
   background: #25272a;
 }
 
-.overview-stat span {
-  color: #858f9b;
-  font-size: 11px;
-}
-
-.overview-stat strong {
+.overview-summary-card strong {
   overflow: hidden;
   color: #f1f5f8;
-  font-size: 18px;
+  font-size: 21px;
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.overview-section,
-.overview-status {
+.overview-summary-card > span {
+  color: #a8b2bd;
+  font-size: 11px;
+}
+
+.overview-summary-unavailable {
+  color: #9ba5b0 !important;
+  font-size: 16px !important;
+}
+
+.overview-analysis-hint,
+.overview-notice {
+  flex: 0 0 auto;
+  margin: 10px 0 0;
+  padding: 9px 11px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.035);
+  color: #a3adb9;
+  font-size: 12px;
+}
+
+.overview-notice-warning {
+  border-color: rgba(247, 190, 91, 0.25);
+  background: rgba(180, 117, 28, 0.08);
+  color: #f7d797;
+}
+
+.overview-panel {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  margin-top: 14px;
-  padding: 14px;
+  min-width: 0;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 13px 14px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 7px;
   background: #222427;
 }
 
-.overview-caption,
-.overview-status p:not(.eyebrow) {
+.overview-section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.overview-caption {
   margin: 5px 0 0;
   color: #a3adb9;
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .overview-muted {
@@ -975,16 +1072,93 @@ button:disabled {
   font-size: 12px;
 }
 
-.overview-status {
-  align-items: flex-start;
-  justify-content: flex-start;
-  flex-direction: column;
-  background: rgba(50, 163, 116, 0.07);
+.overview-link {
+  flex: 0 0 auto;
+  padding: 2px 0;
+  background: transparent;
+  color: #8fd6ef;
+  font-size: 11px;
 }
 
-.overview-status-error {
-  border-color: rgba(247, 190, 91, 0.25);
-  background: rgba(180, 117, 28, 0.08);
+.overview-link:hover {
+  color: #c4effc;
+}
+
+.overview-artifact-table {
+  min-width: 0;
+}
+
+.overview-artifact-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1.2fr) minmax(130px, 1.5fr) minmax(75px, 0.7fr) minmax(105px, 0.85fr);
+  align-items: center;
+  min-width: 0;
+  min-height: 38px;
+  padding: 0 9px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+  color: #c7ced7;
+  font-size: 11px;
+  text-align: left;
+}
+
+.overview-artifact-row-header {
+  min-height: 27px;
+  background: #25272a;
+  color: #828c99;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.overview-artifact-row-button {
+  width: 100%;
+  background: transparent;
+}
+
+.overview-artifact-row-button:hover,
+.overview-artifact-row-button:focus-visible {
+  background: rgba(102, 185, 220, 0.1);
+}
+
+.overview-artifact-row-button:focus-visible {
+  outline: 1px solid #6ac9ec;
+  outline-offset: -1px;
+}
+
+.overview-artifact-row-button > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overview-artifact-row-button > span:first-child,
+.overview-artifact-row-button > span:nth-child(2) {
+  color: #e5ebf0;
+  font-weight: 650;
+}
+
+.overview-artifact-row-button > span:nth-child(3) {
+  color: #b8c1cc;
+  font-variant-numeric: tabular-nums;
+}
+
+.overview-artifact-row-button .recommendation {
+  width: fit-content;
+}
+
+.last-cleanup-summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  color: #aeb8c3;
+  font-size: 12px;
+}
+
+.last-cleanup-summary strong {
+  color: #edf2f6;
 }
 
 .history-list-scroll {
@@ -1001,10 +1175,6 @@ button:disabled {
 
 .history-table {
   min-width: 680px;
-}
-
-.history-view .content-heading {
-  padding-bottom: 10px;
 }
 
 .history-row {
@@ -1599,9 +1769,12 @@ button:disabled {
   }
 
   .workspace-view,
-  .overview-view,
-  .history-view {
+  .overview-view {
     padding: 16px 12px 10px;
+  }
+
+  .history-view {
+    padding: 0 12px 10px;
   }
 
   .content-heading h1 {
@@ -1641,24 +1814,21 @@ button:disabled {
   }
 
   .workspace-controls {
-    align-items: flex-start;
-    flex-direction: column;
+    align-items: center;
     gap: 7px;
     padding-top: 8px;
   }
 
   .cleanup-mode-control {
-    width: 100%;
-    justify-content: space-between;
+    flex: 1 1 auto;
   }
 
-  .overview-grid {
+  .overview-summary-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .overview-section {
-    align-items: flex-start;
-    flex-direction: column;
+  .overview-artifact-row {
+    grid-template-columns: minmax(105px, 1fr) minmax(115px, 1.2fr) 70px minmax(95px, 0.8fr);
   }
 
   .app-statusbar {
@@ -1669,10 +1839,6 @@ button:disabled {
     padding: 7px 10px;
   }
 
-  .statusbar-selection {
-    width: 100%;
-    justify-content: space-between;
-  }
 }
 
 @media (max-width: 560px) {
@@ -1691,5 +1857,15 @@ button:disabled {
   .cleanup-mode-control {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .cleanup-selection-summary {
+    width: 100%;
+    justify-content: space-between;
+    margin-left: 0;
+  }
+
+  .overview-summary-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- Remove the redundant History heading and add accessible sorting to all History columns.
- Add semantic, stable Workspace sorting for project, artifact, size, modified, and recommendation status.
- Move cleanup controls into Workspace and remove Workspace-only actions from the global footer.
- Refocus Overview on reclaimable items, items needing review, largest normalized artifacts, and the latest cleanup.
- Support stable Overview-to-Workspace Inspector navigation without implicit cleanup selection.

## Validation
- npm test -- --run (7 files, 21 tests)
- npm run build
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace (328 tests)
- git diff --check

Manual desktop launch and visual capture completed. Interactive macOS click-through was unavailable because Accessibility permission was not granted to osascript; automated tests cover sorting, navigation, drawer identity, and cleanup-control behavior.