### PR TITLE
feat(tauri): expose GitHub Actions security scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tempfile",
  "tokio",
 ]
 

--- a/apps/tauri/README.md
+++ b/apps/tauri/README.md
@@ -34,6 +34,7 @@ case-sensitive.
 | `build_cleanup_plan` | `{ options: RunOptions }` | `CleanupPlanResponse` |
 | `audit` | `{ options: RunOptions }` | `LifecycleScript[]` |
 | `security_scan` | `{ options: RunOptions }` | `SecurityScanResponse` (may include additive `historyWarning`) |
+| `workflow_scan` | `{ options: RunOptions }` | `WorkflowScanResponse` (local, read-only workflow findings; no history entry) |
 | `execute_cleanup` | `{ request: { root, ecosystems, analysisId, selectedArtifacts, mode } }` | `CleanupResultResponse` (may include additive `historyWarning`) |
 | `load_activity_history` | none | `ActivityRecord[]` |
 | `load_cleanup_history` | none | `CleanupHistoryEntry[]` |
@@ -64,6 +65,7 @@ refreshes set it to `false` so they do not change the generated-artifact baselin
 - Safe cleanup with Trash or permanent delete confirmation
 - Activity history viewer backed by shared, versioned core history storage
 - Explicit scans return the generated-artifact snapshot comparison produced by Core
+- Explicit local GitHub Actions workflow scans with structured command, permission, and direct secret-exposure findings
 
 Activity persistence is auxiliary to scan, cleanup, and security results. If a
 history write fails, the operation response remains available and includes an
@@ -78,11 +80,11 @@ additive `historyWarning` for the desktop status surface.
 - `HistoryList`
 - `AsyncStatePanel`
 - `ModulePlaceholderView`
+- `GithubActionsView`
 
 ## Desktop module navigation
 
-The sidebar keeps the planned Desktop information architecture in
-`src/model/categories.ts`:
+The sidebar keeps the Desktop information architecture in `src/model/categories.ts`:
 
 ```text
 Overview
@@ -100,13 +102,17 @@ Workspace
 
 Security
   Supply Chain (planned)
-  GitHub Actions (planned)
+  GitHub Actions
   Executable Integrity (planned)
 ```
 
 Rust, Node.js, and Java destinations filter the existing unified analysis
-result; they do not start a new scan when selected. Planned destinations render
-an explicit unsupported state and do not invoke speculative Tauri commands.
+result; they do not start a new scan when selected. GitHub Actions is an
+explicit local workflow scan: selecting the destination does not run it, and
+the `workflow_scan` command runs only after the user chooses Scan Workflows.
+The scan is read-only and does not write an activity-history entry. Other
+planned destinations render an explicit unsupported state and do not invoke
+speculative Tauri commands.
 
 Advanced operations use the small state model in `src/model/async.ts`. It
 keeps loading, success, partial success, unsupported, empty, and error states

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -25,3 +25,6 @@ tauri-plugin-opener = "2"
 tokio = { version = "1", features = ["rt"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/apps/tauri/src-tauri/src/contract.rs
+++ b/apps/tauri/src-tauri/src/contract.rs
@@ -8,8 +8,9 @@ use dustfril_core::models::{
     ArtifactSnapshotResult, ArtifactSnapshotStatus, CleanupFailureReason, CleanupRecommendation,
     DeleteMode, DeveloperStorageSummary, Ecosystem, LifecycleScript, LockfileCheck, LockfileKind,
     LockfileStatus, PackageManager, ProjectIdentity, RecommendationPolicy, RiskLevel, ScriptType,
-    SecurityFinding, SecurityReport, SecurityWarning, StorageSummary, VolumeStorage,
-    DEFAULT_CLEANUP_AGE_DAYS,
+    SecurityFinding, SecurityReport, SecurityWarning, StorageSummary, VolumeStorage, Workflow,
+    WorkflowExposureSink, WorkflowFinding, WorkflowFindingCategory, WorkflowScanNotice,
+    WorkflowScanReport, DEFAULT_CLEANUP_AGE_DAYS,
 };
 use serde::{Deserialize, Serialize};
 
@@ -364,6 +365,90 @@ pub(crate) struct SecurityScanResponse {
     pub(crate) history_warning: Option<String>,
 }
 
+/// Structured, presentation-safe result for the local GitHub Actions scan.
+///
+/// Workflow YAML is intentionally reduced to file/job metadata here. The
+/// desktop receives findings and partial-analysis notices, but never the
+/// parsed environment or action input values that Core uses internally.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkflowScanResponse {
+    pub(crate) workflows: Vec<WorkflowSummaryDto>,
+    pub(crate) findings: Vec<WorkflowFindingDto>,
+    pub(crate) notices: Vec<WorkflowScanNoticeDto>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkflowSummaryDto {
+    pub(crate) path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) name: Option<String>,
+    pub(crate) analysis_status: WorkflowAnalysisStatusDto,
+    pub(crate) jobs: Vec<WorkflowJobSummaryDto>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkflowJobSummaryDto {
+    pub(crate) id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) name: Option<String>,
+    pub(crate) step_count: usize,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum WorkflowAnalysisStatusDto {
+    Analyzed,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkflowFindingDto {
+    pub(crate) workflow_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) job_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) step_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) step_name: Option<String>,
+    pub(crate) rule_id: String,
+    pub(crate) category: WorkflowFindingCategoryDto,
+    pub(crate) risk_level: RiskLevelDto,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) evidence: Option<String>,
+    pub(crate) reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) secret_reference: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) exposure_sink: Option<WorkflowExposureSinkDto>,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum WorkflowFindingCategoryDto {
+    SuspiciousCommand,
+    TokenPermissions,
+    SecretExposure,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum WorkflowExposureSinkDto {
+    Stdout,
+    NetworkRequest,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkflowScanNoticeDto {
+    pub(crate) workflow_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) job_id: Option<String>,
+    pub(crate) reason: String,
+}
+
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SecurityFindingDto {
@@ -589,6 +674,105 @@ impl From<SecurityReport> for SecurityScanResponse {
     }
 }
 
+impl From<WorkflowScanReport> for WorkflowScanResponse {
+    fn from(report: WorkflowScanReport) -> Self {
+        Self {
+            workflows: report
+                .workflows
+                .into_iter()
+                .map(WorkflowSummaryDto::from)
+                .collect(),
+            findings: report
+                .findings
+                .into_iter()
+                .map(WorkflowFindingDto::from)
+                .collect(),
+            notices: report
+                .notices
+                .into_iter()
+                .map(WorkflowScanNoticeDto::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<Workflow> for WorkflowSummaryDto {
+    fn from(workflow: Workflow) -> Self {
+        Self {
+            path: workflow.path.display().to_string(),
+            name: workflow.name,
+            analysis_status: WorkflowAnalysisStatusDto::Analyzed,
+            jobs: workflow
+                .jobs
+                .into_iter()
+                .map(|(id, job)| WorkflowJobSummaryDto {
+                    id,
+                    name: job.name,
+                    step_count: job.steps.len(),
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<WorkflowFinding> for WorkflowFindingDto {
+    fn from(finding: WorkflowFinding) -> Self {
+        // Core already strips secret values from secret findings. Keep the
+        // boundary defensive as well: only expose the supported sink label
+        // and reference name, never a raw expression or command context.
+        let evidence = match finding.category {
+            WorkflowFindingCategory::SecretExposure => finding
+                .exposure_sink
+                .map(|sink| format!("supported {sink} sink")),
+            WorkflowFindingCategory::SuspiciousCommand
+            | WorkflowFindingCategory::TokenPermissions => finding.evidence,
+        };
+
+        Self {
+            workflow_path: finding.workflow_path.display().to_string(),
+            job_id: finding.job_id,
+            step_index: finding.step_index,
+            step_name: finding.step_name,
+            rule_id: finding.rule_id,
+            category: finding.category.into(),
+            risk_level: finding.risk_level.into(),
+            evidence,
+            reason: finding.reason,
+            secret_reference: finding.secret_reference,
+            exposure_sink: finding.exposure_sink.map(Into::into),
+        }
+    }
+}
+
+impl From<WorkflowFindingCategory> for WorkflowFindingCategoryDto {
+    fn from(category: WorkflowFindingCategory) -> Self {
+        match category {
+            WorkflowFindingCategory::SuspiciousCommand => Self::SuspiciousCommand,
+            WorkflowFindingCategory::TokenPermissions => Self::TokenPermissions,
+            WorkflowFindingCategory::SecretExposure => Self::SecretExposure,
+        }
+    }
+}
+
+impl From<WorkflowExposureSink> for WorkflowExposureSinkDto {
+    fn from(sink: WorkflowExposureSink) -> Self {
+        match sink {
+            WorkflowExposureSink::Stdout => Self::Stdout,
+            WorkflowExposureSink::NetworkRequest => Self::NetworkRequest,
+        }
+    }
+}
+
+impl From<WorkflowScanNotice> for WorkflowScanNoticeDto {
+    fn from(notice: WorkflowScanNotice) -> Self {
+        Self {
+            workflow_path: notice.workflow_path.display().to_string(),
+            job_id: notice.job_id,
+            reason: notice.reason,
+        }
+    }
+}
+
 impl From<SecurityFinding> for SecurityFindingDto {
     fn from(finding: SecurityFinding) -> Self {
         Self {
@@ -649,6 +833,7 @@ impl From<LockfileStatus> for LockfileStatusDto {
 mod tests {
     use dustfril_core::models::AnalysisResult;
     use serde_json::json;
+    use tempfile::TempDir;
 
     use super::*;
 
@@ -1091,6 +1276,46 @@ mod tests {
                 "reason": "Remote script is piped to a shell."
             })
         );
+    }
+
+    #[test]
+    fn workflow_scan_wire_format_is_structured_and_secret_safe() {
+        let temp_dir = TempDir::new().unwrap();
+        let workflow_dir = temp_dir.path().join(".github/workflows");
+        std::fs::create_dir_all(&workflow_dir).unwrap();
+        std::fs::write(
+            workflow_dir.join("security.yml"),
+            r#"name: Security
+permissions: write-all
+jobs:
+  build:
+    name: Build
+    steps:
+      - name: Upload token
+        run: echo "${{ secrets.DEPLOY_TOKEN }}"
+"#,
+        )
+        .unwrap();
+
+        let report = dustfril_core::api::workflow_scan(temp_dir.path()).unwrap();
+        let response: WorkflowScanResponse = report.into();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(value["workflows"][0]["analysisStatus"], "analyzed");
+        assert_eq!(value["workflows"][0]["jobs"][0]["id"], "build");
+        assert_eq!(value["workflows"][0]["jobs"][0]["stepCount"], 1);
+        let secret_finding = value["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|finding| finding["category"] == "secretExposure")
+            .unwrap();
+        assert_eq!(secret_finding["secretReference"], "DEPLOY_TOKEN");
+        assert_eq!(secret_finding["exposureSink"], "stdout");
+        assert_eq!(secret_finding["evidence"], "supported stdout sink");
+        let serialized = value.to_string();
+        assert!(!serialized.contains("${{"));
+        assert!(!serialized.contains("actual-secret-value"));
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -21,7 +21,7 @@ use contract::{
     ArtifactDto, CleanupCandidateDto, CleanupFailureDto, CleanupHistoryEntryDto,
     CleanupPlanResponse, CleanupResultResponse, ExecuteCleanupRequest, LifecycleScriptDto,
     RunOptions, ScanResponse, SecurityScanResponse, StorageSummaryDto, VolumeStorageDto,
-    WorkspaceAnalysisResponse,
+    WorkflowScanResponse, WorkspaceAnalysisResponse,
 };
 use dustfril_core::{
     api,
@@ -600,6 +600,24 @@ async fn security_scan(options: RunOptions) -> Result<SecurityScanResponse, Stri
     .map_err(|error| error.to_string())?
 }
 
+/// Runs the local, read-only GitHub Actions workflow security scan.
+///
+/// The command deliberately does not record activity history: workflow
+/// security results are transient evidence for this screen, and the Core
+/// report contains no operation that should be persisted by the desktop.
+#[tauri::command]
+async fn workflow_scan(options: RunOptions) -> Result<WorkflowScanResponse, String> {
+    let root = resolve_root(options.root)?;
+
+    tokio::task::spawn_blocking(move || {
+        api::workflow_scan(&root)
+            .map(Into::into)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -617,7 +635,8 @@ pub fn run() {
             clear_activity_history,
             load_cleanup_history,
             audit,
-            security_scan
+            security_scan,
+            workflow_scan
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.test.tsx
@@ -7,6 +7,7 @@ import {
   executeCleanup,
   loadActivityHistory,
   refreshStorageVolume,
+  workflowSecurityScan,
 } from '../../lib/tauri';
 
 vi.mock('../../lib/tauri', () => ({
@@ -15,6 +16,7 @@ vi.mock('../../lib/tauri', () => ({
   defaultRoot: vi.fn().mockResolvedValue('/workspace'),
   executeCleanup: vi.fn(),
   refreshStorageVolume: vi.fn(),
+  workflowSecurityScan: vi.fn(),
   loadActivityHistory: vi.fn().mockResolvedValue([]),
   clearActivityHistory: vi.fn().mockResolvedValue(undefined),
 }));
@@ -58,6 +60,25 @@ const historyEntry = {
 describe('AppShell Overview navigation', () => {
   afterEach(() => vi.clearAllMocks());
 
+  it('runs the GitHub Actions scan only after an explicit click', async () => {
+    vi.mocked(workflowSecurityScan).mockResolvedValue({
+      workflows: [],
+      findings: [],
+      notices: [],
+    });
+
+    render(<AppShell />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Analyze Workspace' })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub Actions' }));
+
+    expect(workflowSecurityScan).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Scan Workflows' }));
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'No workflow files found' })).toBeInTheDocument());
+    expect(workflowSecurityScan).toHaveBeenCalledWith({ root: '/workspace', ecosystems: [] });
+    expect(loadActivityHistory).toHaveBeenCalledOnce();
+  });
+
   it.each([
     ['Rust', false],
     ['Node.js', false],
@@ -67,7 +88,7 @@ describe('AppShell Overview navigation', () => {
     ['Artifact History', true],
     ['Activity', false],
     ['Supply Chain', true],
-    ['GitHub Actions', true],
+    ['GitHub Actions', false],
     ['Executable Integrity', true],
   ])('navigates to the %s module without starting another operation', async (title, planned) => {
     render(<AppShell />);

--- a/apps/tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.tsx
@@ -5,6 +5,7 @@ import { pathBreadcrumb } from '../../model/presentation';
 import { AppHeader } from './components/AppHeader';
 import { useAppState } from './hooks/useAppState';
 import { HistoryView } from './views/HistoryView';
+import { GithubActionsView } from './views/GithubActionsView';
 import { ModulePlaceholderView } from './views/ModulePlaceholderView';
 import { OverviewView } from './views/OverviewView';
 import { WorkspaceView } from './views/WorkspaceView';
@@ -85,7 +86,20 @@ export function AppShell() {
             />
           ) : null}
 
-          {app.activeCategory !== 'overview' && !showingWorkspace && !showingActivity && activeConfig ? (
+          {app.activeCategory === 'security-github-actions' ? (
+            <GithubActionsView
+              root={app.root}
+              operation={app.workflowOperation}
+              canScan={app.canScanWorkflows}
+              onScan={app.handleWorkflowSecurityScan}
+            />
+          ) : null}
+
+          {app.activeCategory !== 'overview' &&
+          !showingWorkspace &&
+          !showingActivity &&
+          app.activeCategory !== 'security-github-actions' &&
+          activeConfig ? (
             <ModulePlaceholderView
               config={activeConfig}
               onReturnToOverview={() => app.setActiveCategory('overview')}

--- a/apps/tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useAppState.ts
@@ -8,6 +8,7 @@ import {
   executeCleanup,
   loadActivityHistory,
   refreshStorageVolume,
+  workflowSecurityScan,
 } from '../../../lib/tauri';
 import { categoryConfigs, type SidebarCategory } from '../../../model/categories';
 import {
@@ -23,6 +24,7 @@ import type {
   DeleteMode,
   StorageSummary,
   VolumeStorage,
+  WorkflowScanResponse,
 } from '../../../types/workflow';
 import { cleanupAgeOptions, defaultCleanupAgeDays, deleteModes, ecosystems } from '../../../types/workflow';
 import {
@@ -53,7 +55,12 @@ export function useAppState() {
     reduceAsyncOperation<WorkspaceAnalysisResponse>,
     idleAsyncOperation<WorkspaceAnalysisResponse>(),
   );
+  const [workflowOperation, dispatchWorkflowOperation] = useReducer(
+    reduceAsyncOperation<WorkflowScanResponse>,
+    idleAsyncOperation<WorkflowScanResponse>(),
+  );
   const workspaceRequestRef = useRef(0);
+  const workflowRequestRef = useRef(0);
   const actionRequestRef = useRef(0);
 
   useEffect(() => {
@@ -112,6 +119,7 @@ export function useAppState() {
   );
 
   const canAnalyze = busyAction === null && root.length > 0;
+  const canScanWorkflows = busyAction === null && root.length > 0;
   const canReviewCleanup =
     busyAction === null && cleanupPlan !== null && selectedCleanupPaths.length > 0;
   const confirmSamplePaths = cleanupReviewPaths.slice(0, 5);
@@ -149,6 +157,11 @@ export function useAppState() {
       type: 'invalidate',
       requestId: workspaceRequestRef.current,
     });
+    workflowRequestRef.current += 1;
+    dispatchWorkflowOperation({
+      type: 'invalidate',
+      requestId: workflowRequestRef.current,
+    });
     actionRequestRef.current += 1;
     setRoot(nextRoot);
     setError(null);
@@ -184,6 +197,38 @@ export function useAppState() {
     }
 
     await analyzeWorkspaceWithPolicy(cleanupAgeDays, true, true);
+  }
+
+  async function handleWorkflowSecurityScan() {
+    if (busyAction !== null || !root) {
+      return;
+    }
+
+    await runAction('workflow-security-scan', async () => {
+      const requestId = ++workflowRequestRef.current;
+      dispatchWorkflowOperation({ type: 'start', requestId });
+
+      try {
+        const response = await workflowSecurityScan({
+          root,
+          ecosystems: [],
+        });
+
+        dispatchWorkflowOperation({
+          type: 'success',
+          requestId,
+          data: response,
+          warnings: response.notices.map((notice) => notice.reason),
+        });
+      } catch (invokeError) {
+        dispatchWorkflowOperation({
+          type: 'error',
+          requestId,
+          error: String(invokeError),
+        });
+        throw invokeError;
+      }
+    });
   }
 
   async function analyzeWorkspaceWithPolicy(
@@ -462,7 +507,9 @@ export function useAppState() {
     confirmDialogOpen,
     confirmSamplePaths,
     workspaceOperation,
+    workflowOperation,
     canAnalyze,
+    canScanWorkflows,
     canReviewCleanup,
     summary,
     deleteModes,
@@ -476,6 +523,7 @@ export function useAppState() {
     handleRootChange,
     handleChooseWorkspace,
     handleAnalyzeWorkspace,
+    handleWorkflowSecurityScan,
     handleCleanupAgeChange,
     handleClearHistory,
     handleRequestCleanup,

--- a/apps/tauri/src/features/app-shell/views/GithubActionsView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/GithubActionsView.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GithubActionsView } from './GithubActionsView';
+import type { WorkflowScanResponse } from '../../../types/workflow';
+
+const report: WorkflowScanResponse = {
+  workflows: [
+    {
+      path: '/workspace/.github/workflows/secure.yml',
+      name: 'Secure build',
+      analysisStatus: 'analyzed',
+      jobs: [{ id: 'build', name: 'Build', stepCount: 3 }],
+    },
+  ],
+  findings: [
+    {
+      workflowPath: '/workspace/.github/workflows/secure.yml',
+      jobId: 'build',
+      stepIndex: 1,
+      stepName: 'Download tool',
+      ruleId: 'remote-script-pipe',
+      category: 'suspiciousCommand',
+      riskLevel: 'High',
+      evidence: 'curl https://example.test/tool.sh | bash',
+      reason: 'A remote script is piped to a shell.',
+    },
+    {
+      workflowPath: '/workspace/.github/workflows/secure.yml',
+      jobId: 'build',
+      ruleId: 'workflow-broad-write-permissions',
+      category: 'tokenPermissions',
+      riskLevel: 'High',
+      evidence: 'contents: write, pull-requests: write',
+      reason: 'The workflow grants write access to multiple token scopes.',
+    },
+    {
+      workflowPath: '/workspace/.github/workflows/secure.yml',
+      jobId: 'build',
+      stepIndex: 2,
+      stepName: 'Upload token',
+      ruleId: 'workflow-direct-secret-exposure',
+      category: 'secretExposure',
+      riskLevel: 'High',
+      evidence: 'supported networkRequest sink',
+      reason: 'A secret reference is passed directly to a supported network request sink.',
+      secretReference: 'DEPLOY_TOKEN',
+      exposureSink: 'networkRequest',
+    },
+  ],
+  notices: [
+    {
+      workflowPath: '/workspace/.github/workflows/secure.yml',
+      jobId: 'build',
+      reason: 'An indirect secret flow is unresolved.',
+    },
+  ],
+};
+
+describe('GithubActionsView', () => {
+  it('requires an explicit scan and does not start one while rendering', () => {
+    const onScan = vi.fn();
+
+    render(
+      <GithubActionsView
+        root="/workspace"
+        operation={{ status: 'idle', requestId: 0 }}
+        canScan
+        onScan={onScan}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Ready for an explicit scan' })).toBeInTheDocument();
+    expect(onScan).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Scan Workflows' }));
+    expect(onScan).toHaveBeenCalledOnce();
+  });
+
+  it('renders workflow context, permission evidence, notices, and safe secret metadata', () => {
+    render(
+      <GithubActionsView
+        root="/workspace"
+        operation={{ status: 'partial', requestId: 1, data: report, warnings: ['partial'] }}
+        canScan
+        onScan={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Secure build')).toBeInTheDocument();
+    expect(screen.getAllByText('/workspace/.github/workflows/secure.yml').length).toBeGreaterThan(0);
+    expect(screen.getByText('remote-script-pipe')).toBeInTheDocument();
+    expect(screen.getByText('contents: write, pull-requests: write')).toBeInTheDocument();
+    expect(screen.getByText('DEPLOY_TOKEN')).toBeInTheDocument();
+    expect(screen.getByText('network request')).toBeInTheDocument();
+    expect(screen.getByText(/indirect secret flow is unresolved/)).toBeInTheDocument();
+    expect(screen.queryByText('${{ secrets.DEPLOY_TOKEN }}')).not.toBeInTheDocument();
+  });
+
+  it('keeps no-workflow and inspection-failure states distinct from clean results', () => {
+    const { rerender } = render(
+      <GithubActionsView
+        root="/workspace"
+        operation={{ status: 'success', requestId: 1, data: { workflows: [], findings: [], notices: [] } }}
+        canScan
+        onScan={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'No workflow files found' })).toBeInTheDocument();
+    expect(screen.queryByText('No supported findings')).not.toBeInTheDocument();
+
+    rerender(
+      <GithubActionsView
+        root="/workspace"
+        operation={{ status: 'error', requestId: 2, error: 'security.yml: malformed YAML' }}
+        canScan
+        onScan={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Workflow inspection failed' })).toBeInTheDocument();
+    expect(screen.getByText('security.yml: malformed YAML')).toBeInTheDocument();
+  });
+});

--- a/apps/tauri/src/features/app-shell/views/GithubActionsView.tsx
+++ b/apps/tauri/src/features/app-shell/views/GithubActionsView.tsx
@@ -1,0 +1,365 @@
+import { AsyncStatePanel } from '../../../components/AsyncStatePanel/AsyncStatePanel';
+import { ItemIcon } from '../../../components/icons';
+import type { AsyncOperationState } from '../../../model/async';
+import type {
+  RiskLevel,
+  WorkflowFinding,
+  WorkflowFindingCategory,
+  WorkflowScanResponse,
+} from '../../../types/workflow';
+
+type GithubActionsViewProps = {
+  root: string;
+  operation: AsyncOperationState<WorkflowScanResponse>;
+  canScan: boolean;
+  onScan: () => void | Promise<void>;
+};
+
+export function GithubActionsView(props: GithubActionsViewProps) {
+  const report = reportFromOperation(props.operation);
+  const error = props.operation.status === 'error' ? props.operation.error : null;
+
+  return (
+    <div className="github-actions-view">
+      <header className="github-actions-header">
+        <div className="github-actions-heading">
+          <p className="eyebrow">Security</p>
+          <h1>GitHub Actions</h1>
+          <p>
+            Inspect local workflow files with the offline Core analyzer. Nothing is executed,
+            uploaded, or resolved from GitHub.
+          </p>
+          <p className="github-actions-root" title={props.root}>
+            Workspace: {props.root || 'No workspace selected'}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="workflow-scan-button"
+          onClick={() => void props.onScan()}
+          disabled={!props.canScan}
+        >
+          Scan Workflows
+        </button>
+      </header>
+
+      {props.operation.status === 'idle' ? (
+        <AsyncStatePanel
+          status="idle"
+          title="Ready for an explicit scan"
+          description="Choose Scan Workflows to inspect only .github/workflows/*.yml and *.yaml files in the selected workspace."
+        />
+      ) : null}
+
+      {props.operation.status === 'loading' ? (
+        <AsyncStatePanel
+          status="loading"
+          title="Inspecting workflows"
+          description="DustFril is parsing local workflow structure and applying supported static rules."
+        />
+      ) : null}
+
+      {props.operation.status === 'error' && !report ? (
+        <AsyncStatePanel
+          status="error"
+          title="Workflow inspection failed"
+          description="The workflow files could not be inspected. Malformed or unreadable input is not treated as clean."
+          error={error ?? 'The workflow scan failed.'}
+        />
+      ) : null}
+
+      {report ? (
+        <WorkflowResults report={report} staleError={error} operationStatus={props.operation.status} />
+      ) : null}
+    </div>
+  );
+}
+
+function WorkflowResults({
+  report,
+  staleError,
+  operationStatus,
+}: {
+  report: WorkflowScanResponse;
+  staleError: string | null;
+  operationStatus: AsyncOperationState<WorkflowScanResponse>['status'];
+}) {
+  if (!report.workflows.length) {
+    return (
+      <div className="github-actions-results">
+        {staleError ? <ScanErrorNotice error={staleError} /> : null}
+        <AsyncStatePanel
+          status={report.notices.length ? 'partial' : 'empty'}
+          title="No workflow files found"
+          description="This workspace has no direct .github/workflows/*.yml or *.yaml files. That is an empty inspection result, not a clean security verdict."
+          warnings={report.notices.map(formatNotice)}
+        />
+      </div>
+    );
+  }
+
+  const findingsByCategory = groupFindings(report.findings);
+  const jobCount = report.workflows.reduce((total, workflow) => total + workflow.jobs.length, 0);
+  const highestRisk = highestRiskLevel(report.findings);
+  const partial = report.notices.length > 0 || operationStatus === 'partial';
+
+  return (
+    <div className="github-actions-results">
+      {staleError ? <ScanErrorNotice error={staleError} /> : null}
+      {partial ? (
+        <AsyncStatePanel
+          status="partial"
+          title="Analysis is partial"
+          description="Some workflow semantics are outside the supported offline rules. The notices below do not claim those paths are safe or leaked."
+          warnings={report.notices.map(formatNotice)}
+        />
+      ) : null}
+
+      <section className="workflow-summary-grid" aria-label="Workflow scan summary">
+        <SummaryCard value={report.workflows.length} label="Workflows inspected" />
+        <SummaryCard value={jobCount} label="Jobs parsed" />
+        <SummaryCard value={report.findings.length} label="Supported findings" />
+        <SummaryCard value={highestRisk ?? 'None'} label="Highest risk" />
+      </section>
+
+      <section className="workflow-section" aria-labelledby="workflow-overview-heading">
+        <SectionHeading
+          id="workflow-overview-heading"
+          title="Workflow overview"
+          description="Every listed workflow was parsed successfully by Core."
+        />
+        <div className="workflow-overview-list">
+          {report.workflows.map((workflow) => {
+            const findingCount = report.findings.filter(
+              (finding) => finding.workflowPath === workflow.path,
+            ).length;
+            const noticeCount = report.notices.filter(
+              (notice) => notice.workflowPath === workflow.path,
+            ).length;
+
+            return (
+              <article className="workflow-overview-card" key={workflow.path}>
+                <div className="workflow-overview-icon">
+                  <ItemIcon kind={findingCount ? 'warning' : 'document'} />
+                </div>
+                <div className="workflow-overview-copy">
+                  <strong>{workflow.name || workflow.path.split(/[\\/]/).pop()}</strong>
+                  <span title={workflow.path}>{workflow.path}</span>
+                  <small>
+                    {workflow.jobs.length} job{workflow.jobs.length === 1 ? '' : 's'} ·{' '}
+                    {workflow.jobs.reduce((total, job) => total + job.stepCount, 0)} steps ·{' '}
+                    {findingCount} finding{findingCount === 1 ? '' : 's'}
+                    {noticeCount ? ` · ${noticeCount} notice${noticeCount === 1 ? '' : 's'}` : ''}
+                  </small>
+                </div>
+                <span className="workflow-analysis-status">Analyzed</span>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <FindingSection
+        title="Command findings"
+        description="Supported suspicious run commands reported by Core."
+        category="suspiciousCommand"
+        findings={findingsByCategory.suspiciousCommand}
+      />
+      <FindingSection
+        title="Permission findings"
+        description="Effective workflow/job token permissions, including exact write scopes."
+        category="tokenPermissions"
+        findings={findingsByCategory.tokenPermissions}
+      />
+      <FindingSection
+        title="Secret-exposure findings"
+        description="Only direct references reaching supported stdout or network sinks are reported as findings."
+        category="secretExposure"
+        findings={findingsByCategory.secretExposure}
+      />
+
+      {!report.findings.length ? (
+        <AsyncStatePanel
+          status={partial ? 'partial' : 'success'}
+          title={partial ? 'No supported findings in the analyzed paths' : 'No supported findings'}
+          description={
+            partial
+              ? 'The analyzed portions produced no findings; review the partial-analysis notices before treating the result as complete.'
+              : 'The inspected workflows produced no findings from the supported local rules.'
+          }
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function FindingSection({
+  title,
+  description,
+  category,
+  findings,
+}: {
+  title: string;
+  description: string;
+  category: WorkflowFindingCategory;
+  findings: WorkflowFinding[];
+}) {
+  return (
+    <section className="workflow-section" aria-labelledby={`${category}-heading`}>
+      <SectionHeading id={`${category}-heading`} title={title} description={description} />
+      {findings.length ? (
+        <div className="workflow-finding-list">
+          {findings.map((finding, index) => (
+            <FindingCard finding={finding} key={`${finding.workflowPath}-${finding.ruleId}-${index}`} />
+          ))}
+        </div>
+      ) : (
+        <p className="workflow-section-empty">No findings in this category.</p>
+      )}
+    </section>
+  );
+}
+
+function FindingCard({ finding }: { finding: WorkflowFinding }) {
+  const secretFinding = finding.category === 'secretExposure';
+  const step = finding.stepIndex === undefined
+    ? null
+    : `${finding.stepName || 'Step'} (${finding.stepIndex + 1})`;
+
+  return (
+    <article className={`workflow-finding-card workflow-risk-${finding.riskLevel.toLowerCase()}`}>
+      <div className="workflow-finding-header">
+        <div>
+          <span className="workflow-finding-category">{categoryLabel(finding.category)}</span>
+          <h3>{finding.ruleId}</h3>
+        </div>
+        <span className="workflow-risk-badge">{finding.riskLevel}</span>
+      </div>
+      <dl className="workflow-finding-details">
+        <div>
+          <dt>Workflow</dt>
+          <dd title={finding.workflowPath}>{finding.workflowPath}</dd>
+        </div>
+        <div>
+          <dt>Job</dt>
+          <dd>{finding.jobId || 'Workflow scope'}</dd>
+        </div>
+        {step ? (
+          <div>
+            <dt>Step</dt>
+            <dd>{step}</dd>
+          </div>
+        ) : null}
+        {secretFinding ? (
+          <>
+            <div>
+              <dt>Secret reference</dt>
+              <dd>{finding.secretReference || 'Reference name unavailable'}</dd>
+            </div>
+            <div>
+              <dt>Known sink</dt>
+              <dd>{sinkLabel(finding.exposureSink)}</dd>
+            </div>
+          </>
+        ) : null}
+        {finding.evidence ? (
+          <div>
+            <dt>{finding.category === 'tokenPermissions' ? 'Permission evidence' : 'Command context'}</dt>
+            <dd className="workflow-evidence">{finding.evidence}</dd>
+          </div>
+        ) : null}
+      </dl>
+      <p className="workflow-finding-reason">{finding.reason}</p>
+    </article>
+  );
+}
+
+function SectionHeading({ id, title, description }: { id: string; title: string; description: string }) {
+  return (
+    <div className="workflow-section-heading">
+      <div>
+        <h2 id={id}>{title}</h2>
+        <p>{description}</p>
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({ value, label }: { value: number | string; label: string }) {
+  return (
+    <div className="workflow-summary-card">
+      <strong>{value}</strong>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function ScanErrorNotice({ error }: { error: string }) {
+  return (
+    <div className="workflow-scan-error" role="status">
+      The latest scan failed: {error}. Showing the previous result until another scan completes.
+    </div>
+  );
+}
+
+function reportFromOperation(
+  operation: AsyncOperationState<WorkflowScanResponse>,
+): WorkflowScanResponse | undefined {
+  if ('data' in operation) {
+    return operation.data;
+  }
+
+  return operation.status === 'loading' || operation.status === 'error'
+    ? operation.previous
+    : undefined;
+}
+
+function groupFindings(findings: WorkflowFinding[]) {
+  return findings.reduce(
+    (groups, finding) => {
+      groups[finding.category].push(finding);
+      return groups;
+    },
+    {
+      suspiciousCommand: [],
+      tokenPermissions: [],
+      secretExposure: [],
+    } as Record<WorkflowFindingCategory, WorkflowFinding[]>,
+  );
+}
+
+function highestRiskLevel(findings: WorkflowFinding[]): RiskLevel | null {
+  const order: RiskLevel[] = ['None', 'Low', 'Medium', 'High', 'Critical'];
+  return findings.reduce<RiskLevel | null>((highest, finding) => {
+    if (!highest || order.indexOf(finding.riskLevel) > order.indexOf(highest)) {
+      return finding.riskLevel;
+    }
+    return highest;
+  }, null);
+}
+
+function categoryLabel(category: WorkflowFindingCategory) {
+  switch (category) {
+    case 'suspiciousCommand':
+      return 'Suspicious command';
+    case 'tokenPermissions':
+      return 'Token permissions';
+    case 'secretExposure':
+      return 'Secret exposure';
+  }
+}
+
+function sinkLabel(sink: WorkflowFinding['exposureSink']) {
+  switch (sink) {
+    case 'stdout':
+      return 'stdout / logging';
+    case 'networkRequest':
+      return 'network request';
+    default:
+      return 'Supported sink';
+  }
+}
+
+function formatNotice(notice: WorkflowScanResponse['notices'][number]) {
+  return `${notice.workflowPath}${notice.jobId ? ` · job ${notice.jobId}` : ''}: ${notice.reason}`;
+}

--- a/apps/tauri/src/lib/tauri.ts
+++ b/apps/tauri/src/lib/tauri.ts
@@ -12,6 +12,7 @@ import type {
   ScanResponse,
   SecurityScanResponse,
   VolumeStorage,
+  WorkflowScanResponse,
   WorkspaceAnalysisResponse,
 } from '../types/workflow';
 
@@ -23,6 +24,7 @@ const commands = {
   analyzeWorkspace: 'analyze_workspace',
   audit: 'audit',
   securityScan: 'security_scan',
+  workflowScan: 'workflow_scan',
   executeCleanup: 'execute_cleanup',
   refreshStorageVolume: 'refresh_storage_volume',
   loadActivityHistory: 'load_activity_history',
@@ -67,6 +69,10 @@ export function auditScripts(options: RunOptions) {
 
 export function securityScan(options: RunOptions) {
   return invoke<SecurityScanResponse>(commands.securityScan, { options });
+}
+
+export function workflowSecurityScan(options: RunOptions) {
+  return invoke<WorkflowScanResponse>(commands.workflowScan, { options });
 }
 
 export function executeCleanup(

--- a/apps/tauri/src/model/categories.test.ts
+++ b/apps/tauri/src/model/categories.test.ts
@@ -31,6 +31,7 @@ describe('desktop module navigation', () => {
     expect(categoryConfig('cleanup-node')?.availability).toBe('available');
     expect(categoryConfig('cleanup-java')?.availability).toBe('available');
     expect(categoryConfig('workspace-activity')?.availability).toBe('available');
+    expect(categoryConfig('security-github-actions')?.availability).toBe('available');
     expect(categoryConfig('cleanup-cache')?.availability).toBe('planned');
     expect(categoryConfig('security-supply-chain')?.availability).toBe('planned');
     expect(categoryConfig('workspace-artifact-history')?.availability).toBe('planned');

--- a/apps/tauri/src/model/categories.ts
+++ b/apps/tauri/src/model/categories.ts
@@ -112,9 +112,9 @@ export const categoryConfigs: CategoryConfig[] = [
   {
     key: 'security-github-actions',
     title: 'GitHub Actions',
-    description: 'Future workflow security analysis',
+    description: 'Inspect local GitHub Actions workflows for static security findings',
     section: 'security',
-    availability: 'planned',
+    availability: 'available',
   },
   {
     key: 'security-executable-integrity',

--- a/apps/tauri/src/styles/style.css
+++ b/apps/tauri/src/styles/style.css
@@ -2000,6 +2000,343 @@ button:disabled {
   opacity: 0.5;
 }
 
+.github-actions-view {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 20px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 26px 28px 30px;
+}
+
+.github-actions-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  flex: 0 0 auto;
+}
+
+.github-actions-heading {
+  display: flex;
+  max-width: 780px;
+  min-width: 0;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.github-actions-heading h1 {
+  margin: 0;
+  color: #f5f7fb;
+  font-size: 24px;
+  letter-spacing: -0.025em;
+}
+
+.github-actions-heading p {
+  margin: 0;
+  color: #a3adb9;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.github-actions-heading .github-actions-root {
+  overflow: hidden;
+  color: #7f8996;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-scan-button {
+  min-height: 34px;
+  flex: 0 0 auto;
+  padding: 0 14px;
+  border: 1px solid rgba(127, 211, 244, 0.45);
+  border-radius: 7px;
+  background: #2d9bc4;
+  color: #06151d;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.workflow-scan-button:hover:not(:disabled) {
+  background: #57b9df;
+}
+
+.workflow-scan-button:disabled {
+  cursor: default;
+  border-color: rgba(255, 255, 255, 0.1);
+  background: #46484d;
+  color: #949ba5;
+}
+
+.github-actions-view > .async-state-panel,
+.github-actions-results > .async-state-panel {
+  width: 100%;
+  max-width: none;
+  flex: 0 0 auto;
+}
+
+.github-actions-results {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.workflow-scan-error {
+  padding: 10px 12px;
+  border: 1px solid rgba(242, 112, 112, 0.28);
+  border-radius: 6px;
+  background: rgba(180, 55, 55, 0.1);
+  color: #f6aaaa;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.workflow-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.workflow-summary-card {
+  display: flex;
+  min-width: 0;
+  min-height: 78px;
+  justify-content: space-between;
+  flex-direction: column;
+  gap: 5px;
+  padding: 13px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  background: #25272a;
+}
+
+.workflow-summary-card strong {
+  overflow: hidden;
+  color: #f1f5f8;
+  font-size: 20px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-summary-card span {
+  color: #a8b2bd;
+  font-size: 11px;
+}
+
+.workflow-section {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.workflow-section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.workflow-section-heading h2 {
+  margin: 0;
+  color: #eef3f7;
+  font-size: 16px;
+}
+
+.workflow-section-heading p {
+  margin: 4px 0 0;
+  color: #87919e;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.workflow-overview-list,
+.workflow-finding-list {
+  display: grid;
+  min-width: 0;
+  gap: 8px;
+}
+
+.workflow-overview-card,
+.workflow-finding-card {
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  background: #25272a;
+}
+
+.workflow-overview-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 12px;
+}
+
+.workflow-overview-icon {
+  flex: 0 0 auto;
+}
+
+.workflow-overview-icon .item-icon {
+  width: 28px;
+  height: 28px;
+}
+
+.workflow-overview-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.workflow-overview-copy strong,
+.workflow-overview-copy span,
+.workflow-overview-copy small {
+  overflow: hidden;
+  min-width: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-overview-copy strong {
+  color: #f1f5f8;
+  font-size: 13px;
+}
+
+.workflow-overview-copy span {
+  color: #9ca7b3;
+  font-size: 11px;
+}
+
+.workflow-overview-copy small {
+  color: #737e8b;
+  font-size: 10px;
+}
+
+.workflow-analysis-status {
+  flex: 0 0 auto;
+  padding: 4px 7px;
+  border: 1px solid rgba(103, 207, 153, 0.23);
+  border-radius: 5px;
+  background: rgba(64, 172, 111, 0.11);
+  color: #b6e7cc;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.workflow-finding-card {
+  padding: 13px 14px;
+}
+
+.workflow-finding-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.workflow-finding-category {
+  color: #8bd5f4;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.workflow-finding-header h3 {
+  margin: 4px 0 0;
+  color: #f1f5f8;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.workflow-risk-badge {
+  flex: 0 0 auto;
+  padding: 4px 7px;
+  border: 1px solid rgba(247, 190, 91, 0.28);
+  border-radius: 5px;
+  background: rgba(205, 144, 44, 0.12);
+  color: #f4d18f;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.workflow-risk-critical .workflow-risk-badge,
+.workflow-risk-high .workflow-risk-badge {
+  border-color: rgba(242, 112, 112, 0.3);
+  background: rgba(180, 55, 55, 0.12);
+  color: #f6aaaa;
+}
+
+.workflow-risk-low .workflow-risk-badge,
+.workflow-risk-none .workflow-risk-badge {
+  border-color: rgba(103, 207, 153, 0.23);
+  background: rgba(64, 172, 111, 0.11);
+  color: #b6e7cc;
+}
+
+.workflow-finding-details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 16px;
+  margin: 13px 0 0;
+}
+
+.workflow-finding-details > div {
+  min-width: 0;
+}
+
+.workflow-finding-details dt {
+  margin: 0 0 3px;
+  color: #7f8996;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.workflow-finding-details dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: #c9d1da;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.workflow-evidence {
+  color: #b8e5f5 !important;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  white-space: pre-wrap;
+}
+
+.workflow-finding-reason {
+  margin: 13px 0 0;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  color: #aeb8c3;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.workflow-section-empty {
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.12);
+  color: #7f8996;
+  font-size: 11px;
+}
+
 @media (max-width: 1100px) {
   .app-toolbar {
     grid-template-columns: auto minmax(150px, 1fr) minmax(150px, 1fr) auto;
@@ -2100,6 +2437,26 @@ button:disabled {
 
   .history-drawer {
     width: min(420px, calc(100% - 14px));
+  }
+
+  .github-actions-view {
+    padding: 18px 12px 22px;
+  }
+
+  .github-actions-header {
+    flex-direction: column;
+  }
+
+  .workflow-scan-button {
+    width: 100%;
+  }
+
+  .workflow-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .workflow-finding-details {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .workspace-controls {

--- a/apps/tauri/src/types/workflow.ts
+++ b/apps/tauri/src/types/workflow.ts
@@ -183,6 +183,52 @@ export type SecurityScanResponse = {
   historyWarning?: string;
 };
 
+export type WorkflowAnalysisStatus = 'analyzed';
+export type WorkflowFindingCategory =
+  | 'suspiciousCommand'
+  | 'tokenPermissions'
+  | 'secretExposure';
+export type WorkflowExposureSink = 'stdout' | 'networkRequest';
+
+export type WorkflowJobSummary = {
+  id: string;
+  name?: string;
+  stepCount: number;
+};
+
+export type WorkflowSummary = {
+  path: string;
+  name?: string;
+  analysisStatus: WorkflowAnalysisStatus;
+  jobs: WorkflowJobSummary[];
+};
+
+export type WorkflowFinding = {
+  workflowPath: string;
+  jobId?: string;
+  stepIndex?: number;
+  stepName?: string;
+  ruleId: string;
+  category: WorkflowFindingCategory;
+  riskLevel: RiskLevel;
+  evidence?: string;
+  reason: string;
+  secretReference?: string;
+  exposureSink?: WorkflowExposureSink;
+};
+
+export type WorkflowScanNotice = {
+  workflowPath: string;
+  jobId?: string;
+  reason: string;
+};
+
+export type WorkflowScanResponse = {
+  workflows: WorkflowSummary[];
+  findings: WorkflowFinding[];
+  notices: WorkflowScanNotice[];
+};
+
 export type ActivityKind = 'Scan' | 'Cleanup' | 'Security';
 
 export type ActivityFailure = {


### PR DESCRIPTION
## Summary

- Expose the existing local, read-only Core GitHub Actions analyzer through a new `workflow_scan` Tauri command.
- Add the Security > GitHub Actions desktop screen with explicit scan execution, workflow overview, command findings, permission findings, secret-exposure findings, partial notices, empty states, and inspection errors.
- Preserve stale-workspace protection and avoid activity-history writes for workflow scans.
- Keep secret findings presentation-safe by exposing only reference names and supported sink metadata.

Closes #142

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p dustfril-tauri workflow_scan_wire_format_is_structured_and_secret_safe`
- `cargo test -p dustfril-core api::workflow`
- `npm run build`
- `npm test` — 13 files, 51 tests passed
- `cargo llvm-cov --workspace --all-features --summary-only` / `cargo llvm-cov report --summary-only` — report generated

`cargo test --workspace` runs 301 tests successfully but has one existing macOS-only fixture mismatch: `signed_system_fixture_is_reported_as_valid` observes `macOS Software Signing` while the fixture expects `Software Signing`. This is unrelated to this change and the test was not weakened.