### PR TITLE
Prepare DustFril v0.1.0 macOS release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,183 @@
+name: Publish macOS release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build and publish DustFril macOS release
+    if: github.repository == 'FrilLab/dustfril'
+    runs-on: macos-14
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - name: Validate release metadata
+        working-directory: apps/tauri
+        env:
+          EXPECTED_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          cargo metadata --no-deps --format-version 1 > "$RUNNER_TEMP/dustfril-cargo-metadata.json"
+          node - "$RUNNER_TEMP/dustfril-cargo-metadata.json" "$EXPECTED_TAG" <<'NODE'
+          const fs = require('node:fs');
+
+          const metadataPath = process.argv[2];
+          const expectedTag = process.argv[3];
+          const config = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
+          const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const packageLock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
+          const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+          const tauriPackage = metadata.packages.find(({ name }) => name === 'dustfril-tauri');
+          const expectedVersion = '0.1.0';
+          const errors = [];
+
+          if (expectedTag !== `v${expectedVersion}`) {
+            errors.push(`release tag must be v${expectedVersion}, got ${expectedTag}`);
+          }
+          if (config.productName !== 'DustFril') {
+            errors.push(`Tauri productName must be DustFril, got ${config.productName}`);
+          }
+          if (config.identifier !== 'com.frillab.dustfril') {
+            errors.push(`Tauri identifier is not com.frillab.dustfril: ${config.identifier}`);
+          }
+          if (config.version !== expectedVersion) {
+            errors.push(`Tauri version is not ${expectedVersion}: ${config.version}`);
+          }
+          if (packageJson.version !== expectedVersion) {
+            errors.push(`frontend version is not ${expectedVersion}: ${packageJson.version}`);
+          }
+          if (packageLock.version !== expectedVersion || packageLock.packages[''].version !== expectedVersion) {
+            errors.push('package-lock.json version does not match the release version');
+          }
+          if (!tauriPackage || tauriPackage.version !== expectedVersion) {
+            errors.push('Tauri Cargo package version does not match the release version');
+          }
+          if (!fs.existsSync(`../../docs/releases/v${expectedVersion}.md`)) {
+            errors.push(`missing release notes for v${expectedVersion}`);
+          }
+
+          if (errors.length > 0) {
+            console.error(errors.join('\n'));
+            process.exit(1);
+          }
+
+          fs.appendFileSync(process.env.GITHUB_ENV, `RELEASE_VERSION=${expectedVersion}\n`);
+          fs.appendFileSync(process.env.GITHUB_ENV, `DMG_NAME=DustFril_${expectedVersion}_aarch64.dmg\n`);
+          NODE
+
+      - name: Install frontend dependencies
+        working-directory: apps/tauri
+        run: npm ci
+
+      - name: Run frontend tests
+        working-directory: apps/tauri
+        run: npm test
+
+      - name: Build frontend
+        working-directory: apps/tauri
+        run: npm run build
+
+      - name: Run Rust quality gates
+        run: |
+          git diff --check
+          cargo fmt --all -- --check
+          cargo clippy --workspace --all-targets -- -D warnings
+          cargo test --workspace
+
+      - name: Run Rust coverage
+        run: |
+          rustup component add llvm-tools-preview
+          cargo install cargo-llvm-cov --locked
+          cargo llvm-cov --workspace --all-features --summary-only
+
+      - name: Build production DMG
+        working-directory: apps/tauri
+        env:
+          CI: true
+          TAURI_BUNDLER_DMG_IGNORE_CI: false
+        run: npm run tauri build -- --verbose
+
+      - name: Validate DMG and generate checksum
+        run: |
+          set -euo pipefail
+          DMG_PATH="target/release/bundle/dmg/$DMG_NAME"
+          APP_PATH='target/release/bundle/macos/DustFril.app'
+          DMG_ABS_PATH="$(cd "$(dirname "$DMG_PATH")" && pwd)/$(basename "$DMG_PATH")"
+          test -d "$APP_PATH"
+          test -f "$APP_PATH/Contents/Info.plist"
+          test -f "$APP_PATH/Contents/Resources/icon.icns"
+          /usr/libexec/PlistBuddy -c 'Print :CFBundleName' "$APP_PATH/Contents/Info.plist" | grep -Fx 'DustFril'
+          APP_EXECUTABLE=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP_PATH/Contents/Info.plist")
+          test -x "$APP_PATH/Contents/MacOS/$APP_EXECUTABLE"
+          file "$APP_PATH/Contents/MacOS/$APP_EXECUTABLE" | grep -Eq 'arm64|Apple Silicon'
+
+          test -f "$DMG_PATH"
+          hdiutil verify "$DMG_PATH"
+
+          mount_device=''
+          mount_point=''
+          detach_mount() {
+            if [[ -n "$mount_device" ]]; then
+              hdiutil detach "$mount_device" >/dev/null || hdiutil detach "$mount_point" >/dev/null || true
+            fi
+          }
+          trap detach_mount EXIT
+
+          attach_output=$(hdiutil attach -nobrowse -readonly "$DMG_PATH")
+          mount_device=$(printf '%s\n' "$attach_output" | awk '$1 ~ /^\/dev\/disk/ && $NF ~ /^\/Volumes\// { print $1; exit }')
+          mount_point=$(printf '%s\n' "$attach_output" | sed -n 's#.*\(/Volumes/.*\)$#\1#p' | tail -1)
+          test -n "$mount_device"
+          test -n "$mount_point"
+          test -d "$mount_point/DustFril.app"
+          test -L "$mount_point/Applications"
+          test "$(readlink "$mount_point/Applications")" = '/Applications'
+          test -f "$mount_point/.VolumeIcon.icns"
+
+          hdiutil detach "$mount_device" >/dev/null
+          mount_device=''
+          mount_point=''
+          if hdiutil info | grep -F "$DMG_ABS_PATH" >/dev/null; then
+            echo 'release DMG is still mounted' >&2
+            exit 1
+          fi
+
+          (cd "$(dirname "$DMG_PATH")" && shasum -a 256 "$(basename "$DMG_PATH")" > "$(basename "$DMG_PATH").sha256")
+          cat "$DMG_PATH.sha256"
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release create "$RELEASE_TAG" \
+            "target/release/bundle/dmg/$DMG_NAME" \
+            "target/release/bundle/dmg/$DMG_NAME.sha256" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "DustFril $RELEASE_TAG" \
+            --notes-file "$GITHUB_WORKSPACE/docs/releases/v$RELEASE_VERSION.md" \
+            --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish macOS release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v0.1.0'
 
 permissions:
   contents: write
@@ -33,7 +33,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Validate release metadata
         working-directory: apps/tauri

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install system dependencies
         run: |

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,8 +27,26 @@ DustFril은 개발 산출물을 스캔, 분석, 점검, 정리하기 위한 워�
 - CLI 정리 이력을 운영체제 앱 데이터 디렉터리에 저장
 - 로컬 GitHub Actions 워크플로를 실행하지 않고 읽기 전용으로 보안 점검
 
-공급망 보안 스캐너는 v0.0.1 이후 작업입니다. v0.0.1 릴리스 범위는
-`AGENTS.md`에 정의된 데스크톱 산출물 정리 흐름으로 유지됩니다.
+공급망 보안 스캐너는 v0.0.1 이후 작업입니다. v0.1.0 릴리스는 아래에 설명한
+데스크톱 산출물 정리 흐름과 분석·이력 기능을 포함합니다.
+
+## macOS v0.1.0 릴리스
+
+[DustFril v0.1.0 GitHub Release](https://github.com/FrilLab/dustfril/releases/tag/v0.1.0)에서
+Apple Silicon용 빌드를 내려받습니다.
+
+1. `DustFril_0.1.0_aarch64.dmg`와 `.sha256` 체크섬을 내려받습니다.
+2. `shasum -a 256 -c DustFril_0.1.0_aarch64.dmg.sha256`로 DMG를 검증합니다.
+3. DMG를 열고 `DustFril.app`을 `응용 프로그램`으로 복사합니다.
+4. DustFril을 실행합니다.
+
+이 릴리스는 Apple Silicon(`aarch64`)만 지원하며 Intel 및 universal 빌드는
+제공하지 않습니다. DustFril v0.1.0은 현재 서명되지 않았고 공증되지 않은
+초기 릴리스이므로 첫 실행 시 macOS 보안 경고가 나타날 수 있습니다. 서명 및
+공증 배포는 #161에서 별도로 다룹니다.
+
+이번 릴리스의 설치 방법은 GitHub Releases 직접 다운로드만 문서화합니다.
+Homebrew와 Chocolatey 배포는 각각 #162와 #163에서 별도로 다룹니다.
 
 ## 현재 탐지 대상
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,27 @@ The repository is split into a reusable Rust core crate, a CLI app, and a Tauri 
 - Persist CLI cleanup history to the OS app data directory
 - Run a local, read-only GitHub Actions workflow security scan
 
-The supply-chain scanner is post-v0.0.1 work. The v0.0.1 release remains
-focused on the desktop artifact-cleaner workflow.
+The supply-chain scanner is post-v0.0.1 work. The v0.1.0 release includes the
+desktop artifact-cleaner workflow and the supporting analysis and history
+features described below.
+
+## macOS v0.1.0 release
+
+Download the Apple Silicon build from the
+[DustFril v0.1.0 GitHub Release](https://github.com/FrilLab/dustfril/releases/tag/v0.1.0):
+
+1. Download `DustFril_0.1.0_aarch64.dmg` and its `.sha256` checksum.
+2. Verify the DMG with `shasum -a 256 -c DustFril_0.1.0_aarch64.dmg.sha256`.
+3. Open the DMG and copy `DustFril.app` to `Applications`.
+4. Launch DustFril.
+
+This release supports Apple Silicon (`aarch64`) only. Intel and universal
+artifacts are not provided. DustFril v0.1.0 is currently distributed as an
+unsigned/not-notarized early release, so macOS may show a security warning on
+first launch. Signed and notarized distribution is tracked separately in #161.
+
+Installation for this release is through GitHub Releases only. Homebrew and
+Chocolatey distribution are tracked separately in #162 and #163.
 
 Scans reject missing, symbolic-link, or non-directory roots and report
 filesystem traversal errors. Cleanup only accepts real artifact directories,

--- a/apps/tauri/README.md
+++ b/apps/tauri/README.md
@@ -1,4 +1,4 @@
-# dustfril-tauri
+# DustFril desktop app
 
 Official desktop application for DustFril.
 
@@ -20,7 +20,7 @@ All business rules remain in `dustfril-core`. The desktop layer handles presenta
 
 ## Tauri API Contract
 
-The v0.0.1 frontend/backend boundary is defined by the Rust DTOs in
+The v0.1.0 frontend/backend boundary is defined by the Rust DTOs in
 `src-tauri/src/contract.rs` and mirrored by TypeScript types in
 `src/types/workflow.ts`. Payload fields use `camelCase`; enum values are
 case-sensitive.
@@ -39,7 +39,7 @@ case-sensitive.
 | `load_cleanup_history` | none | `CleanupHistoryEntry[]` |
 
 Contract changes must preserve existing command names, nullability, and enum wire
-values for v0.0.1. Cleanup execution intentionally accepts analyzed artifact
+values for v0.1.0. Cleanup execution intentionally accepts analyzed artifact
 identities rather than client-created deletion candidates; Core reconstructs and
 validates the cleanup plan from the immutable analysis identified by
 `analysisId`. The token preserves the exact preview analysis through execution,
@@ -56,7 +56,7 @@ artifact recommendations and the cleanup plan. Workspace analysis also accepts
 the optional `recordArtifactSnapshot` field, which defaults to `true`; policy-only
 refreshes set it to `false` so they do not change the generated-artifact baseline.
 
-## v0.0.1 Features
+## v0.1.0 Features
 
 - Workspace-first Finder-like shell with native folder selection
 - One explicit Analyze Workspace action that discovers Rust, Node.js, and Java artifacts together

--- a/apps/tauri/index.html
+++ b/apps/tauri/index.html
@@ -2,9 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + React + Typescript</title>
+    <meta
+      name="description"
+      content="DustFril scans, analyzes, and safely cleans development artifacts."
+    />
+    <title>DustFril</title>
   </head>
 
   <body>

--- a/apps/tauri/package-lock.json
+++ b/apps/tauri/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "dustfril-tauri",
       "version": "0.1.0",
+      "description": "Official DustFril desktop application",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.2",
         "@tauri-apps/api": "^2",

--- a/apps/tauri/package.json
+++ b/apps/tauri/package.json
@@ -2,6 +2,7 @@
   "name": "dustfril-tauri",
   "private": true,
   "version": "0.1.0",
+  "description": "Official DustFril desktop application",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dustfril-tauri"
 version = "0.1.0"
-description = "A Tauri App"
-authors = ["you"]
+description = "DustFril desktop application"
+authors = ["FrilLab"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/apps/tauri/src-tauri/tauri.conf.json
+++ b/apps/tauri/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "dustfril-tauri",
+  "productName": "DustFril",
   "version": "0.1.0",
-  "identifier": "com.frillab.dustfril-tauri",
+  "identifier": "com.frillab.dustfril",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",

--- a/docs/macos-release-packaging.md
+++ b/docs/macos-release-packaging.md
@@ -2,8 +2,8 @@
 
 DustFril's macOS production bundle creates an application bundle and a DMG:
 
-- `target/release/bundle/macos/dustfril-tauri.app`
-- `target/release/bundle/dmg/dustfril-tauri_<version>_aarch64.dmg`
+- `target/release/bundle/macos/DustFril.app`
+- `target/release/bundle/dmg/DustFril_<version>_aarch64.dmg`
 
 ## DMG build failure on a local macOS session
 
@@ -54,10 +54,35 @@ environment; that forces the Finder AppleScript and recreates the TCC failure.
 After either build, verify the artifact before release:
 
 ```sh
-hdiutil verify target/release/bundle/dmg/dustfril-tauri_<version>_aarch64.dmg
-hdiutil attach -nobrowse -readonly target/release/bundle/dmg/dustfril-tauri_<version>_aarch64.dmg
+hdiutil verify target/release/bundle/dmg/DustFril_<version>_aarch64.dmg
+hdiutil attach -nobrowse -readonly target/release/bundle/dmg/DustFril_<version>_aarch64.dmg
 ```
 
-Confirm that the mounted volume contains `dustfril-tauri.app`, an
+Confirm that the mounted volume contains `DustFril.app`, an
 `Applications` link to `/Applications`, and the expected volume icon. Detach
 the volume with `hdiutil detach <device>` after verification.
+
+## v0.1.0 release policy
+
+The first public release is built and validated for Apple Silicon only
+(`aarch64`). It is distributed through the
+[DustFril GitHub Releases page](https://github.com/FrilLab/dustfril/releases)
+as `DustFril_0.1.0_aarch64.dmg` with a matching `.sha256` file.
+
+DustFril v0.1.0 is currently an unsigned/not-notarized early release. macOS
+may show a security warning on first launch. Do not describe this build as
+signed or notarized; signed and notarized distribution is tracked separately
+in #161.
+
+After the release is public, validate the downloaded artifact rather than only
+the local build:
+
+1. Download the DMG and its `.sha256` file from the GitHub Release.
+2. Run `shasum -a 256 -c DustFril_0.1.0_aarch64.dmg.sha256`.
+3. Run `hdiutil verify DustFril_0.1.0_aarch64.dmg` and mount it read-only.
+4. Copy `DustFril.app` to `Applications` or a disposable test location and
+   launch it, acknowledging the unsigned/not-notarized warning if shown.
+5. In a disposable workspace fixture, analyze the workspace, perform one
+   Trash cleanup, verify Activity History, and confirm unrelated files are
+   unchanged.
+6. Detach the DMG and confirm no release DMG remains mounted.

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,30 @@
+# DustFril v0.1.0
+
+DustFril v0.1.0 is the first public macOS release. Download the primary
+`DustFril_0.1.0_aarch64.dmg` asset and its matching `.sha256` checksum from
+this GitHub Release.
+
+## Included
+
+- Rust `target/` cleanup
+- Node.js `node_modules/` cleanup
+- supported Java `build/` artifact cleanup
+- workspace analysis with measured artifact sizes
+- advisory cleanup recommendations with manual selection
+- Trash as the default cleanup mode, with Permanent cleanup explicitly selected
+- Activity History for scans and cleanup operations
+
+## Platform and security status
+
+- Supported artifact: Apple Silicon macOS (`aarch64`)
+- Intel and universal binaries are not included in this release
+- DustFril v0.1.0 is currently distributed as an unsigned/not-notarized early
+  release. macOS may show a security warning on first launch.
+- Signed and notarized distribution is tracked separately in #161.
+
+Verify the downloaded DMG byte-for-byte with the attached checksum before
+opening it:
+
+```sh
+shasum -a 256 -c DustFril_0.1.0_aarch64.dmg.sha256
+```


### PR DESCRIPTION
## What

Prepare the first public DustFril v0.1.0 macOS release for #160.

- Normalize public Tauri metadata to DustFril and com.frillab.dustfril.
- Add a tag-only v0.1.0 release workflow on an Apple Silicon macos-14 runner.
- Run frontend tests/build and Rust fmt, clippy, test, coverage, and diff checks before packaging.
- Build and validate the production DMG, including app identity, arm64 binary, hdiutil verification, Applications link, volume icon, and clean detach.
- Generate a filename-relative SHA-256 checksum and publish the DMG/checksum with the checked-in release notes.
- Document GitHub Releases-only installation and the unsigned/not-notarized early-release limitation in English, Korean, and macOS packaging docs.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 335 tests passed
- `cargo llvm-cov --workspace --all-features --summary-only` — passed, 77.53% regions / 77.04% lines
- `npm test` — 9 files / 26 tests passed
- `npm run build`
- `CI=true TAURI_BUNDLER_DMG_IGNORE_CI=false npm run tauri build -- --verbose`
- `hdiutil verify` and DMG mount smoke validation — passed
- `shasum -a 256 -c` against generated checksum — passed
- `git diff --check`

The actual GitHub Release and post-publication downloaded-artifact smoke test remain the merge/tag follow-up required by the issue close rule.