### PR TITLE
feat: add Overview storage capacity summary

### DIFF
--- a/apps/tauri/src-tauri/src/contract.rs
+++ b/apps/tauri/src-tauri/src/contract.rs
@@ -6,9 +6,9 @@ use std::{
 use dustfril_core::models::{
     ArtifactChangeKind, ArtifactSizeChange, ArtifactSnapshot, ArtifactSnapshotArtifact,
     ArtifactSnapshotResult, ArtifactSnapshotStatus, CleanupFailureReason, CleanupRecommendation,
-    DeleteMode, Ecosystem, LifecycleScript, LockfileCheck, LockfileKind, LockfileStatus,
-    PackageManager, ProjectIdentity, RecommendationPolicy, RiskLevel, ScriptType, SecurityFinding,
-    SecurityReport, SecurityWarning, DEFAULT_CLEANUP_AGE_DAYS,
+    DeleteMode, DeveloperStorageSummary, Ecosystem, LifecycleScript, LockfileCheck, LockfileKind,
+    LockfileStatus, PackageManager, ProjectIdentity, RecommendationPolicy, RiskLevel, ScriptType,
+    SecurityFinding, SecurityReport, SecurityWarning, StorageSummary, DEFAULT_CLEANUP_AGE_DAYS,
 };
 use serde::{Deserialize, Serialize};
 
@@ -194,11 +194,12 @@ pub(crate) struct AnalysisResponse {
 /// Result of the single user-facing Workspace analysis workflow. It carries
 /// both the analyzed artifacts and the cleanup plan derived from that same
 /// scan, so the desktop does not need to repeat filesystem traversal.
-#[derive(Debug, Serialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct WorkspaceAnalysisResponse {
     pub(crate) analysis: AnalysisResponse,
     pub(crate) cleanup_plan: CleanupPlanResponse,
+    pub(crate) storage_summary: StorageSummaryDto,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) artifact_snapshot: Option<ArtifactSnapshotResultDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -250,6 +251,62 @@ pub(crate) struct CleanupResultResponse {
     pub(crate) freed_size_bytes: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) history_warning: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(tag = "status", rename_all = "camelCase")]
+pub(crate) enum StorageSummaryDto {
+    Available {
+        #[serde(rename = "totalBytes")]
+        total_bytes: u64,
+        #[serde(rename = "usedBytes")]
+        used_bytes: u64,
+        #[serde(rename = "availableBytes")]
+        available_bytes: u64,
+        #[serde(rename = "detectedDevelopmentBytes")]
+        detected_development_bytes: u64,
+        #[serde(rename = "detectedSharePercent")]
+        detected_share_percent: Option<f64>,
+        partial: bool,
+        warnings: Vec<String>,
+        #[serde(rename = "recommendedBytes")]
+        recommended_bytes: u64,
+        #[serde(rename = "scopePath")]
+        scope_path: String,
+        categories: Vec<EcosystemDto>,
+    },
+    Unavailable {
+        reason: String,
+    },
+}
+
+pub(crate) fn storage_summary_to_dto(summary: StorageSummary) -> StorageSummaryDto {
+    let detected_share_percent = summary.detected_share_percent();
+    let StorageSummary {
+        volume,
+        developer_storage:
+            DeveloperStorageSummary {
+                measured_bytes,
+                recommended_bytes,
+                scope_path,
+                categories,
+            },
+        partial,
+        warnings,
+    } = summary;
+
+    StorageSummaryDto::Available {
+        total_bytes: volume.total_bytes,
+        used_bytes: volume.used_bytes,
+        available_bytes: volume.available_bytes,
+        detected_development_bytes: measured_bytes,
+        detected_share_percent,
+        partial,
+        warnings,
+        recommended_bytes,
+        scope_path: scope_path.display().to_string(),
+        categories: categories.into_iter().map(Into::into).collect(),
+    }
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -722,6 +779,18 @@ mod tests {
                 reclaimable_size_bytes: 42,
                 analysis_id: "analysis-1".to_string(),
             },
+            storage_summary: StorageSummaryDto::Available {
+                total_bytes: 100,
+                used_bytes: 60,
+                available_bytes: 40,
+                detected_development_bytes: 12,
+                detected_share_percent: Some(20.0),
+                partial: false,
+                warnings: vec![],
+                recommended_bytes: 4,
+                scope_path: "/workspace".to_string(),
+                categories: vec![EcosystemDto::Rust, EcosystemDto::Node],
+            },
             artifact_snapshot: None,
             artifact_snapshot_warning: None,
         };
@@ -749,6 +818,19 @@ mod tests {
                     }],
                     "reclaimableSizeBytes": 42,
                     "analysisId": "analysis-1"
+                },
+                "storageSummary": {
+                    "status": "available",
+                    "totalBytes": 100,
+                    "usedBytes": 60,
+                    "availableBytes": 40,
+                    "detectedDevelopmentBytes": 12,
+                    "detectedSharePercent": 20.0,
+                    "partial": false,
+                    "warnings": [],
+                    "recommendedBytes": 4,
+                    "scopePath": "/workspace",
+                    "categories": ["Rust", "Node"]
                 }
             })
         );

--- a/apps/tauri/src-tauri/src/contract.rs
+++ b/apps/tauri/src-tauri/src/contract.rs
@@ -8,7 +8,8 @@ use dustfril_core::models::{
     ArtifactSnapshotResult, ArtifactSnapshotStatus, CleanupFailureReason, CleanupRecommendation,
     DeleteMode, DeveloperStorageSummary, Ecosystem, LifecycleScript, LockfileCheck, LockfileKind,
     LockfileStatus, PackageManager, ProjectIdentity, RecommendationPolicy, RiskLevel, ScriptType,
-    SecurityFinding, SecurityReport, SecurityWarning, StorageSummary, DEFAULT_CLEANUP_AGE_DAYS,
+    SecurityFinding, SecurityReport, SecurityWarning, StorageSummary, VolumeStorage,
+    DEFAULT_CLEANUP_AGE_DAYS,
 };
 use serde::{Deserialize, Serialize};
 
@@ -251,6 +252,22 @@ pub(crate) struct CleanupResultResponse {
     pub(crate) freed_size_bytes: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) history_warning: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct VolumeStorageDto {
+    pub(crate) total_bytes: u64,
+    pub(crate) used_bytes: u64,
+    pub(crate) available_bytes: u64,
+}
+
+pub(crate) fn volume_storage_to_dto(volume: VolumeStorage) -> VolumeStorageDto {
+    VolumeStorageDto {
+        total_bytes: volume.total_bytes,
+        used_bytes: volume.used_bytes,
+        available_bytes: volume.available_bytes,
+    }
 }
 
 #[derive(Debug, Serialize, PartialEq)]
@@ -832,6 +849,24 @@ mod tests {
                     "scopePath": "/workspace",
                     "categories": ["Rust", "Node"]
                 }
+            })
+        );
+    }
+
+    #[test]
+    fn volume_storage_wire_format_uses_capacity_field_names() {
+        let response = volume_storage_to_dto(VolumeStorage {
+            total_bytes: 100,
+            used_bytes: 60,
+            available_bytes: 40,
+        });
+
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            json!({
+                "totalBytes": 100,
+                "usedBytes": 60,
+                "availableBytes": 40
             })
         );
     }

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -17,9 +17,10 @@ use std::{
 
 use contract::{
     artifact_path, artifact_snapshot_to_dto, cleanup_failure_reason, project_identity_to_dto,
-    AnalysisResponse, ArtifactAnalysisDto, ArtifactDto, CleanupCandidateDto, CleanupFailureDto,
-    CleanupHistoryEntryDto, CleanupPlanResponse, CleanupResultResponse, ExecuteCleanupRequest,
-    LifecycleScriptDto, RunOptions, ScanResponse, SecurityScanResponse, WorkspaceAnalysisResponse,
+    storage_summary_to_dto, AnalysisResponse, ArtifactAnalysisDto, ArtifactDto,
+    CleanupCandidateDto, CleanupFailureDto, CleanupHistoryEntryDto, CleanupPlanResponse,
+    CleanupResultResponse, ExecuteCleanupRequest, LifecycleScriptDto, RunOptions, ScanResponse,
+    SecurityScanResponse, StorageSummaryDto, WorkspaceAnalysisResponse,
 };
 use dustfril_core::{
     api,
@@ -357,6 +358,16 @@ async fn analyze_workspace(options: RunOptions) -> Result<WorkspaceAnalysisRespo
         let analysis_id = cache_analysis(&root, &ecosystems, &analysis);
         let plan = api::clean::build_plan_from_analysis(analysis.clone())
             .map_err(|error| error.to_string())?;
+        let storage_summary = match api::storage::summarize_with_access_summary(
+            &root,
+            &analysis,
+            Some(&scan_result.access_summary),
+        ) {
+            Ok(summary) => storage_summary_to_dto(summary),
+            Err(error) => StorageSummaryDto::Unavailable {
+                reason: error.to_string(),
+            },
+        };
 
         let (artifact_snapshot, artifact_snapshot_warning) = record_artifact_snapshot_if_enabled(
             record_artifact_snapshot,
@@ -409,6 +420,7 @@ async fn analyze_workspace(options: RunOptions) -> Result<WorkspaceAnalysisRespo
         Ok(WorkspaceAnalysisResponse {
             analysis: analysis_response,
             cleanup_plan,
+            storage_summary,
             artifact_snapshot,
             artifact_snapshot_warning,
         })

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -17,10 +17,11 @@ use std::{
 
 use contract::{
     artifact_path, artifact_snapshot_to_dto, cleanup_failure_reason, project_identity_to_dto,
-    storage_summary_to_dto, AnalysisResponse, ArtifactAnalysisDto, ArtifactDto,
-    CleanupCandidateDto, CleanupFailureDto, CleanupHistoryEntryDto, CleanupPlanResponse,
-    CleanupResultResponse, ExecuteCleanupRequest, LifecycleScriptDto, RunOptions, ScanResponse,
-    SecurityScanResponse, StorageSummaryDto, WorkspaceAnalysisResponse,
+    storage_summary_to_dto, volume_storage_to_dto, AnalysisResponse, ArtifactAnalysisDto,
+    ArtifactDto, CleanupCandidateDto, CleanupFailureDto, CleanupHistoryEntryDto,
+    CleanupPlanResponse, CleanupResultResponse, ExecuteCleanupRequest, LifecycleScriptDto,
+    RunOptions, ScanResponse, SecurityScanResponse, StorageSummaryDto, VolumeStorageDto,
+    WorkspaceAnalysisResponse,
 };
 use dustfril_core::{
     api,
@@ -429,6 +430,21 @@ async fn analyze_workspace(options: RunOptions) -> Result<WorkspaceAnalysisRespo
     .map_err(|error| error.to_string())?
 }
 
+/// Refreshes only filesystem capacity after a permanent cleanup. This does
+/// not re-scan or re-analyze the workspace.
+#[tauri::command]
+async fn refresh_storage_volume(root: String) -> Result<VolumeStorageDto, String> {
+    let root = resolve_root(Some(root))?;
+
+    tokio::task::spawn_blocking(move || {
+        api::storage::volume(&root)
+            .map(volume_storage_to_dto)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
 #[tauri::command]
 async fn build_cleanup_plan(options: RunOptions) -> Result<CleanupPlanResponse, String> {
     let policy = options.recommendation_policy()?;
@@ -596,6 +612,7 @@ pub fn run() {
             analyze_workspace,
             build_cleanup_plan,
             execute_cleanup,
+            refresh_storage_volume,
             load_activity_history,
             clear_activity_history,
             load_cleanup_history,
@@ -648,6 +665,7 @@ mod tests {
             &AnalysisResult {
                 artifacts: Vec::new(),
                 total_size_bytes: 1,
+                ..AnalysisResult::default()
             },
         );
         let java_id = cache_analysis(
@@ -656,6 +674,7 @@ mod tests {
             &AnalysisResult {
                 artifacts: Vec::new(),
                 total_size_bytes: 2,
+                ..AnalysisResult::default()
             },
         );
 
@@ -679,6 +698,7 @@ mod tests {
             &AnalysisResult {
                 artifacts: Vec::new(),
                 total_size_bytes: 3,
+                ..AnalysisResult::default()
             },
         );
 

--- a/apps/tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.test.tsx
@@ -1,13 +1,20 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from './AppShell';
-import { analyzeWorkspace, clearActivityHistory, loadActivityHistory } from '../../lib/tauri';
+import {
+  analyzeWorkspace,
+  clearActivityHistory,
+  executeCleanup,
+  loadActivityHistory,
+  refreshStorageVolume,
+} from '../../lib/tauri';
 
 vi.mock('../../lib/tauri', () => ({
   analyzeWorkspace: vi.fn(),
   chooseWorkspaceFolder: vi.fn(),
   defaultRoot: vi.fn().mockResolvedValue('/workspace'),
   executeCleanup: vi.fn(),
+  refreshStorageVolume: vi.fn(),
   loadActivityHistory: vi.fn().mockResolvedValue([]),
   clearActivityHistory: vi.fn().mockResolvedValue(undefined),
 }));
@@ -118,5 +125,66 @@ describe('AppShell Overview navigation', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /^History/ })).toHaveTextContent('0'));
     expect(clearActivityHistory).toHaveBeenCalledOnce();
     expect(screen.getByText('No activity yet')).toBeInTheDocument();
+  });
+
+  it('refreshes volume capacity after permanent cleanup', async () => {
+    const sizeBytes = 11 * 1024 ** 3;
+    vi.mocked(analyzeWorkspace).mockResolvedValue({
+      analysis: {
+        artifacts: [{ ...analyzedArtifact, sizeBytes, recommendation: 'SafeToClean' }],
+        totalSizeBytes: sizeBytes,
+      },
+      cleanupPlan: {
+        analysisId: 'analysis-1',
+        candidates: [
+          {
+            path: analyzedArtifact.path,
+            ecosystem: analyzedArtifact.ecosystem,
+            project: analyzedArtifact.project,
+            sizeBytes,
+            ageDays: analyzedArtifact.ageDays,
+            recommendation: 'SafeToClean',
+            selectedByDefault: true,
+          },
+        ],
+        reclaimableSizeBytes: sizeBytes,
+      },
+      storageSummary: {
+        status: 'available',
+        totalBytes: 512 * 1024 ** 3,
+        usedBytes: 318 * 1024 ** 3,
+        availableBytes: 194 * 1024 ** 3,
+        detectedDevelopmentBytes: sizeBytes,
+        detectedSharePercent: 3.4591194968553455,
+        partial: false,
+        warnings: [],
+        recommendedBytes: sizeBytes,
+        scopePath: '/workspace/dustfril',
+        categories: ['Rust'],
+      },
+    });
+    vi.mocked(executeCleanup).mockResolvedValue({
+      deletedPaths: [analyzedArtifact.path],
+      failedPaths: [],
+      freedSizeBytes: sizeBytes,
+    });
+    vi.mocked(refreshStorageVolume).mockResolvedValue({
+      totalBytes: 512 * 1024 ** 3,
+      usedBytes: 300 * 1024 ** 3,
+      availableBytes: 212 * 1024 ** 3,
+    });
+
+    render(<AppShell />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Analyze Workspace' })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: 'Analyze Workspace' }));
+    await waitFor(() => expect(screen.getByRole('checkbox')).toBeChecked());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete permanently' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cleanup' }));
+    fireEvent.click(screen.getByRole('dialog').querySelector('.button-confirm') as HTMLButtonElement);
+
+    await waitFor(() => expect(refreshStorageVolume).toHaveBeenCalledWith('/workspace'));
+    fireEvent.click(screen.getByRole('button', { name: 'Overview' }));
+    expect(screen.getByText('300 GB used of 512 GB')).toBeInTheDocument();
   });
 });

--- a/apps/tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.test.tsx
@@ -60,6 +60,19 @@ describe('AppShell Overview navigation', () => {
         ],
         reclaimableSizeBytes: 0,
       },
+      storageSummary: {
+        status: 'available',
+        totalBytes: 512 * 1024 ** 3,
+        usedBytes: 318 * 1024 ** 3,
+        availableBytes: 194 * 1024 ** 3,
+        detectedDevelopmentBytes: 11 * 1024 ** 3,
+        detectedSharePercent: 3.4591194968553455,
+        partial: false,
+        warnings: [],
+        recommendedBytes: 0,
+        scopePath: '/workspace/dustfril',
+        categories: ['Rust'],
+      },
     });
 
     render(<AppShell />);

--- a/apps/tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.tsx
@@ -34,6 +34,7 @@ export function AppShell() {
             <OverviewView
               root={app.root}
               analysisReady={app.analysisResult !== null}
+              storageSummary={app.storageSummary}
               artifacts={app.analysisResult?.artifacts ?? []}
               candidates={app.cleanupPlan?.candidates ?? []}
               reclaimableBytes={app.cleanupPlan?.reclaimableSizeBytes ?? 0}

--- a/apps/tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useAppState.ts
@@ -16,6 +16,7 @@ import type {
   CleanupPlanResponse,
   CleanupResultResponse,
   DeleteMode,
+  StorageSummary,
 } from '../../../types/workflow';
 import { cleanupAgeOptions, defaultCleanupAgeDays, deleteModes, ecosystems } from '../../../types/workflow';
 import {
@@ -34,6 +35,7 @@ export function useAppState() {
   const [error, setError] = useState<string | null>(null);
   const [analysisResult, setAnalysisResult] = useState<AnalysisResponse | null>(null);
   const [cleanupPlan, setCleanupPlan] = useState<CleanupPlanResponse | null>(null);
+  const [storageSummary, setStorageSummary] = useState<StorageSummary | null>(null);
   const [historyEntries, setHistoryEntries] = useState<ActivityRecord[]>([]);
   const [selectedCleanupPaths, setSelectedCleanupPaths] = useState<string[]>([]);
   const [cleanupAgeDays, setCleanupAgeDays] = useState<number>(defaultCleanupAgeDays);
@@ -131,6 +133,7 @@ export function useAppState() {
     setError(null);
     setAnalysisResult(null);
     setCleanupPlan(null);
+    setStorageSummary(null);
     setSelectedCleanupPaths([]);
     setSelectedItemId(null);
     setConfirmDialogOpen(false);
@@ -182,6 +185,7 @@ export function useAppState() {
 
       setAnalysisResult(response.analysis);
       setCleanupPlan(response.cleanupPlan);
+      setStorageSummary(response.storageSummary);
       // Rebuild the default cleanup selection from the new policy. This
       // conservatively drops items that are no longer recommended and never
       // broadens the selection without a new recommendation.
@@ -319,6 +323,34 @@ export function useAppState() {
             }
           : current,
       );
+      const deletedCandidates = candidates.filter((candidate) =>
+        result.deletedPaths.includes(candidate.path),
+      );
+      const deletedDetectedBytes = deletedCandidates.reduce(
+        (total, candidate) => total + candidate.sizeBytes,
+        0,
+      );
+      const deletedRecommendedBytes = deletedCandidates
+        .filter((candidate) => candidate.selectedByDefault)
+        .reduce((total, candidate) => total + candidate.sizeBytes, 0);
+      setStorageSummary((current) =>
+        current?.status === 'available'
+          ? {
+              ...current,
+              detectedDevelopmentBytes: Math.max(
+                0,
+                current.detectedDevelopmentBytes - deletedDetectedBytes,
+              ),
+              detectedSharePercent:
+                current.usedBytes > 0
+                  ? (Math.max(0, current.detectedDevelopmentBytes - deletedDetectedBytes) /
+                      current.usedBytes) *
+                    100
+                  : null,
+              recommendedBytes: Math.max(0, current.recommendedBytes - deletedRecommendedBytes),
+            }
+          : current,
+      );
       setSelectedCleanupPaths((current) =>
         current.filter((path) => !result.deletedPaths.includes(path)),
       );
@@ -338,6 +370,7 @@ export function useAppState() {
     error,
     analysisResult,
     cleanupPlan,
+    storageSummary,
     selectedCleanupItems: cleanupCandidates.filter((candidate) =>
       selectedCleanupPaths.includes(candidate.path),
     ),

--- a/apps/tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useAppState.ts
@@ -7,6 +7,7 @@ import {
   defaultRoot,
   executeCleanup,
   loadActivityHistory,
+  refreshStorageVolume,
 } from '../../../lib/tauri';
 import { categoryConfigs, type SidebarCategory } from '../../../model/categories';
 import type { SidebarEntry } from '../../../components/Sidebar/Sidebar';
@@ -17,6 +18,7 @@ import type {
   CleanupResultResponse,
   DeleteMode,
   StorageSummary,
+  VolumeStorage,
 } from '../../../types/workflow';
 import { cleanupAgeOptions, defaultCleanupAgeDays, deleteModes, ecosystems } from '../../../types/workflow';
 import {
@@ -289,10 +291,25 @@ export function useAppState() {
         deleteMode,
       );
 
+      let refreshedVolume: VolumeStorage | null = null;
+      let storageRefreshWarning: string | null = null;
+      if (deleteMode === 'Permanent' && result.deletedPaths.length > 0) {
+        try {
+          refreshedVolume = await refreshStorageVolume(root);
+        } catch (invokeError) {
+          storageRefreshWarning = `Failed to refresh storage statistics: ${String(invokeError)}`;
+        }
+      }
+
       setError(
-        result.failedPaths.length
-          ? formatCleanupFailure(result, result.historyWarning)
-          : result.historyWarning ?? null,
+        [
+          result.failedPaths.length
+            ? formatCleanupFailure(result, result.historyWarning)
+            : result.historyWarning,
+          storageRefreshWarning,
+        ]
+          .filter((warning): warning is string => Boolean(warning))
+          .join(' ') || null,
       );
       setCleanupPlan((current) =>
         current
@@ -335,20 +352,28 @@ export function useAppState() {
         .reduce((total, candidate) => total + candidate.sizeBytes, 0);
       setStorageSummary((current) =>
         current?.status === 'available'
-          ? {
-              ...current,
-              detectedDevelopmentBytes: Math.max(
+          ? (() => {
+              const nextDetectedBytes = Math.max(
                 0,
                 current.detectedDevelopmentBytes - deletedDetectedBytes,
-              ),
-              detectedSharePercent:
-                current.usedBytes > 0
-                  ? (Math.max(0, current.detectedDevelopmentBytes - deletedDetectedBytes) /
-                      current.usedBytes) *
-                    100
-                  : null,
-              recommendedBytes: Math.max(0, current.recommendedBytes - deletedRecommendedBytes),
-            }
+              );
+              const nextVolume = refreshedVolume ?? {
+                totalBytes: current.totalBytes,
+                usedBytes: current.usedBytes,
+                availableBytes: current.availableBytes,
+              };
+
+              return {
+                ...current,
+                ...nextVolume,
+                detectedDevelopmentBytes: nextDetectedBytes,
+                detectedSharePercent:
+                  nextVolume.usedBytes > 0
+                    ? (nextDetectedBytes / nextVolume.usedBytes) * 100
+                    : null,
+                recommendedBytes: Math.max(0, current.recommendedBytes - deletedRecommendedBytes),
+              };
+            })()
           : current,
       );
       setSelectedCleanupPaths((current) =>

--- a/apps/tauri/src/features/app-shell/views/OverviewView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/OverviewView.test.tsx
@@ -2,7 +2,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { OverviewView } from './OverviewView';
-import type { ActivityRecord, ArtifactAnalysis, CleanupCandidate } from '../../../types/workflow';
+import type {
+  ActivityRecord,
+  ArtifactAnalysis,
+  CleanupCandidate,
+  StorageSummary,
+} from '../../../types/workflow';
 
 function artifact(
   project: string,
@@ -68,11 +73,26 @@ const newerScan: ActivityRecord = {
   result: { success: true, details: { path: '/workspace', artifacts: 6, size: 16 * 1024 ** 3 } },
 };
 
+const storageSummary: StorageSummary = {
+  status: 'available',
+  totalBytes: 512 * 1024 ** 3,
+  usedBytes: 318 * 1024 ** 3,
+  availableBytes: 194 * 1024 ** 3,
+  detectedDevelopmentBytes: 34 * 1024 ** 3,
+  detectedSharePercent: 10.69182389937107,
+  partial: false,
+  warnings: [],
+  recommendedBytes: 8 * 1024 ** 3,
+  scopePath: '/workspace/dustfril',
+  categories: ['Rust', 'Node', 'Java'],
+};
+
 function renderOverview(overrides: Partial<ComponentProps<typeof OverviewView>> = {}) {
   return render(
     <OverviewView
       root="/workspace/dustfril"
       analysisReady
+      storageSummary={storageSummary}
       artifacts={artifacts}
       candidates={artifacts.map(candidate)}
       reclaimableBytes={210 * 1024 ** 2}
@@ -96,6 +116,10 @@ describe('OverviewView', () => {
     expect(screen.getAllByText('2 artifacts', { selector: '.overview-summary-card > span' })).toHaveLength(2);
     expect(screen.queryByText('Discovered ecosystems')).not.toBeInTheDocument();
     expect(screen.queryByText('Review recommendations based on inactivity age')).not.toBeInTheDocument();
+    expect(screen.getByText('318 GB used of 512 GB')).toBeInTheDocument();
+    expect(screen.getByText('194 GB available')).toBeInTheDocument();
+    expect(screen.getByText('34 GB · 10.7% of used storage')).toBeInTheDocument();
+    expect(screen.getByText('Recommended cleanup: 8.0 GB')).toBeInTheDocument();
   });
 
   it('shows the five largest artifacts and navigates with the stable path identity', () => {
@@ -124,15 +148,31 @@ describe('OverviewView', () => {
   it('does not present zeroes as analysis when the workspace has not been scanned', () => {
     renderOverview({
       analysisReady: false,
+      storageSummary: null,
       artifacts: [],
       candidates: [],
       reclaimableBytes: 0,
       historyEntries: [],
     });
 
-    expect(screen.getAllByText('Not analyzed')).toHaveLength(2);
+    expect(screen.getAllByText('Not analyzed')).toHaveLength(3);
     expect(screen.getByText('Analyze this workspace to see cleanup insights.')).toBeInTheDocument();
     expect(screen.queryByText('0 B')).not.toBeInTheDocument();
     expect(screen.getByText('No cleanup operations yet.')).toBeInTheDocument();
+  });
+
+  it('does not present zero capacity when filesystem statistics are unavailable', () => {
+    renderOverview({
+      storageSummary: {
+        status: 'unavailable',
+        reason: 'Failed to read filesystem statistics for /workspace/dustfril',
+      },
+    });
+
+    expect(screen.getByText('Storage unavailable')).toBeInTheDocument();
+    expect(
+      screen.getByText('Failed to read filesystem statistics for /workspace/dustfril'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('0 B used of 0 B')).not.toBeInTheDocument();
   });
 });

--- a/apps/tauri/src/features/app-shell/views/OverviewView.tsx
+++ b/apps/tauri/src/features/app-shell/views/OverviewView.tsx
@@ -4,11 +4,17 @@ import { formatBytes, formatCount, formatDate } from '../../../lib/format';
 import { cleanupItemCount, cleanupModeLabel, historyStatusLabel } from '../../../model/activity';
 import { leafName, recommendationClass, recommendationLabel } from '../../../model/presentation';
 import { sortArtifacts } from '../../../model/sorting';
-import type { ActivityRecord, ArtifactAnalysis, CleanupCandidate } from '../../../types/workflow';
+import type {
+  ActivityRecord,
+  ArtifactAnalysis,
+  CleanupCandidate,
+  StorageSummary,
+} from '../../../types/workflow';
 
 type OverviewViewProps = {
   root: string;
   analysisReady: boolean;
+  storageSummary: StorageSummary | null;
   artifacts: ArtifactAnalysis[];
   candidates: CleanupCandidate[];
   reclaimableBytes: number;
@@ -73,6 +79,8 @@ export function OverviewView(props: OverviewViewProps) {
           analysisReady={props.analysisReady}
         />
       </div>
+
+      <StoragePanel analysisReady={props.analysisReady} summary={props.storageSummary} />
 
       {!props.analysisReady ? (
         <p className="overview-analysis-hint" role="status">
@@ -147,6 +155,99 @@ export function OverviewView(props: OverviewViewProps) {
           <p className="overview-muted">No cleanup operations yet.</p>
         )}
       </section>
+    </div>
+  );
+}
+
+function StoragePanel({
+  analysisReady,
+  summary,
+}: {
+  analysisReady: boolean;
+  summary: StorageSummary | null;
+}) {
+  return (
+    <section className="overview-panel overview-storage-panel" aria-labelledby="storage-heading">
+      <div className="overview-section-heading">
+        <div>
+          <p className="eyebrow" id="storage-heading">
+            Storage
+          </p>
+          <p className="overview-caption">
+            The filesystem volume containing this workspace.
+          </p>
+        </div>
+      </div>
+
+      {!analysisReady ? (
+        <div className="overview-storage-unavailable">
+          <strong>Not analyzed</strong>
+          <span>Analyze this workspace to measure detected development storage.</span>
+        </div>
+      ) : summary?.status === 'unavailable' ? (
+        <div className="overview-storage-unavailable">
+          <strong>Storage unavailable</strong>
+          <span>{summary.reason}</span>
+        </div>
+      ) : summary?.status === 'available' ? (
+        <AvailableStorage summary={summary} />
+      ) : (
+        <div className="overview-storage-unavailable">
+          <strong>Storage unavailable</strong>
+          <span>No storage summary was returned for this analysis.</span>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function AvailableStorage({
+  summary,
+}: {
+  summary: Extract<StorageSummary, { status: 'available' }>;
+}) {
+  const usedPercent = summary.totalBytes
+    ? Math.min((summary.usedBytes / summary.totalBytes) * 100, 100)
+    : 0;
+
+  return (
+    <div className="overview-storage-content">
+      <div className="overview-storage-capacity">
+        <strong>
+          {formatBytes(summary.usedBytes)} used of {formatBytes(summary.totalBytes)}
+        </strong>
+        <span>{formatBytes(summary.availableBytes)} available</span>
+      </div>
+      <div
+        className="overview-storage-meter"
+        role="progressbar"
+        aria-label="Used storage"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={usedPercent}
+      >
+        <span style={{ width: `${usedPercent}%` }} />
+      </div>
+      <div className="overview-storage-detected">
+        <div>
+          <strong>Detected development storage</strong>
+          <span title={summary.scopePath}>Measured in current workspace</span>
+        </div>
+        <strong>
+          {formatBytes(summary.detectedDevelopmentBytes)} ·{' '}
+          {summary.detectedSharePercent === null
+            ? 'Share unavailable'
+            : `${summary.detectedSharePercent.toFixed(1)}% of used storage`}
+        </strong>
+      </div>
+      <p className="overview-storage-recommended">
+        Recommended cleanup: {formatBytes(summary.recommendedBytes)}
+      </p>
+      {summary.partial ? (
+        <p className="overview-storage-warning" role="status">
+          {summary.warnings.join(' ') || 'Partial analysis: some filesystem entries could not be measured.'}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/tauri/src/lib/tauri.ts
+++ b/apps/tauri/src/lib/tauri.ts
@@ -11,6 +11,7 @@ import type {
   RunOptions,
   ScanResponse,
   SecurityScanResponse,
+  VolumeStorage,
   WorkspaceAnalysisResponse,
 } from '../types/workflow';
 
@@ -23,6 +24,7 @@ const commands = {
   audit: 'audit',
   securityScan: 'security_scan',
   executeCleanup: 'execute_cleanup',
+  refreshStorageVolume: 'refresh_storage_volume',
   loadActivityHistory: 'load_activity_history',
   clearActivityHistory: 'clear_activity_history',
   loadCleanupHistory: 'load_cleanup_history',
@@ -77,6 +79,10 @@ export function executeCleanup(
   return invoke<CleanupResultResponse>(commands.executeCleanup, {
     request: { root, ecosystems, analysisId, selectedArtifacts, mode },
   });
+}
+
+export function refreshStorageVolume(root: string) {
+  return invoke<VolumeStorage>(commands.refreshStorageVolume, { root });
 }
 
 export function loadActivityHistory() {

--- a/apps/tauri/src/styles/style.css
+++ b/apps/tauri/src/styles/style.css
@@ -1033,6 +1033,93 @@ button:disabled {
   font-size: 11px;
 }
 
+.overview-storage-panel {
+  gap: 12px;
+}
+
+.overview-storage-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.overview-storage-capacity,
+.overview-storage-detected {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.overview-storage-capacity strong,
+.overview-storage-detected strong {
+  color: #edf2f6;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.overview-storage-capacity span,
+.overview-storage-detected span,
+.overview-storage-recommended {
+  color: #a3adb9;
+  font-size: 11px;
+}
+
+.overview-storage-meter {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.overview-storage-meter span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: #67c7e8;
+}
+
+.overview-storage-detected {
+  padding-top: 2px;
+}
+
+.overview-storage-detected > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.overview-storage-detected > strong {
+  flex: 0 0 auto;
+  color: #bceafa;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.overview-storage-recommended {
+  margin: 0;
+}
+
+.overview-storage-warning {
+  margin: 0;
+  color: #f7d797;
+  font-size: 11px;
+}
+
+.overview-storage-unavailable {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  color: #a3adb9;
+  font-size: 12px;
+}
+
+.overview-storage-unavailable strong {
+  color: #edf2f6;
+  font-size: 13px;
+}
+
 .overview-summary-unavailable {
   color: #9ba5b0 !important;
   font-size: 16px !important;

--- a/apps/tauri/src/types/workflow.ts
+++ b/apps/tauri/src/types/workflow.ts
@@ -90,6 +90,12 @@ export type WorkspaceAnalysisResponse = {
   artifactSnapshotWarning?: string;
 };
 
+export type VolumeStorage = {
+  totalBytes: number;
+  usedBytes: number;
+  availableBytes: number;
+};
+
 export type StorageSummary =
   | {
       status: 'available';

--- a/apps/tauri/src/types/workflow.ts
+++ b/apps/tauri/src/types/workflow.ts
@@ -85,9 +85,29 @@ export type AnalysisResponse = {
 export type WorkspaceAnalysisResponse = {
   analysis: AnalysisResponse;
   cleanupPlan: CleanupPlanResponse;
+  storageSummary: StorageSummary;
   artifactSnapshot?: ArtifactSnapshotResult;
   artifactSnapshotWarning?: string;
 };
+
+export type StorageSummary =
+  | {
+      status: 'available';
+      totalBytes: number;
+      usedBytes: number;
+      availableBytes: number;
+      detectedDevelopmentBytes: number;
+      detectedSharePercent: number | null;
+      partial: boolean;
+      warnings: string[];
+      recommendedBytes: number;
+      scopePath: string;
+      categories: Ecosystem[];
+    }
+  | {
+      status: 'unavailable';
+      reason: string;
+    };
 
 export type CleanupCandidate = {
   path: string;

--- a/crates/core/src/analyzer/analyze.rs
+++ b/crates/core/src/analyzer/analyze.rs
@@ -22,11 +22,20 @@ impl Analyzer {
         scan_result: ScanResult,
         policy: RecommendationPolicy,
     ) -> DustResult<AnalysisResult> {
-        let mut artifacts: Vec<ArtifactAnalysis> = normalize_artifacts(scan_result.artifacts)
-            .into_par_iter()
-            .map(|artifact| Self::analyze_artifact(artifact, policy))
-            .collect();
+        let analyzed_artifacts: Vec<(ArtifactAnalysis, u64)> =
+            normalize_artifacts(scan_result.artifacts)
+                .into_par_iter()
+                .map(|artifact| Self::analyze_artifact(artifact, policy))
+                .collect();
 
+        let measurement_failures = analyzed_artifacts
+            .iter()
+            .map(|(_, failures)| *failures)
+            .fold(0, u64::saturating_add);
+        let mut artifacts: Vec<ArtifactAnalysis> = analyzed_artifacts
+            .into_iter()
+            .map(|(artifact, _)| artifact)
+            .collect();
         artifacts.sort_by_key(|artifact| std::cmp::Reverse(artifact.size_bytes));
 
         let total_size_bytes = artifacts
@@ -37,21 +46,29 @@ impl Analyzer {
         Ok(AnalysisResult {
             artifacts,
             total_size_bytes,
+            measurement_failures,
         })
     }
 
-    fn analyze_artifact(artifact: Artifact, policy: RecommendationPolicy) -> ArtifactAnalysis {
-        let (size_bytes, last_modified) = calculate_artifact_metadata(&artifact.path);
+    fn analyze_artifact(
+        artifact: Artifact,
+        policy: RecommendationPolicy,
+    ) -> (ArtifactAnalysis, u64) {
+        let (size_bytes, last_modified, measurement_failures) =
+            calculate_artifact_metadata(&artifact.path);
         let age_days = calculate_age_days(last_modified);
         let recommendation = policy.recommendation(age_days);
 
-        ArtifactAnalysis {
-            artifact,
-            size_bytes,
-            last_modified,
-            age_days,
-            recommendation,
-        }
+        (
+            ArtifactAnalysis {
+                artifact,
+                size_bytes,
+                last_modified,
+                age_days,
+                recommendation,
+            },
+            measurement_failures,
+        )
     }
 }
 
@@ -64,36 +81,46 @@ fn calculate_age_days(modified: Option<SystemTime>) -> Option<u64> {
     Some(duration.as_secs() / SECONDS_PER_DAY)
 }
 
-fn calculate_artifact_metadata(path: &Path) -> (u64, Option<SystemTime>) {
-    WalkDir::new(path)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter_map(|entry| {
-            let metadata = fs::symlink_metadata(entry.path()).ok()?;
-            let size = if metadata.is_file() {
-                metadata.len()
-            } else {
-                0
-            };
-            let modified = metadata.modified().ok();
+fn calculate_artifact_metadata(path: &Path) -> (u64, Option<SystemTime>, u64) {
+    let mut total_size: u64 = 0;
+    let mut latest_modified = None;
+    let mut measurement_failures: u64 = 0;
 
-            Some((size, modified))
-        })
-        .fold(
-            (0, None),
-            |(size, latest_modified), (entry_size, modified)| {
-                (
-                    size.saturating_add(entry_size),
-                    latest_modified.max(modified),
-                )
-            },
-        )
+    for entry in WalkDir::new(path) {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => {
+                measurement_failures = measurement_failures.saturating_add(1);
+                continue;
+            }
+        };
+        let metadata = match fs::symlink_metadata(entry.path()) {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                measurement_failures = measurement_failures.saturating_add(1);
+                continue;
+            }
+        };
+
+        if metadata.is_file() {
+            total_size = total_size.saturating_add(metadata.len());
+        }
+
+        match metadata.modified() {
+            Ok(modified) => latest_modified = latest_modified.max(Some(modified)),
+            Err(_) => measurement_failures = measurement_failures.saturating_add(1),
+        }
+    }
+
+    (total_size, latest_modified, measurement_failures)
 }
 
 #[cfg(test)]
 mod tests {
     use super::calculate_age_days;
+    use crate::analyzer::Analyzer;
     use crate::models::{CleanupRecommendation, RecommendationPolicy};
+    use tempfile::TempDir;
 
     #[test]
     fn cleanup_recommendations_use_documented_age_boundaries() {
@@ -126,5 +153,22 @@ mod tests {
             )),
             None
         );
+    }
+
+    #[test]
+    fn missing_artifact_path_is_reported_as_a_measurement_failure() {
+        let root = TempDir::new().unwrap();
+        let missing_path = root.path().join("missing-artifact");
+        let analysis = Analyzer::analyze(crate::models::ScanResult {
+            artifacts: vec![crate::models::Artifact::new(
+                missing_path,
+                crate::models::Ecosystem::Rust,
+            )],
+            ..crate::models::ScanResult::default()
+        })
+        .unwrap();
+
+        assert_eq!(analysis.total_size_bytes, 0);
+        assert_eq!(analysis.measurement_failures, 1);
     }
 }

--- a/crates/core/src/analyzer/tests.rs
+++ b/crates/core/src/analyzer/tests.rs
@@ -17,6 +17,19 @@ fn analyze_empty_scan_result() {
 
     assert!(analysis.artifacts.is_empty());
     assert_eq!(analysis.total_size_bytes, 0);
+    assert_eq!(analysis.measurement_failures, 0);
+}
+
+#[test]
+fn analysis_measurement_failures_are_backward_compatible_on_the_wire() {
+    let analysis: AnalysisResult =
+        serde_json::from_str(r#"{"artifacts":[],"total_size_bytes":0}"#).unwrap();
+
+    assert_eq!(analysis.measurement_failures, 0);
+    assert_eq!(
+        serde_json::to_string(&analysis).unwrap(),
+        r#"{"artifacts":[],"total_size_bytes":0}"#
+    );
 }
 
 #[test]

--- a/crates/core/src/api/artifact_snapshot.rs
+++ b/crates/core/src/api/artifact_snapshot.rs
@@ -71,6 +71,7 @@ mod tests {
                 recommendation: CleanupRecommendation::Keep,
             }],
             total_size_bytes: 42,
+            ..AnalysisResult::default()
         };
 
         let snapshot = create_artifact_snapshot(workspace.path(), &analysis);

--- a/crates/core/src/api/clean.rs
+++ b/crates/core/src/api/clean.rs
@@ -92,6 +92,7 @@ mod tests {
                 recommendation: CleanupRecommendation::Keep,
             }],
             total_size_bytes: 42,
+            ..AnalysisResult::default()
         };
 
         let plan = build_plan_from_analysis_with_selection(

--- a/crates/core/src/api/mod.rs
+++ b/crates/core/src/api/mod.rs
@@ -7,6 +7,7 @@ pub mod history;
 pub mod integrity;
 pub mod lockfile;
 pub mod scan;
+pub mod storage;
 pub mod workflow;
 
 pub use analyze::*;

--- a/crates/core/src/api/storage.rs
+++ b/crates/core/src/api/storage.rs
@@ -1,3 +1,3 @@
 //! Core API for filesystem capacity and measured development-storage context.
 
-pub use crate::storage::{summarize, summarize_with_access_summary};
+pub use crate::storage::{summarize, summarize_with_access_summary, volume};

--- a/crates/core/src/api/storage.rs
+++ b/crates/core/src/api/storage.rs
@@ -1,0 +1,3 @@
+//! Core API for filesystem capacity and measured development-storage context.
+
+pub use crate::storage::{summarize, summarize_with_access_summary};

--- a/crates/core/src/artifact_snapshot.rs
+++ b/crates/core/src/artifact_snapshot.rs
@@ -414,6 +414,7 @@ mod tests {
         AnalysisResult {
             artifacts: vec![analyzed_artifact(path, Ecosystem::Rust, size_bytes)],
             total_size_bytes: size_bytes,
+            ..AnalysisResult::default()
         }
     }
 
@@ -429,6 +430,7 @@ mod tests {
                     size_bytes,
                 )],
                 total_size_bytes: size_bytes,
+                ..AnalysisResult::default()
             },
             Utc.timestamp_opt(timestamp, 0).single().unwrap(),
         )
@@ -484,6 +486,7 @@ mod tests {
                 analyzed_artifact(workspace.path().join("build"), Ecosystem::Java, 30),
             ],
             total_size_bytes: 60,
+            ..AnalysisResult::default()
         };
         store
             .record_snapshot(ArtifactSnapshot::from_analysis_at(
@@ -501,6 +504,7 @@ mod tests {
                 15,
             )],
             total_size_bytes: 15,
+            ..AnalysisResult::default()
         };
         let filtered_result = store
             .record_with_ecosystems(workspace.path(), &filtered_analysis, &[Ecosystem::Rust])
@@ -525,6 +529,7 @@ mod tests {
                 analyzed_artifact(workspace.path().join("build"), Ecosystem::Java, 30),
             ],
             total_size_bytes: 65,
+            ..AnalysisResult::default()
         };
         let full_result = store
             .record_with_ecosystems(workspace.path(), &full_analysis, &[])

--- a/crates/core/src/cleaner/plan.rs
+++ b/crates/core/src/cleaner/plan.rs
@@ -136,6 +136,7 @@ mod tests {
         AnalysisResult {
             artifacts,
             total_size_bytes: 30,
+            ..AnalysisResult::default()
         }
     }
 
@@ -161,6 +162,7 @@ mod tests {
                 CleanupRecommendation::Keep,
             )],
             total_size_bytes: 10,
+            ..AnalysisResult::default()
         };
 
         let plan = create_cleanup_plan_from_selection(
@@ -187,6 +189,7 @@ mod tests {
                 CleanupRecommendation::Keep,
             )],
             total_size_bytes: 10,
+            ..AnalysisResult::default()
         };
 
         let result = create_cleanup_plan_from_selection(
@@ -211,6 +214,7 @@ mod tests {
                 ),
             ],
             total_size_bytes: 20,
+            ..AnalysisResult::default()
         };
 
         let result = create_cleanup_plan_from_selection(

--- a/crates/core/src/cleaner/tests.rs
+++ b/crates/core/src/cleaner/tests.rs
@@ -64,6 +64,7 @@ fn safe_to_clean_becomes_candidate() {
         artifacts: vec![artifact],
 
         total_size_bytes: 100,
+        ..AnalysisResult::default()
     };
 
     let plan = create_cleanup_plan(analysis).unwrap();
@@ -86,6 +87,7 @@ fn keep_is_not_candidate() {
     let analysis = AnalysisResult {
         artifacts: vec![artifact],
         total_size_bytes: 100,
+        ..AnalysisResult::default()
     };
 
     let plan = create_cleanup_plan(analysis).unwrap();
@@ -245,6 +247,7 @@ fn create_cleanup_plan_filters_safe_to_clean() {
             artifact(CleanupRecommendation::NeedsReview),
         ],
         total_size_bytes: 300,
+        ..AnalysisResult::default()
     };
 
     let plan = create_cleanup_plan(analysis).unwrap();
@@ -279,6 +282,7 @@ fn recommendation_controls_default_selection_not_eligibility() {
             },
         ],
         total_size_bytes: 150,
+        ..AnalysisResult::default()
     };
 
     let default_plan = create_cleanup_plan(analysis.clone()).unwrap();
@@ -330,6 +334,7 @@ fn explicit_selection_allows_review_and_keep_recommendations() {
             },
         ],
         total_size_bytes: 50,
+        ..AnalysisResult::default()
     };
 
     let plan = create_cleanup_plan_from_selection(

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -19,6 +19,12 @@ pub enum DustError {
     },
     /// Indicates an unrecoverable analysis failure.
     AnalysisFailed,
+    /// Indicates that filesystem capacity statistics could not be read for a
+    /// workspace path.
+    FilesystemStats {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
     /// Indicates an unrecoverable cleanup failure.
     CleanupFailed,
     /// Indicates that a cleanup selection was not present in the analyzed
@@ -57,6 +63,13 @@ impl fmt::Display for DustError {
             DustError::AnalysisFailed => {
                 write!(f, "Analysis failed")
             }
+            DustError::FilesystemStats { path, source } => {
+                write!(
+                    f,
+                    "Failed to read filesystem statistics for {}: {source}",
+                    path.display()
+                )
+            }
             DustError::CleanupFailed => {
                 write!(f, "Cleanup failed")
             }
@@ -89,6 +102,7 @@ impl std::error::Error for DustError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io(error) => Some(error),
+            Self::FilesystemStats { source, .. } => Some(source),
             Self::ScanAccess { source, .. } => Some(source),
             _ => None,
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,4 +14,5 @@ mod integrity;
 mod lockfile;
 mod scanner;
 mod security;
+mod storage;
 mod workflow;

--- a/crates/core/src/models/analysis.rs
+++ b/crates/core/src/models/analysis.rs
@@ -29,6 +29,14 @@ pub struct AnalysisResult {
     pub artifacts: Vec<ArtifactAnalysis>,
     /// Sum of all analyzed artifact sizes.
     pub total_size_bytes: u64,
+    /// Number of filesystem entries whose size or modification metadata could
+    /// not be measured while analyzing the artifacts.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub measurement_failures: u64,
+}
+
+fn is_zero(value: &u64) -> bool {
+    *value == 0
 }
 
 /// Removes duplicate and covered analysis records before any aggregate is

--- a/crates/core/src/models/artifact_snapshot.rs
+++ b/crates/core/src/models/artifact_snapshot.rs
@@ -338,6 +338,7 @@ mod tests {
             &AnalysisResult {
                 artifacts,
                 total_size_bytes: 0,
+                ..AnalysisResult::default()
             },
             timestamp(1),
         )
@@ -455,6 +456,7 @@ mod tests {
                 10,
             )],
             total_size_bytes: 10,
+            ..AnalysisResult::default()
         };
         let snapshot = ArtifactSnapshot::from_analysis(&link, &analysis);
 

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -12,6 +12,7 @@ mod project;
 mod recommendation;
 mod scan;
 mod signature;
+mod storage;
 mod workflow;
 
 pub(crate) use analysis::normalize_artifact_analyses;
@@ -30,4 +31,5 @@ pub(crate) use scan::effective_security_ecosystems;
 pub(crate) use scan::normalize_artifacts;
 pub use scan::*;
 pub use signature::*;
+pub use storage::*;
 pub use workflow::*;

--- a/crates/core/src/models/storage.rs
+++ b/crates/core/src/models/storage.rs
@@ -1,0 +1,73 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::Ecosystem;
+
+/// Capacity statistics for the filesystem containing a workspace.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VolumeStorage {
+    /// Total capacity reported by the filesystem.
+    pub total_bytes: u64,
+    /// Bytes considered used, derived as `total_bytes - available_bytes`.
+    pub used_bytes: u64,
+    /// Bytes available to the current user according to the filesystem.
+    pub available_bytes: u64,
+}
+
+impl VolumeStorage {
+    /// Builds internally consistent volume statistics from filesystem values.
+    ///
+    /// A filesystem should never report more available bytes than total bytes,
+    /// but clamping that value keeps the serialized relationship safe if an
+    /// unusual or inconsistent filesystem response is encountered.
+    pub(crate) fn from_filesystem_values(total_bytes: u64, available_bytes: u64) -> Self {
+        let available_bytes = available_bytes.min(total_bytes);
+        let used_bytes = total_bytes.saturating_sub(available_bytes);
+
+        Self {
+            total_bytes,
+            used_bytes,
+            available_bytes,
+        }
+    }
+}
+
+/// Scope and measured categories represented by the developer-storage value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DeveloperStorageSummary {
+    /// Sum of all normalized, measured scanner-owned artifacts.
+    pub measured_bytes: u64,
+    /// Sum of artifacts currently recommended for cleanup.
+    pub recommended_bytes: u64,
+    /// The selected workspace represented by `measured_bytes`.
+    pub scope_path: PathBuf,
+    /// Ecosystems represented by the analyzed artifact set.
+    pub categories: Vec<Ecosystem>,
+}
+
+/// Storage context shown by the Overview.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageSummary {
+    /// Capacity of the volume containing the selected workspace.
+    pub volume: VolumeStorage,
+    /// Measured development storage and its explicit scope.
+    pub developer_storage: DeveloperStorageSummary,
+    /// Whether the supplied workspace analysis had filesystem access failures.
+    pub partial: bool,
+    /// Human-readable coverage warnings for a partial analysis.
+    pub warnings: Vec<String>,
+}
+
+impl StorageSummary {
+    /// Returns measured development storage as a percentage of used volume
+    /// storage. A zero-used volume has no meaningful share percentage.
+    pub fn detected_share_percent(&self) -> Option<f64> {
+        (self.volume.used_bytes > 0).then(|| {
+            self.developer_storage.measured_bytes as f64 / self.volume.used_bytes as f64 * 100.0
+        })
+    }
+}

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -1,0 +1,247 @@
+use std::path::Path;
+
+use crate::{
+    error::{DustError, DustResult},
+    models::{
+        AnalysisResult, CleanupRecommendation, DeveloperStorageSummary, ScanAccessSummary,
+        StorageSummary, VolumeStorage,
+    },
+};
+
+/// Builds the Overview storage context without traversing the workspace.
+///
+/// Filesystem capacity is read from the path itself, so the returned volume is
+/// the volume containing the selected workspace rather than a hard-coded
+/// system volume. Development storage is reused from the supplied completed
+/// analysis and therefore does not perform another artifact-size walk.
+pub fn summarize(workspace: &Path, analysis: &AnalysisResult) -> DustResult<StorageSummary> {
+    summarize_with_access_summary(workspace, analysis, None)
+}
+
+/// Builds the storage context while retaining bounded scan-coverage warnings.
+///
+/// A partial scan still contributes the bytes DustFril measured, but the
+/// caller can present that result as partial instead of implying full
+/// workspace coverage.
+pub fn summarize_with_access_summary(
+    workspace: &Path,
+    analysis: &AnalysisResult,
+    access_summary: Option<&ScanAccessSummary>,
+) -> DustResult<StorageSummary> {
+    let filesystem = fs2::statvfs(workspace).map_err(|source| DustError::FilesystemStats {
+        path: workspace.to_path_buf(),
+        source,
+    })?;
+    let volume = VolumeStorage::from_filesystem_values(
+        filesystem.total_space(),
+        filesystem.available_space(),
+    );
+
+    let recommended_bytes = analysis
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact.recommendation == CleanupRecommendation::SafeToClean)
+        .map(|artifact| artifact.size_bytes)
+        .fold(0, u64::saturating_add);
+
+    let mut categories = analysis
+        .artifacts
+        .iter()
+        .map(|artifact| artifact.artifact.ecosystem)
+        .collect::<Vec<_>>();
+    categories.sort_unstable();
+    categories.dedup();
+
+    let partial = access_summary.is_some_and(|summary| summary.failures > 0);
+    let warnings = access_summary
+        .filter(|summary| summary.failures > 0)
+        .map(|summary| {
+            vec![format!(
+                "Workspace analysis was partial: {} filesystem access failure(s) were not measured.",
+                summary.failures
+            )]
+        })
+        .unwrap_or_default();
+
+    Ok(StorageSummary {
+        volume,
+        developer_storage: DeveloperStorageSummary {
+            measured_bytes: analysis.total_size_bytes,
+            recommended_bytes,
+            scope_path: workspace.to_path_buf(),
+            categories,
+        },
+        partial,
+        warnings,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::models::{Artifact, ArtifactAnalysis, Ecosystem};
+
+    fn analysis(
+        artifacts: Vec<(PathBuf, Ecosystem, u64, CleanupRecommendation)>,
+    ) -> AnalysisResult {
+        let total_size_bytes = artifacts
+            .iter()
+            .map(|(_, _, size_bytes, _)| *size_bytes)
+            .fold(0, u64::saturating_add);
+
+        AnalysisResult {
+            artifacts: artifacts
+                .into_iter()
+                .map(
+                    |(path, ecosystem, size_bytes, recommendation)| ArtifactAnalysis {
+                        artifact: Artifact::new(path, ecosystem),
+                        size_bytes,
+                        last_modified: None,
+                        age_days: None,
+                        recommendation,
+                    },
+                )
+                .collect(),
+            total_size_bytes,
+        }
+    }
+
+    #[test]
+    fn volume_values_preserve_the_capacity_relationship() {
+        let volume = VolumeStorage::from_filesystem_values(100, 35);
+
+        assert_eq!(volume.used_bytes, 65);
+        assert_eq!(
+            volume.used_bytes + volume.available_bytes,
+            volume.total_bytes
+        );
+    }
+
+    #[test]
+    fn inconsistent_available_value_is_clamped() {
+        let volume = VolumeStorage::from_filesystem_values(100, 125);
+
+        assert_eq!(volume.used_bytes, 0);
+        assert_eq!(volume.available_bytes, 100);
+    }
+
+    #[test]
+    fn workspace_path_uses_the_containing_filesystem() {
+        let root = tempfile::tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+
+        let root_stats = fs2::statvfs(root.path()).unwrap();
+        let summary = summarize(&workspace, &AnalysisResult::default()).unwrap();
+
+        assert_eq!(summary.volume.total_bytes, root_stats.total_space());
+        assert_eq!(
+            summary.volume.available_bytes,
+            root_stats.available_space().min(root_stats.total_space())
+        );
+    }
+
+    #[test]
+    fn invalid_workspace_path_reports_filesystem_error() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("missing-workspace");
+
+        let error = summarize(&path, &AnalysisResult::default()).unwrap_err();
+
+        assert!(
+            matches!(error, DustError::FilesystemStats { path: ref error_path, .. } if error_path == &path)
+        );
+        assert!(!error.to_string().contains("0 B"));
+    }
+
+    #[test]
+    fn measured_storage_includes_all_recommendation_states_and_separates_reclaimable_bytes() {
+        let root = tempfile::tempdir().unwrap();
+        let analysis = analysis(vec![
+            (
+                root.path().join("target"),
+                Ecosystem::Rust,
+                10,
+                CleanupRecommendation::Keep,
+            ),
+            (
+                root.path().join("node_modules"),
+                Ecosystem::Node,
+                20,
+                CleanupRecommendation::NeedsReview,
+            ),
+            (
+                root.path().join("build"),
+                Ecosystem::Java,
+                30,
+                CleanupRecommendation::SafeToClean,
+            ),
+        ]);
+
+        let summary = summarize(root.path(), &analysis).unwrap();
+
+        assert_eq!(summary.developer_storage.measured_bytes, 60);
+        assert_eq!(summary.developer_storage.recommended_bytes, 30);
+        assert_eq!(summary.developer_storage.scope_path, root.path());
+        assert_eq!(
+            summary.developer_storage.categories,
+            vec![Ecosystem::Rust, Ecosystem::Node, Ecosystem::Java]
+        );
+    }
+
+    #[test]
+    fn share_percentage_is_calculated_against_used_bytes() {
+        let summary = StorageSummary {
+            volume: VolumeStorage::from_filesystem_values(1_000, 500),
+            developer_storage: DeveloperStorageSummary {
+                measured_bytes: 50,
+                recommended_bytes: 25,
+                scope_path: PathBuf::from("/workspace"),
+                categories: vec![Ecosystem::Rust],
+            },
+            partial: false,
+            warnings: vec![],
+        };
+
+        assert_eq!(summary.detected_share_percent(), Some(10.0));
+    }
+
+    #[test]
+    fn zero_used_bytes_have_no_share_percentage() {
+        let summary = StorageSummary {
+            volume: VolumeStorage::from_filesystem_values(0, 0),
+            developer_storage: DeveloperStorageSummary {
+                measured_bytes: 50,
+                recommended_bytes: 0,
+                scope_path: PathBuf::from("/workspace"),
+                categories: vec![],
+            },
+            partial: false,
+            warnings: vec![],
+        };
+
+        assert_eq!(summary.detected_share_percent(), None);
+    }
+
+    #[test]
+    fn partial_scan_coverage_is_exposed_without_discarding_measured_bytes() {
+        let root = tempfile::tempdir().unwrap();
+        let analysis = analysis(vec![(
+            root.path().join("target"),
+            Ecosystem::Rust,
+            42,
+            CleanupRecommendation::Keep,
+        )]);
+        let mut access_summary = ScanAccessSummary::new(root.path());
+        access_summary.record_failure(root.path(), "permission denied");
+
+        let summary =
+            summarize_with_access_summary(root.path(), &analysis, Some(&access_summary)).unwrap();
+
+        assert!(summary.partial);
+        assert_eq!(summary.developer_storage.measured_bytes, 42);
+        assert_eq!(summary.warnings.len(), 1);
+    }
+}

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -18,6 +18,19 @@ pub fn summarize(workspace: &Path, analysis: &AnalysisResult) -> DustResult<Stor
     summarize_with_access_summary(workspace, analysis, None)
 }
 
+/// Reads the capacity of the filesystem containing the selected workspace.
+pub fn volume(workspace: &Path) -> DustResult<VolumeStorage> {
+    let filesystem = fs2::statvfs(workspace).map_err(|source| DustError::FilesystemStats {
+        path: workspace.to_path_buf(),
+        source,
+    })?;
+
+    Ok(VolumeStorage::from_filesystem_values(
+        filesystem.total_space(),
+        filesystem.available_space(),
+    ))
+}
+
 /// Builds the storage context while retaining bounded scan-coverage warnings.
 ///
 /// A partial scan still contributes the bytes DustFril measured, but the
@@ -28,14 +41,7 @@ pub fn summarize_with_access_summary(
     analysis: &AnalysisResult,
     access_summary: Option<&ScanAccessSummary>,
 ) -> DustResult<StorageSummary> {
-    let filesystem = fs2::statvfs(workspace).map_err(|source| DustError::FilesystemStats {
-        path: workspace.to_path_buf(),
-        source,
-    })?;
-    let volume = VolumeStorage::from_filesystem_values(
-        filesystem.total_space(),
-        filesystem.available_space(),
-    );
+    let volume = volume(workspace)?;
 
     let recommended_bytes = analysis
         .artifacts
@@ -52,16 +58,20 @@ pub fn summarize_with_access_summary(
     categories.sort_unstable();
     categories.dedup();
 
-    let partial = access_summary.is_some_and(|summary| summary.failures > 0);
-    let warnings = access_summary
-        .filter(|summary| summary.failures > 0)
-        .map(|summary| {
-            vec![format!(
-                "Workspace analysis was partial: {} filesystem access failure(s) were not measured.",
-                summary.failures
-            )]
-        })
-        .unwrap_or_default();
+    let mut warnings = Vec::new();
+    if analysis.measurement_failures > 0 {
+        warnings.push(format!(
+            "Workspace analysis was partial: {} artifact measurement failure(s) were not measured.",
+            analysis.measurement_failures
+        ));
+    }
+    if let Some(summary) = access_summary.filter(|summary| summary.failures > 0) {
+        warnings.push(format!(
+            "Workspace analysis was partial: {} filesystem access failure(s) were not measured.",
+            summary.failures
+        ));
+    }
+    let partial = !warnings.is_empty();
 
     Ok(StorageSummary {
         volume,
@@ -105,6 +115,7 @@ mod tests {
                 )
                 .collect(),
             total_size_bytes,
+            ..AnalysisResult::default()
         }
     }
 
@@ -154,6 +165,20 @@ mod tests {
             matches!(error, DustError::FilesystemStats { path: ref error_path, .. } if error_path == &path)
         );
         assert!(!error.to_string().contains("0 B"));
+    }
+
+    #[test]
+    fn volume_reads_capacity_without_an_analysis() {
+        let root = tempfile::tempdir().unwrap();
+
+        let volume = volume(root.path()).unwrap();
+
+        assert!(volume.total_bytes > 0);
+        assert!(volume.available_bytes <= volume.total_bytes);
+        assert_eq!(
+            volume.used_bytes + volume.available_bytes,
+            volume.total_bytes
+        );
     }
 
     #[test]
@@ -243,5 +268,24 @@ mod tests {
         assert!(summary.partial);
         assert_eq!(summary.developer_storage.measured_bytes, 42);
         assert_eq!(summary.warnings.len(), 1);
+    }
+
+    #[test]
+    fn partial_artifact_measurement_is_exposed_without_discarding_measured_bytes() {
+        let root = tempfile::tempdir().unwrap();
+        let mut analysis = analysis(vec![(
+            root.path().join("target"),
+            Ecosystem::Rust,
+            42,
+            CleanupRecommendation::Keep,
+        )]);
+        analysis.measurement_failures = 2;
+
+        let summary = summarize(root.path(), &analysis).unwrap();
+
+        assert!(summary.partial);
+        assert_eq!(summary.developer_storage.measured_bytes, 42);
+        assert_eq!(summary.warnings.len(), 1);
+        assert!(summary.warnings[0].contains("2 artifact measurement failure(s)"));
     }
 }


### PR DESCRIPTION
## What

Closes #158

- Add a Core-owned storage summary API backed by filesystem statistics for the volume containing the selected workspace.
- Reuse the completed `AnalysisResult` to report measured scanner-owned development storage, its share of used volume bytes, and separate recommended cleanup bytes.
- Propagate analyzer measurement failures so partial storage results are not presented as complete.
- Add explicit not-analyzed, unavailable, and partial-analysis states with scope context.
- Render a compact Finder-like Storage section in Desktop Overview without triggering another workspace scan.
- Refresh volume capacity after permanent cleanup without re-scanning or re-analyzing the workspace.

## Why

Overview now answers how full the selected workspace’s volume is while keeping the measured development-storage claim limited to DustFril-supported, analyzed artifacts. Keep, Needs Review, and Recommended artifacts contribute to detected storage; only Recommended bytes are shown as cleanup candidates.

## Validation

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p dustfril-core --lib -- --skip signed_system_fixture_is_reported_as_valid` ✅ (301 tests)
- `cargo test -p dustfril-tauri --lib` ✅ (19 tests)
- `npm test -- --run` ✅ (28 tests)
- `npm run build` ✅
- `git diff --check` ✅
- GitHub Rust CI ✅
- GitHub Tauri Check ✅

`cargo test --workspace` was also run. It has one existing macOS signing fixture assertion failure in `crates/core/src/integrity/macos.rs` (`macOS Software Signing` vs `Software Signing`); no unrelated files were changed.