### PR TITLE
feat(tauri): add shared desktop module navigation

### DIFF
--- a/apps/tauri/README.md
+++ b/apps/tauri/README.md
@@ -76,6 +76,43 @@ additive `historyWarning` for the desktop status surface.
 - `WorkspaceView`
 - `CleanupDialog`
 - `HistoryList`
+- `AsyncStatePanel`
+- `ModulePlaceholderView`
+
+## Desktop module navigation
+
+The sidebar keeps the planned Desktop information architecture in
+`src/model/categories.ts`:
+
+```text
+Overview
+
+Cleanup
+  Rust
+  Node.js
+  Java
+  Cache (planned)
+
+Workspace
+  Dependencies (planned)
+  Artifact History (planned)
+  Activity
+
+Security
+  Supply Chain (planned)
+  GitHub Actions (planned)
+  Executable Integrity (planned)
+```
+
+Rust, Node.js, and Java destinations filter the existing unified analysis
+result; they do not start a new scan when selected. Planned destinations render
+an explicit unsupported state and do not invoke speculative Tauri commands.
+
+Advanced operations use the small state model in `src/model/async.ts`. It
+keeps loading, success, partial success, unsupported, empty, and error states
+distinct, preserves a previous result on refresh errors, and ignores responses
+from older request IDs. Workspace changes invalidate the current operation
+before clearing workspace-bound results.
 
 ## Commands
 

--- a/apps/tauri/src/components/AsyncStatePanel/AsyncStatePanel.test.tsx
+++ b/apps/tauri/src/components/AsyncStatePanel/AsyncStatePanel.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AsyncStatePanel } from './AsyncStatePanel';
+
+describe('AsyncStatePanel', () => {
+  it('distinguishes partial results from their warnings', () => {
+    render(
+      <AsyncStatePanel
+        status="partial"
+        title="Analysis complete"
+        description="The primary result is available."
+        warnings={['One auxiliary record could not be saved.']}
+      />,
+    );
+
+    expect(screen.getByText('Partial')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Analysis complete' })).toBeInTheDocument();
+    expect(screen.getByText('One auxiliary record could not be saved.')).toBeInTheDocument();
+  });
+
+  it('renders planned surfaces as unsupported instead of functional results', () => {
+    render(
+      <AsyncStatePanel
+        status="unsupported"
+        title="Cache cleanup is planned"
+        description="This module is not available yet."
+        actionLabel="Return to Overview"
+        onAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Planned')).toBeInTheDocument();
+    expect(screen.getByText('This module is not available yet.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Return to Overview' })).toBeInTheDocument();
+  });
+});

--- a/apps/tauri/src/components/AsyncStatePanel/AsyncStatePanel.tsx
+++ b/apps/tauri/src/components/AsyncStatePanel/AsyncStatePanel.tsx
@@ -1,0 +1,47 @@
+import type { AsyncOperationStatus } from '../../model/async';
+
+type AsyncStatePanelProps = {
+  status: AsyncOperationStatus;
+  title: string;
+  description: string;
+  warnings?: string[];
+  error?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+};
+
+const statusLabels: Record<AsyncOperationStatus, string> = {
+  idle: 'Ready',
+  loading: 'Loading',
+  success: 'Complete',
+  partial: 'Partial',
+  unsupported: 'Planned',
+  empty: 'No results',
+  error: 'Error',
+};
+
+export function AsyncStatePanel(props: AsyncStatePanelProps) {
+  const message = props.error ?? props.description;
+
+  return (
+    <section className={`async-state-panel async-state-${props.status}`} role="status">
+      <div className="async-state-header">
+        <span className="status-badge">{statusLabels[props.status]}</span>
+        <h2>{props.title}</h2>
+      </div>
+      <p>{message}</p>
+      {props.warnings?.length ? (
+        <ul className="async-state-warnings">
+          {props.warnings.map((warning) => (
+            <li key={warning}>{warning}</li>
+          ))}
+        </ul>
+      ) : null}
+      {props.actionLabel && props.onAction ? (
+        <button type="button" className="button-secondary" onClick={props.onAction}>
+          {props.actionLabel}
+        </button>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/tauri/src/components/Sidebar/Sidebar.tsx
+++ b/apps/tauri/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,9 @@
-import type { CategoryConfig, SidebarCategory } from '../../model/categories';
+import {
+  categorySections,
+  type CategoryConfig,
+  type CategorySection,
+  type SidebarCategory,
+} from '../../model/categories';
 
 export type SidebarEntry = CategoryConfig & {
   count: number | null;
@@ -11,32 +16,82 @@ type SidebarProps = {
 };
 
 export function Sidebar(props: SidebarProps) {
+  const entriesBySection = new Map<CategorySection, SidebarEntry[]>();
+  for (const entry of props.entries) {
+    const sectionEntries = entriesBySection.get(entry.section) ?? [];
+    sectionEntries.push(entry);
+    entriesBySection.set(entry.section, sectionEntries);
+  }
+
   return (
     <aside className="app-sidebar">
-      <p className="sidebar-heading">Favorites</p>
       <nav className="sidebar-nav" aria-label="Primary navigation">
-        {props.entries.map((entry) => {
-          const active = entry.key === props.activeCategory;
+        {categorySections.map((section) => {
+          const entries = entriesBySection.get(section.key) ?? [];
+          if (!entries.length) {
+            return null;
+          }
 
           return (
-            <button
-              key={entry.key}
-              type="button"
-              onClick={() => props.onCategoryChange(entry.key)}
-              className={`sidebar-item${active ? ' sidebar-item-active' : ''}`}
-              aria-current={active ? 'page' : undefined}
-              title={entry.description}
-            >
-              <span className={`sidebar-item-icon sidebar-icon-${entry.key}`} aria-hidden="true">
-                {entry.key === 'overview' ? '◌' : entry.key === 'workspace' ? '▣' : '◷'}
-              </span>
-              <span className="sidebar-item-label">{entry.title}</span>
-              {entry.count !== null ? <span className="sidebar-count">{entry.count}</span> : null}
-            </button>
+            <div className="sidebar-section" key={section.key}>
+              <p className="sidebar-heading">{section.title}</p>
+              {entries.map((entry) => (
+                <SidebarButton
+                  key={entry.key}
+                  entry={entry}
+                  active={isCategoryActive(entry.key, props.activeCategory)}
+                  onCategoryChange={props.onCategoryChange}
+                />
+              ))}
+            </div>
           );
         })}
       </nav>
-
     </aside>
+  );
+}
+
+function isCategoryActive(entry: SidebarCategory, activeCategory: SidebarCategory) {
+  if (entry === 'workspace') {
+    return activeCategory === 'workspace' || activeCategory.startsWith('cleanup-');
+  }
+  if (entry === 'history') {
+    return activeCategory === 'history' || activeCategory === 'workspace-activity';
+  }
+  return entry === activeCategory;
+}
+
+function SidebarButton({
+  entry,
+  active,
+  onCategoryChange,
+}: {
+  entry: SidebarEntry;
+  active: boolean;
+  onCategoryChange: (category: SidebarCategory) => void;
+}) {
+  const planned = entry.availability === 'planned';
+
+  return (
+    <button
+      type="button"
+      onClick={() => onCategoryChange(entry.key)}
+      className={`sidebar-item${active ? ' sidebar-item-active' : ''}${planned ? ' sidebar-item-planned' : ''}`}
+      aria-current={active ? 'page' : undefined}
+      title={entry.description}
+    >
+      <span className={`sidebar-item-icon sidebar-icon-${entry.section}`} aria-hidden="true">
+        {entry.section === 'favorites'
+          ? '◌'
+          : entry.section === 'cleanup'
+            ? '▣'
+            : entry.section === 'workspace'
+              ? '◷'
+              : '◇'}
+      </span>
+      <span className="sidebar-item-label">{entry.title}</span>
+      {planned ? <span className="sidebar-planned-label" aria-hidden="true">Planned</span> : null}
+      {entry.count !== null ? <span className="sidebar-count" aria-hidden="true">{entry.count}</span> : null}
+    </button>
   );
 }

--- a/apps/tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.test.tsx
@@ -46,6 +46,30 @@ const historyEntry = {
 describe('AppShell Overview navigation', () => {
   afterEach(() => vi.clearAllMocks());
 
+  it.each([
+    ['Rust', false],
+    ['Node.js', false],
+    ['Java', false],
+    ['Cache', true],
+    ['Dependencies', true],
+    ['Artifact History', true],
+    ['Activity', false],
+    ['Supply Chain', true],
+    ['GitHub Actions', true],
+    ['Executable Integrity', true],
+  ])('navigates to the %s module without starting another operation', async (title, planned) => {
+    render(<AppShell />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Analyze Workspace' })).toBeEnabled());
+
+    fireEvent.click(screen.getByRole('button', { name: title }));
+
+    expect(screen.getByRole('button', { name: title })).toHaveAttribute('aria-current', 'page');
+    if (planned) {
+      expect(screen.getByRole('heading', { name: `${title} is planned` })).toBeInTheDocument();
+    }
+    expect(analyzeWorkspace).not.toHaveBeenCalled();
+  });
+
   it('opens the exact Overview artifact in Workspace without selecting it', async () => {
     vi.mocked(analyzeWorkspace).mockResolvedValue({
       analysis: {

--- a/apps/tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.test.tsx
@@ -33,6 +33,18 @@ const analyzedArtifact = {
   recommendation: 'Keep' as const,
 };
 
+const analyzedNodeArtifact = {
+  ...analyzedArtifact,
+  path: '/workspace/dustfril/node_modules',
+  ecosystem: 'Node' as const,
+  project: {
+    ...analyzedArtifact.project,
+    ecosystem: 'Node' as const,
+  },
+  sizeBytes: 7 * 1024 ** 3,
+  recommendation: 'SafeToClean' as const,
+};
+
 const historyEntry = {
   id: 'scan-1',
   timestampMs: Date.UTC(2026, 8, 3, 4, 5),
@@ -149,6 +161,78 @@ describe('AppShell Overview navigation', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /^History/ })).toHaveTextContent('0'));
     expect(clearActivityHistory).toHaveBeenCalledOnce();
     expect(screen.getByText('No activity yet')).toBeInTheDocument();
+  });
+
+  it('confirms and executes only the selected ecosystem artifacts', async () => {
+    vi.mocked(analyzeWorkspace).mockResolvedValue({
+      analysis: {
+        artifacts: [analyzedArtifact, analyzedNodeArtifact],
+        totalSizeBytes: analyzedArtifact.sizeBytes + analyzedNodeArtifact.sizeBytes,
+      },
+      cleanupPlan: {
+        analysisId: 'analysis-1',
+        candidates: [
+          {
+            path: analyzedArtifact.path,
+            ecosystem: analyzedArtifact.ecosystem,
+            project: analyzedArtifact.project,
+            sizeBytes: analyzedArtifact.sizeBytes,
+            ageDays: analyzedArtifact.ageDays,
+            recommendation: analyzedArtifact.recommendation,
+            selectedByDefault: true,
+          },
+          {
+            path: analyzedNodeArtifact.path,
+            ecosystem: analyzedNodeArtifact.ecosystem,
+            project: analyzedNodeArtifact.project,
+            sizeBytes: analyzedNodeArtifact.sizeBytes,
+            ageDays: analyzedNodeArtifact.ageDays,
+            recommendation: analyzedNodeArtifact.recommendation,
+            selectedByDefault: true,
+          },
+        ],
+        reclaimableSizeBytes: analyzedNodeArtifact.sizeBytes,
+      },
+      storageSummary: {
+        status: 'available',
+        totalBytes: 512 * 1024 ** 3,
+        usedBytes: 318 * 1024 ** 3,
+        availableBytes: 194 * 1024 ** 3,
+        detectedDevelopmentBytes: analyzedArtifact.sizeBytes + analyzedNodeArtifact.sizeBytes,
+        detectedSharePercent: 5.660377358490566,
+        partial: false,
+        warnings: [],
+        recommendedBytes: analyzedNodeArtifact.sizeBytes,
+        scopePath: '/workspace/dustfril',
+        categories: ['Rust', 'Node'],
+      },
+    });
+    vi.mocked(executeCleanup).mockResolvedValue({
+      deletedPaths: [analyzedArtifact.path],
+      failedPaths: [],
+      freedSizeBytes: analyzedArtifact.sizeBytes,
+    });
+
+    render(<AppShell />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Analyze Workspace' })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: 'Analyze Workspace' }));
+    await waitFor(() => expect(screen.getByRole('checkbox')).toBeChecked());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cleanup' }));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('1 selected');
+    expect(dialog).toHaveTextContent(analyzedArtifact.path);
+    expect(dialog).not.toHaveTextContent(analyzedNodeArtifact.path);
+
+    fireEvent.click(dialog.querySelector('.button-confirm') as HTMLButtonElement);
+    await waitFor(() => expect(executeCleanup).toHaveBeenCalledOnce());
+    expect(executeCleanup).toHaveBeenCalledWith(
+      '/workspace',
+      ['Rust', 'Node', 'Java'],
+      'analysis-1',
+      [{ path: analyzedArtifact.path, ecosystem: 'Rust' }],
+      'Trash',
+    );
   });
 
   it('refreshes volume capacity after permanent cleanup', async () => {

--- a/apps/tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.tsx
@@ -111,7 +111,7 @@ export function AppShell() {
 
       <CleanupDialog
         open={app.confirmDialogOpen}
-        itemCount={app.selectedCleanupPaths.length}
+        itemCount={app.selectedCleanupItems.length}
         totalBytes={app.selectedCandidateBytes}
         deleteMode={app.deleteMode}
         selectedItems={app.selectedCleanupItems}

--- a/apps/tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.tsx
@@ -1,14 +1,21 @@
 import { CleanupDialog } from '../../components/CleanupDialog/CleanupDialog';
 import { Sidebar } from '../../components/Sidebar/Sidebar';
+import { categoryConfig } from '../../model/categories';
 import { pathBreadcrumb } from '../../model/presentation';
 import { AppHeader } from './components/AppHeader';
 import { useAppState } from './hooks/useAppState';
 import { HistoryView } from './views/HistoryView';
+import { ModulePlaceholderView } from './views/ModulePlaceholderView';
 import { OverviewView } from './views/OverviewView';
 import { WorkspaceView } from './views/WorkspaceView';
 
 export function AppShell() {
   const app = useAppState();
+  const activeConfig = categoryConfig(app.activeCategory);
+  const showingCleanup = activeConfig?.ecosystem !== undefined;
+  const showingWorkspace = app.activeCategory === 'workspace' || showingCleanup;
+  const showingActivity =
+    app.activeCategory === 'history' || app.activeCategory === 'workspace-activity';
 
   return (
     <main className="app-shell">
@@ -45,15 +52,14 @@ export function AppShell() {
             />
           ) : null}
 
-          {app.activeCategory === 'workspace' ? (
+          {showingWorkspace ? (
             <WorkspaceView
+              ecosystem={activeConfig?.ecosystem}
               artifacts={app.filteredArtifacts}
-              artifactCount={app.summary.artifactCount}
-              totalSizeBytes={app.analysisResult?.totalSizeBytes ?? 0}
               candidates={app.cleanupPlan?.candidates ?? []}
+              operationStatus={app.workspaceOperation.status}
               selectedItemId={app.selectedItemId}
               selectedPaths={app.selectedCleanupPaths}
-              selectedCandidateBytes={app.selectedCandidateBytes}
               canReviewCleanup={app.canReviewCleanup}
               deleteMode={app.deleteMode}
               deleteModes={app.deleteModes}
@@ -70,12 +76,19 @@ export function AppShell() {
             />
           ) : null}
 
-          {app.activeCategory === 'history' ? (
+          {showingActivity ? (
             <HistoryView
               entries={app.historyEntries}
               busy={app.busyAction !== null}
               error={app.error}
               onClearHistory={app.handleClearHistory}
+            />
+          ) : null}
+
+          {app.activeCategory !== 'overview' && !showingWorkspace && !showingActivity && activeConfig ? (
+            <ModulePlaceholderView
+              config={activeConfig}
+              onReturnToOverview={() => app.setActiveCategory('overview')}
             />
           ) : null}
         </section>

--- a/apps/tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useAppState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { formatBytes } from '../../../lib/format';
 import {
   analyzeWorkspace,
@@ -10,6 +10,10 @@ import {
   refreshStorageVolume,
 } from '../../../lib/tauri';
 import { categoryConfigs, type SidebarCategory } from '../../../model/categories';
+import {
+  idleAsyncOperation,
+  reduceAsyncOperation,
+} from '../../../model/async';
 import type { SidebarEntry } from '../../../components/Sidebar/Sidebar';
 import type {
   ActivityRecord,
@@ -27,10 +31,12 @@ import {
   selectedCandidateBytes,
 } from '../../../model/presentation';
 
+type WorkspaceAnalysisResponse = Awaited<ReturnType<typeof analyzeWorkspace>>;
+
 export function useAppState() {
   const [root, setRoot] = useState('');
   const [search, setSearch] = useState('');
-  const [activeCategory, setActiveCategory] = useState<SidebarCategory>('workspace');
+  const [activeCategory, setActiveCategory] = useState<SidebarCategory>('cleanup-rust');
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const [deleteMode, setDeleteMode] = useState<DeleteMode>('Trash');
   const [busyAction, setBusyAction] = useState<string | null>(null);
@@ -42,6 +48,10 @@ export function useAppState() {
   const [selectedCleanupPaths, setSelectedCleanupPaths] = useState<string[]>([]);
   const [cleanupAgeDays, setCleanupAgeDays] = useState<number>(defaultCleanupAgeDays);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [workspaceOperation, dispatchWorkspaceOperation] = useReducer(
+    reduceAsyncOperation<WorkspaceAnalysisResponse>,
+    idleAsyncOperation<WorkspaceAnalysisResponse>(),
+  );
   const workspaceRequestRef = useRef(0);
   const actionRequestRef = useRef(0);
 
@@ -87,13 +97,13 @@ export function useAppState() {
       categoryConfigs.map((config) => ({
         ...config,
         count:
-          config.key === 'workspace'
-            ? workspaceArtifacts.length
-            : config.key === 'history'
+          config.ecosystem
+            ? workspaceArtifacts.filter((artifact) => artifact.ecosystem === config.ecosystem).length
+            : config.key === 'workspace-activity' || config.key === 'history'
               ? historyEntries.length
               : null,
       })),
-    [historyEntries.length, workspaceArtifacts.length],
+    [historyEntries.length, workspaceArtifacts],
   );
 
   const canAnalyze = busyAction === null && root.length > 0;
@@ -130,6 +140,10 @@ export function useAppState() {
     }
 
     workspaceRequestRef.current += 1;
+    dispatchWorkspaceOperation({
+      type: 'invalidate',
+      requestId: workspaceRequestRef.current,
+    });
     actionRequestRef.current += 1;
     setRoot(nextRoot);
     setError(null);
@@ -173,42 +187,66 @@ export function useAppState() {
   ) {
     await runAction('analyze-workspace', async () => {
       const requestId = ++workspaceRequestRef.current;
-      const response = await analyzeWorkspace({
-        root,
-        ecosystems: [...ecosystems],
-        cleanupAgeDays: policyAgeDays,
-        recordHistory,
-        recordArtifactSnapshot,
-      });
+      dispatchWorkspaceOperation({ type: 'start', requestId });
 
-      if (requestId !== workspaceRequestRef.current) {
-        return;
+      try {
+        const response = await analyzeWorkspace({
+          root,
+          ecosystems: [...ecosystems],
+          cleanupAgeDays: policyAgeDays,
+          recordHistory,
+          recordArtifactSnapshot,
+        });
+
+        dispatchWorkspaceOperation({
+          type: 'success',
+          requestId,
+          data: response,
+          warnings: [response.analysis.historyWarning, response.artifactSnapshotWarning].filter(
+            (warning): warning is string => Boolean(warning),
+          ),
+        });
+
+        if (requestId !== workspaceRequestRef.current) {
+          return;
+        }
+
+        setAnalysisResult(response.analysis);
+        setCleanupPlan(response.cleanupPlan);
+        setStorageSummary(response.storageSummary);
+        // Rebuild the default cleanup selection from the new policy. This
+        // conservatively drops items that are no longer recommended and never
+        // broadens the selection without a new recommendation.
+        setSelectedCleanupPaths(
+          response.cleanupPlan.candidates
+            .filter((candidate) => candidate.selectedByDefault)
+            .map((candidate) => candidate.path),
+        );
+        setSelectedItemId((current) =>
+          current && response.analysis.artifacts.some((artifact) => artifact.path === current)
+            ? current
+            : null,
+        );
+        setCleanupAgeDays(policyAgeDays);
+        setError(
+          [response.analysis.historyWarning, response.artifactSnapshotWarning]
+            .filter((warning): warning is string => Boolean(warning))
+            .join(' ') || null,
+        );
+        const refreshedHistory = await loadActivityHistory();
+        if (requestId !== workspaceRequestRef.current) {
+          return;
+        }
+        setHistoryEntries(refreshedHistory);
+        setActiveCategory((current) => (current === 'overview' ? 'cleanup-rust' : current));
+      } catch (invokeError) {
+        dispatchWorkspaceOperation({
+          type: 'error',
+          requestId,
+          error: String(invokeError),
+        });
+        throw invokeError;
       }
-
-      setAnalysisResult(response.analysis);
-      setCleanupPlan(response.cleanupPlan);
-      setStorageSummary(response.storageSummary);
-      // Rebuild the default cleanup selection from the new policy. This
-      // conservatively drops items that are no longer recommended and never
-      // broadens the selection without a new recommendation.
-      setSelectedCleanupPaths(
-        response.cleanupPlan.candidates
-          .filter((candidate) => candidate.selectedByDefault)
-          .map((candidate) => candidate.path),
-      );
-      setSelectedItemId((current) =>
-        current && response.analysis.artifacts.some((artifact) => artifact.path === current)
-          ? current
-          : null,
-      );
-      setCleanupAgeDays(policyAgeDays);
-      setError(
-        [response.analysis.historyWarning, response.artifactSnapshotWarning]
-          .filter((warning): warning is string => Boolean(warning))
-          .join(' ') || null,
-      );
-      setHistoryEntries(await loadActivityHistory());
-      setActiveCategory('workspace');
     });
   }
 
@@ -264,7 +302,8 @@ export function useAppState() {
   function openWorkspaceArtifact(path: string) {
     setSearch('');
     setSelectedItemId(path);
-    setActiveCategory('workspace');
+    const artifact = analysisResult?.artifacts.find((candidate) => candidate.path === path);
+    setActiveCategory(categoryForEcosystem(artifact?.ecosystem));
   }
 
   function handleRequestCleanup() {
@@ -407,6 +446,7 @@ export function useAppState() {
     historyEntries,
     confirmDialogOpen,
     confirmSamplePaths,
+    workspaceOperation,
     canAnalyze,
     canReviewCleanup,
     summary,
@@ -426,6 +466,20 @@ export function useAppState() {
     handleRequestCleanup,
     handleConfirmCleanup,
   };
+}
+
+function categoryForEcosystem(
+  ecosystem: WorkspaceAnalysisResponse['analysis']['artifacts'][number]['ecosystem'] | undefined,
+): SidebarCategory {
+  switch (ecosystem) {
+    case 'Node':
+      return 'cleanup-node';
+    case 'Java':
+      return 'cleanup-java';
+    case 'Rust':
+    default:
+      return 'cleanup-rust';
+  }
 }
 
 function formatCleanupFailure(result: CleanupResultResponse, historyWarning?: string): string {

--- a/apps/tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useAppState.ts
@@ -46,6 +46,7 @@ export function useAppState() {
   const [storageSummary, setStorageSummary] = useState<StorageSummary | null>(null);
   const [historyEntries, setHistoryEntries] = useState<ActivityRecord[]>([]);
   const [selectedCleanupPaths, setSelectedCleanupPaths] = useState<string[]>([]);
+  const [cleanupReviewPaths, setCleanupReviewPaths] = useState<string[]>([]);
   const [cleanupAgeDays, setCleanupAgeDays] = useState<number>(defaultCleanupAgeDays);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [workspaceOperation, dispatchWorkspaceOperation] = useReducer(
@@ -82,9 +83,13 @@ export function useAppState() {
     }
   }, [filteredArtifacts, selectedItemId]);
 
-  const selectedCandidateTotalBytes = useMemo(
-    () => selectedCandidateBytes(cleanupCandidates, selectedCleanupPaths),
-    [cleanupCandidates, selectedCleanupPaths],
+  const cleanupReviewItems = useMemo(
+    () => cleanupCandidates.filter((candidate) => cleanupReviewPaths.includes(candidate.path)),
+    [cleanupCandidates, cleanupReviewPaths],
+  );
+  const cleanupReviewTotalBytes = useMemo(
+    () => selectedCandidateBytes(cleanupCandidates, cleanupReviewPaths),
+    [cleanupCandidates, cleanupReviewPaths],
   );
 
   const summary = useMemo(
@@ -109,7 +114,7 @@ export function useAppState() {
   const canAnalyze = busyAction === null && root.length > 0;
   const canReviewCleanup =
     busyAction === null && cleanupPlan !== null && selectedCleanupPaths.length > 0;
-  const confirmSamplePaths = selectedCleanupPaths.slice(0, 5);
+  const confirmSamplePaths = cleanupReviewPaths.slice(0, 5);
 
   async function runAction(action: string, runner: () => Promise<void>) {
     const requestId = ++actionRequestRef.current;
@@ -151,6 +156,7 @@ export function useAppState() {
     setCleanupPlan(null);
     setStorageSummary(null);
     setSelectedCleanupPaths([]);
+    setCleanupReviewPaths([]);
     setSelectedItemId(null);
     setConfirmDialogOpen(false);
     setSearch('');
@@ -222,6 +228,7 @@ export function useAppState() {
             .filter((candidate) => candidate.selectedByDefault)
             .map((candidate) => candidate.path),
         );
+        setCleanupReviewPaths([]);
         setSelectedItemId((current) =>
           current && response.analysis.artifacts.some((artifact) => artifact.path === current)
             ? current
@@ -306,10 +313,19 @@ export function useAppState() {
     setActiveCategory(categoryForEcosystem(artifact?.ecosystem));
   }
 
-  function handleRequestCleanup() {
-    if (canReviewCleanup) {
-      setConfirmDialogOpen(true);
+  function handleRequestCleanup(paths: string[]) {
+    if (busyAction !== null || cleanupPlan === null) {
+      return;
     }
+
+    const candidatePaths = new Set(cleanupPlan.candidates.map((candidate) => candidate.path));
+    const reviewPaths = [...new Set(paths)].filter((path) => candidatePaths.has(path));
+    if (!reviewPaths.length) {
+      return;
+    }
+
+    setCleanupReviewPaths(reviewPaths);
+    setConfirmDialogOpen(true);
   }
 
   async function handleConfirmCleanup() {
@@ -318,7 +334,7 @@ export function useAppState() {
     }
 
     const candidates = cleanupPlan.candidates.filter((candidate) =>
-      selectedCleanupPaths.includes(candidate.path),
+      cleanupReviewPaths.includes(candidate.path),
     );
 
     await runAction('cleanup-execute', async () => {
@@ -418,6 +434,7 @@ export function useAppState() {
       setSelectedCleanupPaths((current) =>
         current.filter((path) => !result.deletedPaths.includes(path)),
       );
+      setCleanupReviewPaths([]);
       setSelectedItemId(null);
       setConfirmDialogOpen(false);
       setHistoryEntries(await loadActivityHistory());
@@ -435,11 +452,9 @@ export function useAppState() {
     analysisResult,
     cleanupPlan,
     storageSummary,
-    selectedCleanupItems: cleanupCandidates.filter((candidate) =>
-      selectedCleanupPaths.includes(candidate.path),
-    ),
+    selectedCleanupItems: cleanupReviewItems,
     selectedCleanupPaths,
-    selectedCandidateBytes: selectedCandidateTotalBytes,
+    selectedCandidateBytes: cleanupReviewTotalBytes,
     cleanupAgeDays,
     sidebarEntries,
     filteredArtifacts,

--- a/apps/tauri/src/features/app-shell/views/ModulePlaceholderView.tsx
+++ b/apps/tauri/src/features/app-shell/views/ModulePlaceholderView.tsx
@@ -1,0 +1,26 @@
+import { AsyncStatePanel } from '../../../components/AsyncStatePanel/AsyncStatePanel';
+import type { CategoryConfig } from '../../../model/categories';
+
+type ModulePlaceholderViewProps = {
+  config: CategoryConfig;
+  onReturnToOverview: () => void;
+};
+
+export function ModulePlaceholderView({ config, onReturnToOverview }: ModulePlaceholderViewProps) {
+  return (
+    <div className="module-placeholder-view">
+      <div className="module-placeholder-heading">
+        <p className="eyebrow">{config.section}</p>
+        <h1>{config.title}</h1>
+        <p>{config.description}</p>
+      </div>
+      <AsyncStatePanel
+        status="unsupported"
+        title={`${config.title} is planned`}
+        description="This destination is reserved for an upcoming DustFril capability. No scan or analysis runs from this screen."
+        actionLabel="Return to Overview"
+        onAction={onReturnToOverview}
+      />
+    </div>
+  );
+}

--- a/apps/tauri/src/features/app-shell/views/WorkspaceView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/WorkspaceView.test.tsx
@@ -21,8 +21,6 @@ function renderWorkspace(deleteMode: 'Trash' | 'Permanent' = 'Trash') {
   return render(
     <WorkspaceView
       artifacts={[artifact]}
-      artifactCount={1}
-      totalSizeBytes={artifact.sizeBytes}
       candidates={[{
         path: artifact.path,
         ecosystem: artifact.ecosystem,
@@ -34,7 +32,6 @@ function renderWorkspace(deleteMode: 'Trash' | 'Permanent' = 'Trash') {
       }]}
       selectedItemId={artifact.path}
       selectedPaths={[]}
-      selectedCandidateBytes={0}
       canReviewCleanup={false}
       deleteMode={deleteMode}
       deleteModes={['Trash', 'Permanent']}

--- a/apps/tauri/src/features/app-shell/views/WorkspaceView.tsx
+++ b/apps/tauri/src/features/app-shell/views/WorkspaceView.tsx
@@ -45,7 +45,7 @@ type WorkspaceViewProps = {
   onTogglePath: (path: string) => void;
   onDeleteModeChange: (mode: DeleteMode) => void;
   onCleanupAgeChange: (days: number) => void | Promise<void>;
-  onRequestCleanup: () => void;
+  onRequestCleanup: (paths: string[]) => void;
 };
 
 export function WorkspaceView(props: WorkspaceViewProps) {
@@ -172,7 +172,7 @@ export function WorkspaceView(props: WorkspaceViewProps) {
               <button
                 type="button"
                 className="review-button"
-                onClick={props.onRequestCleanup}
+                onClick={() => props.onRequestCleanup(visibleSelectedPaths)}
                 disabled={!props.canReviewCleanup || visibleSelectedPaths.length === 0}
               >
                 Cleanup

--- a/apps/tauri/src/features/app-shell/views/WorkspaceView.tsx
+++ b/apps/tauri/src/features/app-shell/views/WorkspaceView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { AsyncStatePanel } from '../../../components/AsyncStatePanel/AsyncStatePanel';
 import { EmptyState } from '../../../components/EmptyState/EmptyState';
 import { FolderIcon, ItemIcon } from '../../../components/icons';
 import { SortableHeader } from '../../../components/SortableHeader/SortableHeader';
@@ -9,12 +10,15 @@ import {
   leafName,
   recommendationClass,
   recommendationLabel,
+  selectedCandidateBytes,
 } from '../../../model/presentation';
 import type {
   ArtifactAnalysis,
   CleanupCandidate,
   DeleteMode,
+  Ecosystem,
 } from '../../../types/workflow';
+import type { AsyncOperationStatus } from '../../../model/async';
 import { cleanupAgeOptions } from '../../../types/workflow';
 import {
   sortArtifacts,
@@ -23,13 +27,12 @@ import {
 } from '../../../model/sorting';
 
 type WorkspaceViewProps = {
+  ecosystem?: Ecosystem;
   artifacts: ArtifactAnalysis[];
-  artifactCount: number;
-  totalSizeBytes: number;
   candidates: CleanupCandidate[];
+  operationStatus?: AsyncOperationStatus;
   selectedItemId: string | null;
   selectedPaths: string[];
-  selectedCandidateBytes: number;
   canReviewCleanup: boolean;
   deleteMode: DeleteMode;
   deleteModes: DeleteMode[];
@@ -47,12 +50,32 @@ type WorkspaceViewProps = {
 
 export function WorkspaceView(props: WorkspaceViewProps) {
   const [sort, setSort] = useState<WorkspaceSortState>({ column: 'size', direction: 'desc' });
-  const candidatesByPath = new Map(props.candidates.map((candidate) => [candidate.path, candidate]));
+  const visibleArtifacts = useMemo(
+    () => props.ecosystem ? props.artifacts.filter((artifact) => artifact.ecosystem === props.ecosystem) : props.artifacts,
+    [props.artifacts, props.ecosystem],
+  );
+  const visibleCandidates = useMemo(
+    () => props.ecosystem ? props.candidates.filter((candidate) => candidate.ecosystem === props.ecosystem) : props.candidates,
+    [props.candidates, props.ecosystem],
+  );
+  const visibleSelectedPaths = useMemo(
+    () => props.selectedPaths.filter((path) => visibleCandidates.some((candidate) => candidate.path === path)),
+    [props.selectedPaths, visibleCandidates],
+  );
+  const visibleSelectedBytes = useMemo(
+    () => selectedCandidateBytes(visibleCandidates, visibleSelectedPaths),
+    [visibleCandidates, visibleSelectedPaths],
+  );
+  const candidatesByPath = new Map(visibleCandidates.map((candidate) => [candidate.path, candidate]));
   const selectedArtifact =
-    props.artifacts.find((artifact) => artifact.path === props.selectedItemId) ?? null;
+    visibleArtifacts.find((artifact) => artifact.path === props.selectedItemId) ?? null;
   const sortedArtifacts = useMemo(
-    () => sortArtifacts(props.artifacts, sort),
-    [props.artifacts, sort],
+    () => sortArtifacts(visibleArtifacts, sort),
+    [visibleArtifacts, sort],
+  );
+  const visibleTotalSizeBytes = visibleArtifacts.reduce(
+    (total, artifact) => total + artifact.sizeBytes,
+    0,
   );
 
   function handleSort(column: WorkspaceSortColumn) {
@@ -82,10 +105,10 @@ export function WorkspaceView(props: WorkspaceViewProps) {
       <div className="workspace-summary-strip" aria-live="polite">
         <span>
           <strong>
-            {formatCount(props.artifactCount)} artifact{props.artifactCount === 1 ? '' : 's'}
+            {formatCount(visibleArtifacts.length)} artifact{visibleArtifacts.length === 1 ? '' : 's'}
           </strong>{' '}
           ·{' '}
-          <strong>{formatBytes(props.totalSizeBytes)}</strong> total
+          <strong>{formatBytes(visibleTotalSizeBytes)}</strong> total
         </span>
         <label className="cleanup-age-control">
           <span>AGE</span>
@@ -116,8 +139,9 @@ export function WorkspaceView(props: WorkspaceViewProps) {
             artifacts={sortedArtifacts}
             candidatesByPath={candidatesByPath}
             selectedItemId={props.selectedItemId}
-            selectedPaths={props.selectedPaths}
+            selectedPaths={visibleSelectedPaths}
             analysisReady={props.analysisReady}
+            operationStatus={props.operationStatus ?? 'idle'}
             sort={sort}
             onSort={handleSort}
             onSelectItem={props.onSelectItem}
@@ -143,13 +167,13 @@ export function WorkspaceView(props: WorkspaceViewProps) {
             </div>
             <div className="cleanup-selection-summary">
               <span>
-                {formatCount(props.selectedPaths.length)} selected · {formatBytes(props.selectedCandidateBytes)}
+                {formatCount(visibleSelectedPaths.length)} selected · {formatBytes(visibleSelectedBytes)}
               </span>
               <button
                 type="button"
                 className="review-button"
                 onClick={props.onRequestCleanup}
-                disabled={!props.canReviewCleanup}
+                disabled={!props.canReviewCleanup || visibleSelectedPaths.length === 0}
               >
                 Cleanup
               </button>
@@ -161,7 +185,7 @@ export function WorkspaceView(props: WorkspaceViewProps) {
           <Inspector
             artifact={selectedArtifact}
             candidate={candidatesByPath.get(selectedArtifact.path)}
-            selectedPaths={props.selectedPaths}
+            selectedPaths={visibleSelectedPaths}
             onClose={props.onCloseInspector}
           />
         ) : null}
@@ -177,6 +201,7 @@ type WorkspaceResultsProps = {
   selectedItemId: string | null;
   selectedPaths: string[];
   analysisReady: boolean;
+  operationStatus: AsyncOperationStatus;
   sort: WorkspaceSortState;
   onSort: (column: WorkspaceSortColumn) => void;
   onSelectItem: (path: string) => void;
@@ -184,6 +209,26 @@ type WorkspaceResultsProps = {
 };
 
 function WorkspaceResults(props: WorkspaceResultsProps) {
+  if (props.operationStatus === 'loading' && !props.analysisReady) {
+    return (
+      <AsyncStatePanel
+        status="loading"
+        title="Analyzing workspace"
+        description="DustFril is scanning the selected workspace for supported development artifacts."
+      />
+    );
+  }
+
+  if (props.operationStatus === 'error' && !props.analysisReady) {
+    return (
+      <AsyncStatePanel
+        status="error"
+        title="Workspace analysis failed"
+        description="The workspace could not be analyzed. Choose another workspace or try again."
+      />
+    );
+  }
+
   if (!props.analysisReady) {
     return (
       <EmptyState

--- a/apps/tauri/src/model/async.test.ts
+++ b/apps/tauri/src/model/async.test.ts
@@ -46,10 +46,17 @@ describe('async operation state', () => {
       requestId: 1,
       data: 'previous result',
     };
-    const state = reduceAsyncOperation(previous, {
+    const loading = reduceAsyncOperation(previous, { type: 'start', requestId: 2 });
+    const state = reduceAsyncOperation(loading, {
       type: 'error',
       requestId: 2,
       error: 'refresh failed',
+    });
+
+    expect(loading).toEqual({
+      status: 'loading',
+      requestId: 2,
+      previous: 'previous result',
     });
 
     expect(state).toEqual({

--- a/apps/tauri/src/model/async.test.ts
+++ b/apps/tauri/src/model/async.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  idleAsyncOperation,
+  operationData,
+  reduceAsyncOperation,
+  type AsyncOperationState,
+} from './async';
+
+describe('async operation state', () => {
+  it('keeps primary data and exposes auxiliary warnings as partial success', () => {
+    const state = reduceAsyncOperation(
+      reduceAsyncOperation(idleAsyncOperation<string>(), { type: 'start', requestId: 1 }),
+      {
+        type: 'success',
+        requestId: 1,
+        data: 'analysis',
+        warnings: ['History could not be recorded.'],
+      },
+    );
+
+    expect(state).toEqual({
+      status: 'partial',
+      requestId: 1,
+      data: 'analysis',
+      warnings: ['History could not be recorded.'],
+    });
+  });
+
+  it('ignores stale responses after a newer request starts', () => {
+    const loading = reduceAsyncOperation(
+      reduceAsyncOperation(idleAsyncOperation<string>(), { type: 'start', requestId: 1 }),
+      { type: 'start', requestId: 2 },
+    );
+    const state = reduceAsyncOperation(loading, {
+      type: 'success',
+      requestId: 1,
+      data: 'stale result',
+    });
+
+    expect(state).toEqual(loading);
+  });
+
+  it('preserves the previous result when a refresh fails', () => {
+    const previous: AsyncOperationState<string> = {
+      status: 'success',
+      requestId: 1,
+      data: 'previous result',
+    };
+    const state = reduceAsyncOperation(previous, {
+      type: 'error',
+      requestId: 2,
+      error: 'refresh failed',
+    });
+
+    expect(state).toEqual({
+      status: 'error',
+      requestId: 2,
+      error: 'refresh failed',
+      previous: 'previous result',
+    });
+    expect(operationData(state)).toBe('previous result');
+  });
+
+  it('invalidates a result when the workspace changes', () => {
+    const state = reduceAsyncOperation(
+      {
+        status: 'success',
+        requestId: 4,
+        data: 'old workspace',
+      },
+      { type: 'invalidate', requestId: 5 },
+    );
+
+    expect(state).toEqual({ status: 'idle', requestId: 5 });
+  });
+});

--- a/apps/tauri/src/model/async.ts
+++ b/apps/tauri/src/model/async.ts
@@ -9,7 +9,7 @@ export type AsyncOperationStatus =
 
 export type AsyncOperationState<T> =
   | { status: 'idle'; requestId: number }
-  | { status: 'loading'; requestId: number }
+  | { status: 'loading'; requestId: number; previous?: T }
   | { status: 'success'; requestId: number; data: T }
   | { status: 'partial'; requestId: number; data: T; warnings: string[] }
   | { status: 'unsupported'; requestId: number; reason: string }
@@ -38,7 +38,11 @@ export function reduceAsyncOperation<T>(
 
   switch (action.type) {
     case 'start':
-      return { status: 'loading', requestId: action.requestId };
+      return {
+        status: 'loading',
+        requestId: action.requestId,
+        previous: operationData(state),
+      };
     case 'success':
       return action.warnings?.length
         ? {
@@ -65,5 +69,9 @@ export function reduceAsyncOperation<T>(
 }
 
 export function operationData<T>(state: AsyncOperationState<T>): T | undefined {
-  return 'data' in state ? state.data : state.status === 'error' ? state.previous : undefined;
+  if ('data' in state) {
+    return state.data;
+  }
+
+  return state.status === 'error' || state.status === 'loading' ? state.previous : undefined;
 }

--- a/apps/tauri/src/model/async.ts
+++ b/apps/tauri/src/model/async.ts
@@ -1,0 +1,69 @@
+export type AsyncOperationStatus =
+  | 'idle'
+  | 'loading'
+  | 'success'
+  | 'partial'
+  | 'unsupported'
+  | 'empty'
+  | 'error';
+
+export type AsyncOperationState<T> =
+  | { status: 'idle'; requestId: number }
+  | { status: 'loading'; requestId: number }
+  | { status: 'success'; requestId: number; data: T }
+  | { status: 'partial'; requestId: number; data: T; warnings: string[] }
+  | { status: 'unsupported'; requestId: number; reason: string }
+  | { status: 'empty'; requestId: number }
+  | { status: 'error'; requestId: number; error: string; previous?: T };
+
+export type AsyncOperationAction<T> =
+  | { type: 'start'; requestId: number }
+  | { type: 'success'; requestId: number; data: T; warnings?: string[] }
+  | { type: 'unsupported'; requestId: number; reason: string }
+  | { type: 'empty'; requestId: number }
+  | { type: 'error'; requestId: number; error: string }
+  | { type: 'invalidate'; requestId: number };
+
+export function idleAsyncOperation<T>(requestId = 0): AsyncOperationState<T> {
+  return { status: 'idle', requestId };
+}
+
+export function reduceAsyncOperation<T>(
+  state: AsyncOperationState<T>,
+  action: AsyncOperationAction<T>,
+): AsyncOperationState<T> {
+  if (action.requestId < state.requestId) {
+    return state;
+  }
+
+  switch (action.type) {
+    case 'start':
+      return { status: 'loading', requestId: action.requestId };
+    case 'success':
+      return action.warnings?.length
+        ? {
+            status: 'partial',
+            requestId: action.requestId,
+            data: action.data,
+            warnings: action.warnings,
+          }
+        : { status: 'success', requestId: action.requestId, data: action.data };
+    case 'unsupported':
+      return { status: 'unsupported', requestId: action.requestId, reason: action.reason };
+    case 'empty':
+      return { status: 'empty', requestId: action.requestId };
+    case 'error':
+      return {
+        status: 'error',
+        requestId: action.requestId,
+        error: action.error,
+        previous: operationData(state),
+      };
+    case 'invalidate':
+      return { status: 'idle', requestId: action.requestId };
+  }
+}
+
+export function operationData<T>(state: AsyncOperationState<T>): T | undefined {
+  return 'data' in state ? state.data : state.status === 'error' ? state.previous : undefined;
+}

--- a/apps/tauri/src/model/categories.test.ts
+++ b/apps/tauri/src/model/categories.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { categoryConfig, categoryConfigs, categorySections } from './categories';
+
+describe('desktop module navigation', () => {
+  it('declares the planned information architecture in one place', () => {
+    expect(categorySections.map((section) => section.title)).toEqual([
+      'Favorites',
+      'Cleanup',
+      'Workspace',
+      'Security',
+    ]);
+    expect(categoryConfigs.map((config) => config.title)).toEqual([
+      'Overview',
+      'Workspace',
+      'History',
+      'Rust',
+      'Node.js',
+      'Java',
+      'Cache',
+      'Dependencies',
+      'Artifact History',
+      'Activity',
+      'Supply Chain',
+      'GitHub Actions',
+      'Executable Integrity',
+    ]);
+  });
+
+  it('marks only existing workflows as available', () => {
+    expect(categoryConfig('cleanup-rust')?.availability).toBe('available');
+    expect(categoryConfig('cleanup-node')?.availability).toBe('available');
+    expect(categoryConfig('cleanup-java')?.availability).toBe('available');
+    expect(categoryConfig('workspace-activity')?.availability).toBe('available');
+    expect(categoryConfig('cleanup-cache')?.availability).toBe('planned');
+    expect(categoryConfig('security-supply-chain')?.availability).toBe('planned');
+    expect(categoryConfig('workspace-artifact-history')?.availability).toBe('planned');
+  });
+});

--- a/apps/tauri/src/model/categories.ts
+++ b/apps/tauri/src/model/categories.ts
@@ -1,15 +1,31 @@
+import type { Ecosystem } from '../types/workflow';
+
 export type SidebarCategory =
   | 'overview'
   | 'workspace'
-  | 'history';
+  | 'history'
+  | 'cleanup-rust'
+  | 'cleanup-node'
+  | 'cleanup-java'
+  | 'cleanup-cache'
+  | 'workspace-dependencies'
+  | 'workspace-artifact-history'
+  | 'workspace-activity'
+  | 'security-supply-chain'
+  | 'security-github-actions'
+  | 'security-executable-integrity';
 
-export type CategorySection = 'favorites';
+export type CategorySection = 'favorites' | 'cleanup' | 'workspace' | 'security';
+
+export type CategoryAvailability = 'available' | 'planned';
 
 export type CategoryConfig = {
   key: SidebarCategory;
   title: string;
   description: string;
   section: CategorySection;
+  availability?: CategoryAvailability;
+  ecosystem?: Ecosystem;
 };
 
 export const categoryConfigs: CategoryConfig[] = [
@@ -18,17 +34,104 @@ export const categoryConfigs: CategoryConfig[] = [
     title: 'Overview',
     description: 'Workspace summary',
     section: 'favorites',
+    availability: 'available',
   },
   {
     key: 'workspace',
     title: 'Workspace',
-    description: 'Analyze and clean project artifacts',
+    description: 'All analyzed project artifacts and cleanup controls',
     section: 'favorites',
+    availability: 'available',
   },
   {
     key: 'history',
     title: 'History',
-    description: 'Previous scans and cleanup operations',
+    description: 'Shortcut to workspace activity',
     section: 'favorites',
+    availability: 'available',
+  },
+  {
+    key: 'cleanup-rust',
+    title: 'Rust',
+    description: 'Analyze and clean Rust artifacts',
+    section: 'cleanup',
+    availability: 'available',
+    ecosystem: 'Rust',
+  },
+  {
+    key: 'cleanup-node',
+    title: 'Node.js',
+    description: 'Analyze and clean Node.js artifacts',
+    section: 'cleanup',
+    availability: 'available',
+    ecosystem: 'Node',
+  },
+  {
+    key: 'cleanup-java',
+    title: 'Java',
+    description: 'Analyze and clean Java artifacts',
+    section: 'cleanup',
+    availability: 'available',
+    ecosystem: 'Java',
+  },
+  {
+    key: 'cleanup-cache',
+    title: 'Cache',
+    description: 'Future cache cleanup surface',
+    section: 'cleanup',
+    availability: 'planned',
+  },
+  {
+    key: 'workspace-dependencies',
+    title: 'Dependencies',
+    description: 'Future dependency inventory and comparison',
+    section: 'workspace',
+    availability: 'planned',
+  },
+  {
+    key: 'workspace-artifact-history',
+    title: 'Artifact History',
+    description: 'Future generated-artifact history and growth',
+    section: 'workspace',
+    availability: 'planned',
+  },
+  {
+    key: 'workspace-activity',
+    title: 'Activity',
+    description: 'Previous scans and cleanup operations',
+    section: 'workspace',
+    availability: 'available',
+  },
+  {
+    key: 'security-supply-chain',
+    title: 'Supply Chain',
+    description: 'Future dependency and lifecycle security analysis',
+    section: 'security',
+    availability: 'planned',
+  },
+  {
+    key: 'security-github-actions',
+    title: 'GitHub Actions',
+    description: 'Future workflow security analysis',
+    section: 'security',
+    availability: 'planned',
+  },
+  {
+    key: 'security-executable-integrity',
+    title: 'Executable Integrity',
+    description: 'Future executable integrity evidence',
+    section: 'security',
+    availability: 'planned',
   },
 ];
+
+export const categorySections: Array<{ key: CategorySection; title: string }> = [
+  { key: 'favorites', title: 'Favorites' },
+  { key: 'cleanup', title: 'Cleanup' },
+  { key: 'workspace', title: 'Workspace' },
+  { key: 'security', title: 'Security' },
+];
+
+export function categoryConfig(category: SidebarCategory) {
+  return categoryConfigs.find((config) => config.key === category);
+}

--- a/apps/tauri/src/styles/style.css
+++ b/apps/tauri/src/styles/style.css
@@ -245,6 +245,11 @@ button:disabled {
 
 .sidebar-nav {
   display: grid;
+  gap: 14px;
+}
+
+.sidebar-section {
+  display: grid;
   gap: 2px;
 }
 
@@ -305,11 +310,129 @@ button:disabled {
   color: #d9e7ee;
 }
 
+.sidebar-item-planned {
+  color: #8f98a4;
+}
+
+.sidebar-item-planned .sidebar-item-icon {
+  color: #737d89;
+}
+
+.sidebar-item-planned:hover {
+  color: #d2d8df;
+}
+
+.sidebar-planned-label {
+  color: #737d89;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
 .main-pane {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
   background: #1d1e21;
+}
+
+.module-placeholder-view {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 22px;
+  overflow: auto;
+  padding: 28px 30px;
+}
+
+.module-placeholder-heading {
+  display: flex;
+  max-width: 680px;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.module-placeholder-heading h1 {
+  margin: 0;
+  color: #f5f7fb;
+  font-size: 24px;
+  letter-spacing: -0.025em;
+}
+
+.module-placeholder-heading p:last-child {
+  margin: 0;
+  color: #a3adb9;
+  font-size: 13px;
+}
+
+.async-state-panel {
+  display: flex;
+  max-width: 680px;
+  flex-direction: column;
+  gap: 11px;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 8px;
+  background: #222427;
+}
+
+.async-state-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.async-state-header h2 {
+  margin: 0;
+  color: #f0f4f7;
+  font-size: 16px;
+}
+
+.async-state-panel p {
+  margin: 0;
+  color: #aeb8c3;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.status-badge {
+  display: inline-flex;
+  min-height: 20px;
+  align-items: center;
+  padding: 0 7px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.09);
+  color: #c8d0d9;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.async-state-unsupported .status-badge {
+  background: rgba(198, 182, 252, 0.13);
+  color: #d4c7ff;
+}
+
+.async-state-partial .status-badge {
+  background: rgba(247, 190, 91, 0.13);
+  color: #f7d797;
+}
+
+.async-state-error .status-badge {
+  background: rgba(242, 112, 112, 0.13);
+  color: #f6aaaa;
+}
+
+.async-state-warnings {
+  margin: 0;
+  padding-left: 18px;
+  color: #f7d797;
+  font-size: 11px;
+  line-height: 1.5;
 }
 
 .workspace-view,


### PR DESCRIPTION
## Summary

Closes #137.

- Add grouped Cleanup, Workspace, and Security navigation destinations.
- Keep Rust, Node.js, and Java cleanup on the existing Core-backed workflow, scoped by ecosystem.
- Mark future Cache, Dependencies, Artifact History, and Security destinations as planned placeholders without speculative Tauri commands.
- Add shared async operation state handling for loading, success, partial, unsupported, empty, and error states, including workspace invalidation and stale-response protection.
- Preserve the existing Workspace/History shortcuts and cleanup confirmation flow.

## Validation

- npm run build
- npm test -- --run (47 tests passed)
- npm run tauri dev (Tauri app built and launched successfully)
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --skip signed_system_fixture_is_reported_as_valid --skip workspace_path_uses_the_containing_filesystem (all remaining tests passed)

Note: an unfiltered cargo test --workspace run still has two host-environment-sensitive failures: signed_system_fixture_is_reported_as_valid expects Software Signing while this macOS host reports macOS Software Signing, and workspace_path_uses_the_containing_filesystem observes a changing filesystem capacity value.