### PR TITLE
feat(tauri): expose executable integrity evidence

### DIFF
--- a/apps/tauri/README.md
+++ b/apps/tauri/README.md
@@ -34,6 +34,7 @@ case-sensitive.
 | `build_cleanup_plan` | `{ options: RunOptions }` | `CleanupPlanResponse` |
 | `audit` | `{ options: RunOptions }` | `LifecycleScript[]` |
 | `security_scan` | `{ options: RunOptions }` | `SecurityScanResponse` (may include additive `historyWarning`) |
+| `integrity_scan` | `{ options: { tools } }` | `IntegrityScanResponse` |
 | `execute_cleanup` | `{ request: { root, ecosystems, analysisId, selectedArtifacts, mode } }` | `CleanupResultResponse` (may include additive `historyWarning`) |
 | `load_activity_history` | none | `ActivityRecord[]` |
 | `load_cleanup_history` | none | `CleanupHistoryEntry[]` |
@@ -64,6 +65,7 @@ refreshes set it to `false` so they do not change the generated-artifact baselin
 - Safe cleanup with Trash or permanent delete confirmation
 - Activity history viewer backed by shared, versioned core history storage
 - Explicit scans return the generated-artifact snapshot comparison produced by Core
+- Executable Integrity screen exposes non-executing tool path, SHA-256 baseline, and platform signature evidence
 
 Activity persistence is auxiliary to scan, cleanup, and security results. If a
 history write fails, the operation response remains available and includes an
@@ -78,10 +80,11 @@ additive `historyWarning` for the desktop status surface.
 - `HistoryList`
 - `AsyncStatePanel`
 - `ModulePlaceholderView`
+- `ExecutableIntegrityView`
 
 ## Desktop module navigation
 
-The sidebar keeps the planned Desktop information architecture in
+The sidebar keeps the Desktop information architecture in
 `src/model/categories.ts`:
 
 ```text
@@ -101,12 +104,14 @@ Workspace
 Security
   Supply Chain (planned)
   GitHub Actions (planned)
-  Executable Integrity (planned)
+  Executable Integrity
 ```
 
 Rust, Node.js, and Java destinations filter the existing unified analysis
-result; they do not start a new scan when selected. Planned destinations render
-an explicit unsupported state and do not invoke speculative Tauri commands.
+result; they do not start a new scan when selected. Executable Integrity runs
+only when the user explicitly requests it and passes selected tool identifiers
+to Core. Planned destinations render an explicit unsupported state and do not
+invoke speculative Tauri commands.
 
 Advanced operations use the small state model in `src/model/async.ts`. It
 keeps loading, success, partial success, unsupported, empty, and error states

--- a/apps/tauri/src-tauri/src/contract.rs
+++ b/apps/tauri/src-tauri/src/contract.rs
@@ -6,10 +6,12 @@ use std::{
 use dustfril_core::models::{
     ArtifactChangeKind, ArtifactSizeChange, ArtifactSnapshot, ArtifactSnapshotArtifact,
     ArtifactSnapshotResult, ArtifactSnapshotStatus, CleanupFailureReason, CleanupRecommendation,
-    DeleteMode, DeveloperStorageSummary, Ecosystem, LifecycleScript, LockfileCheck, LockfileKind,
-    LockfileStatus, PackageManager, ProjectIdentity, RecommendationPolicy, RiskLevel, ScriptType,
-    SecurityFinding, SecurityReport, SecurityWarning, StorageSummary, VolumeStorage,
-    DEFAULT_CLEANUP_AGE_DAYS,
+    DeleteMode, DeveloperStorageSummary, Ecosystem, ExecutableObservation, IntegrityCheck,
+    IntegrityFailure, IntegrityFailureKind, IntegrityReport, IntegrityStatus, LifecycleScript,
+    LockfileCheck, LockfileKind, LockfileStatus, PackageManager, ProjectIdentity,
+    RecommendationPolicy, RiskLevel, ScriptType, SecurityFinding, SecurityReport, SecurityWarning,
+    SignatureFailure, SignatureFailureKind, SignaturePlatform, SignatureReport, SignatureStatus,
+    StorageSummary, ToolSpec, VolumeStorage, DEFAULT_CLEANUP_AGE_DAYS,
 };
 use serde::{Deserialize, Serialize};
 
@@ -364,6 +366,90 @@ pub(crate) struct SecurityScanResponse {
     pub(crate) history_warning: Option<String>,
 }
 
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct IntegrityScanOptions {
+    #[serde(default)]
+    pub(crate) tools: Vec<String>,
+}
+
+impl IntegrityScanOptions {
+    pub(crate) fn tools(self) -> Vec<ToolSpec> {
+        if self.tools.is_empty() {
+            dustfril_core::api::integrity::default_tools()
+        } else {
+            self.tools.into_iter().map(ToolSpec::from).collect()
+        }
+    }
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct IntegrityScanResponse {
+    pub(crate) checks: Vec<IntegrityCheckDto>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct IntegrityCheckDto {
+    pub(crate) requested_tool: String,
+    pub(crate) status: IntegrityStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) observation: Option<ExecutableObservationDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) previous_observation: Option<ExecutableObservationDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) failure: Option<IntegrityFailureDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) signature: Option<SignatureReportDto>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ExecutableObservationDto {
+    pub(crate) requested_tool: String,
+    pub(crate) resolved_path: String,
+    pub(crate) canonical_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) symlink_target: Option<String>,
+    pub(crate) size_bytes: u64,
+    pub(crate) sha256: String,
+    pub(crate) observed_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) version_metadata: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct IntegrityFailureDto {
+    pub(crate) kind: IntegrityFailureKind,
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SignatureReportDto {
+    pub(crate) platform: SignaturePlatform,
+    pub(crate) status: SignatureStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) signer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) team_identifier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) verification_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) verification_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) failure: Option<SignatureFailureDto>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SignatureFailureDto {
+    pub(crate) kind: SignatureFailureKind,
+    pub(crate) message: String,
+}
+
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SecurityFindingDto {
@@ -589,6 +675,76 @@ impl From<SecurityReport> for SecurityScanResponse {
     }
 }
 
+impl From<IntegrityReport> for IntegrityScanResponse {
+    fn from(report: IntegrityReport) -> Self {
+        Self {
+            checks: report.checks.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<IntegrityCheck> for IntegrityCheckDto {
+    fn from(check: IntegrityCheck) -> Self {
+        Self {
+            requested_tool: check.requested_tool,
+            status: check.status,
+            observation: check.observation.map(Into::into),
+            previous_observation: check.previous_observation.map(Into::into),
+            failure: check.failure.map(Into::into),
+            signature: check.signature.map(Into::into),
+        }
+    }
+}
+
+impl From<ExecutableObservation> for ExecutableObservationDto {
+    fn from(observation: ExecutableObservation) -> Self {
+        Self {
+            requested_tool: observation.requested_tool,
+            resolved_path: observation.resolved_path.display().to_string(),
+            canonical_path: observation.canonical_path.display().to_string(),
+            symlink_target: observation
+                .symlink_target
+                .map(|path| path.display().to_string()),
+            size_bytes: observation.size_bytes,
+            sha256: observation.sha256,
+            observed_at: observation.observed_at.to_rfc3339(),
+            version_metadata: observation.version_metadata,
+        }
+    }
+}
+
+impl From<IntegrityFailure> for IntegrityFailureDto {
+    fn from(failure: IntegrityFailure) -> Self {
+        Self {
+            kind: failure.kind,
+            message: failure.message,
+        }
+    }
+}
+
+impl From<SignatureReport> for SignatureReportDto {
+    fn from(report: SignatureReport) -> Self {
+        Self {
+            platform: report.platform,
+            status: report.status,
+            signer: report.signer,
+            team_identifier: report.team_identifier,
+            verification_message: report.verification_message,
+            verification_code: report.verification_code,
+            failure: report.failure.map(Into::into),
+        }
+    }
+}
+
+impl From<SignatureFailure> for SignatureFailureDto {
+    fn from(failure: SignatureFailure) -> Self {
+        Self {
+            kind: failure.kind,
+            message: failure.message,
+        }
+    }
+}
+
 impl From<SecurityFinding> for SecurityFindingDto {
     fn from(finding: SecurityFinding) -> Self {
         Self {
@@ -704,6 +860,92 @@ mod tests {
         .unwrap();
         assert_eq!(refresh_options.record_history, Some(false));
         assert_eq!(refresh_options.record_artifact_snapshot, Some(false));
+    }
+
+    #[test]
+    fn integrity_scan_options_preserve_selected_tools_and_default_to_core_selection() {
+        let defaults = IntegrityScanOptions { tools: Vec::new() }.tools();
+        assert_eq!(defaults, dustfril_core::api::integrity::default_tools());
+
+        let options: IntegrityScanOptions = serde_json::from_value(json!({
+            "tools": ["git", "/Applications/Developer Tools/git"]
+        }))
+        .unwrap();
+        assert_eq!(
+            options.tools(),
+            vec![
+                dustfril_core::models::ToolSpec::from("git"),
+                dustfril_core::models::ToolSpec::from("/Applications/Developer Tools/git")
+            ]
+        );
+    }
+
+    #[test]
+    fn integrity_response_wire_format_preserves_evidence_and_neutral_signature_state() {
+        let observation: ExecutableObservation = serde_json::from_value(json!({
+            "requestedTool": "/Applications/Developer Tools/git",
+            "resolvedPath": "/Applications/Developer Tools/git",
+            "canonicalPath": "/Applications/Developer Tools/git",
+            "symlinkTarget": null,
+            "sizeBytes": 9,
+            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "observedAt": "2026-09-07T01:02:03Z",
+            "versionMetadata": null
+        }))
+        .unwrap();
+        let report = IntegrityReport {
+            checks: vec![IntegrityCheck {
+                requested_tool: observation.requested_tool.clone(),
+                status: IntegrityStatus::ContentChanged,
+                observation: Some(observation),
+                previous_observation: None,
+                failure: None,
+                signature: Some(SignatureReport {
+                    platform: SignaturePlatform::Linux,
+                    status: SignatureStatus::Unsupported,
+                    signer: None,
+                    team_identifier: None,
+                    verification_message: Some(
+                        "Linux does not provide a universal executable code-signature verifier"
+                            .to_owned(),
+                    ),
+                    verification_code: None,
+                    failure: Some(SignatureFailure {
+                        kind: SignatureFailureKind::PlatformUnsupported,
+                        message: "no verifier".to_owned(),
+                    }),
+                }),
+            }],
+        };
+
+        let response: IntegrityScanResponse = report.into();
+
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            json!({
+                "checks": [{
+                    "requestedTool": "/Applications/Developer Tools/git",
+                    "status": "contentChanged",
+                    "observation": {
+                        "requestedTool": "/Applications/Developer Tools/git",
+                        "resolvedPath": "/Applications/Developer Tools/git",
+                        "canonicalPath": "/Applications/Developer Tools/git",
+                        "sizeBytes": 9,
+                        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "observedAt": "2026-09-07T01:02:03+00:00"
+                    },
+                    "signature": {
+                        "platform": "linux",
+                        "status": "unsupported",
+                        "verificationMessage": "Linux does not provide a universal executable code-signature verifier",
+                        "failure": {
+                            "kind": "platformUnsupported",
+                            "message": "no verifier"
+                        }
+                    }
+                }]
+            })
+        );
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -19,9 +19,9 @@ use contract::{
     artifact_path, artifact_snapshot_to_dto, cleanup_failure_reason, project_identity_to_dto,
     storage_summary_to_dto, volume_storage_to_dto, AnalysisResponse, ArtifactAnalysisDto,
     ArtifactDto, CleanupCandidateDto, CleanupFailureDto, CleanupHistoryEntryDto,
-    CleanupPlanResponse, CleanupResultResponse, ExecuteCleanupRequest, LifecycleScriptDto,
-    RunOptions, ScanResponse, SecurityScanResponse, StorageSummaryDto, VolumeStorageDto,
-    WorkspaceAnalysisResponse,
+    CleanupPlanResponse, CleanupResultResponse, ExecuteCleanupRequest, IntegrityScanOptions,
+    IntegrityScanResponse, LifecycleScriptDto, RunOptions, ScanResponse, SecurityScanResponse,
+    StorageSummaryDto, VolumeStorageDto, WorkspaceAnalysisResponse,
 };
 use dustfril_core::{
     api,
@@ -600,6 +600,21 @@ async fn security_scan(options: RunOptions) -> Result<SecurityScanResponse, Stri
     .map_err(|error| error.to_string())?
 }
 
+#[tauri::command]
+async fn integrity_scan(options: IntegrityScanOptions) -> Result<IntegrityScanResponse, String> {
+    let baseline_path = api::integrity::state_path()
+        .map_err(|error| format!("Failed to determine executable-integrity state path: {error}"))?;
+    let tools = options.tools();
+
+    tokio::task::spawn_blocking(move || {
+        api::integrity::scan(&tools, &baseline_path)
+            .map(Into::into)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -617,7 +632,8 @@ pub fn run() {
             clear_activity_history,
             load_cleanup_history,
             audit,
-            security_scan
+            security_scan,
+            integrity_scan
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from './AppShell';
 import {
@@ -7,7 +7,9 @@ import {
   executeCleanup,
   loadActivityHistory,
   refreshStorageVolume,
+  scanExecutableIntegrity,
 } from '../../lib/tauri';
+import type { IntegrityScanResponse } from '../../types/workflow';
 
 vi.mock('../../lib/tauri', () => ({
   analyzeWorkspace: vi.fn(),
@@ -81,6 +83,36 @@ describe('AppShell Overview navigation', () => {
       expect(screen.getByRole('heading', { name: `${title} is planned` })).toBeInTheDocument();
     }
     expect(analyzeWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('keeps an integrity result available after navigating away while scanning', async () => {
+    let resolveScan: ((response: IntegrityScanResponse) => void) | undefined;
+    vi.mocked(scanExecutableIntegrity).mockImplementation(
+      () =>
+        new Promise<IntegrityScanResponse>((resolve) => {
+          resolveScan = resolve;
+        }),
+    );
+
+    render(<AppShell />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Analyze Workspace' })).toBeEnabled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Executable Integrity' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Run integrity scan' }));
+    await waitFor(() => expect(scanExecutableIntegrity).toHaveBeenCalledOnce());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Overview' }));
+    expect(screen.queryByRole('heading', { name: 'git' })).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveScan?.({
+        checks: [{ requestedTool: 'git', status: 'contentChanged' }],
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Executable Integrity' }));
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'git' })).toBeInTheDocument());
+    expect(screen.getByText('Content changed')).toBeInTheDocument();
   });
 
   it('opens the exact Overview artifact in Workspace without selecting it', async () => {

--- a/apps/tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../lib/tauri', () => ({
   refreshStorageVolume: vi.fn(),
   loadActivityHistory: vi.fn().mockResolvedValue([]),
   clearActivityHistory: vi.fn().mockResolvedValue(undefined),
+  scanExecutableIntegrity: vi.fn(),
 }));
 
 const analyzedArtifact = {
@@ -68,7 +69,7 @@ describe('AppShell Overview navigation', () => {
     ['Activity', false],
     ['Supply Chain', true],
     ['GitHub Actions', true],
-    ['Executable Integrity', true],
+    ['Executable Integrity', false],
   ])('navigates to the %s module without starting another operation', async (title, planned) => {
     render(<AppShell />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'Analyze Workspace' })).toBeEnabled());

--- a/apps/tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.tsx
@@ -3,6 +3,7 @@ import { Sidebar } from '../../components/Sidebar/Sidebar';
 import { categoryConfig } from '../../model/categories';
 import { pathBreadcrumb } from '../../model/presentation';
 import { AppHeader } from './components/AppHeader';
+import { useExecutableIntegrity } from './hooks/useExecutableIntegrity';
 import { useAppState } from './hooks/useAppState';
 import { HistoryView } from './views/HistoryView';
 import { ModulePlaceholderView } from './views/ModulePlaceholderView';
@@ -12,6 +13,7 @@ import { WorkspaceView } from './views/WorkspaceView';
 
 export function AppShell() {
   const app = useAppState();
+  const executableIntegrity = useExecutableIntegrity();
   const activeConfig = categoryConfig(app.activeCategory);
   const showingCleanup = activeConfig?.ecosystem !== undefined;
   const showingWorkspace = app.activeCategory === 'workspace' || showingCleanup;
@@ -87,7 +89,9 @@ export function AppShell() {
             />
           ) : null}
 
-          {showingExecutableIntegrity ? <ExecutableIntegrityView /> : null}
+          {showingExecutableIntegrity ? (
+            <ExecutableIntegrityView integrity={executableIntegrity} />
+          ) : null}
 
           {app.activeCategory !== 'overview' &&
           !showingWorkspace &&

--- a/apps/tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.tsx
@@ -7,6 +7,7 @@ import { useAppState } from './hooks/useAppState';
 import { HistoryView } from './views/HistoryView';
 import { ModulePlaceholderView } from './views/ModulePlaceholderView';
 import { OverviewView } from './views/OverviewView';
+import { ExecutableIntegrityView } from './views/ExecutableIntegrityView';
 import { WorkspaceView } from './views/WorkspaceView';
 
 export function AppShell() {
@@ -16,6 +17,7 @@ export function AppShell() {
   const showingWorkspace = app.activeCategory === 'workspace' || showingCleanup;
   const showingActivity =
     app.activeCategory === 'history' || app.activeCategory === 'workspace-activity';
+  const showingExecutableIntegrity = app.activeCategory === 'security-executable-integrity';
 
   return (
     <main className="app-shell">
@@ -85,7 +87,13 @@ export function AppShell() {
             />
           ) : null}
 
-          {app.activeCategory !== 'overview' && !showingWorkspace && !showingActivity && activeConfig ? (
+          {showingExecutableIntegrity ? <ExecutableIntegrityView /> : null}
+
+          {app.activeCategory !== 'overview' &&
+          !showingWorkspace &&
+          !showingActivity &&
+          !showingExecutableIntegrity &&
+          activeConfig ? (
             <ModulePlaceholderView
               config={activeConfig}
               onReturnToOverview={() => app.setActiveCategory('overview')}

--- a/apps/tauri/src/features/app-shell/hooks/useExecutableIntegrity.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useExecutableIntegrity.ts
@@ -10,7 +10,14 @@ import type { IntegrityScanResponse } from '../../../types/workflow';
 
 export const defaultIntegrityTools = ['node', 'bun', 'cargo', 'rustc', 'git', 'java', 'gradle'];
 
-export function useExecutableIntegrity() {
+export type ExecutableIntegrityState = {
+  operation: AsyncOperationState<IntegrityScanResponse>;
+  result: IntegrityScanResponse | undefined;
+  busy: boolean;
+  scan: (tools: string[]) => Promise<void>;
+};
+
+export function useExecutableIntegrity(): ExecutableIntegrityState {
   const [operation, dispatch] = useReducer(
     reduceAsyncOperation<IntegrityScanResponse>,
     idleAsyncOperation<IntegrityScanResponse>(),
@@ -34,10 +41,5 @@ export function useExecutableIntegrity() {
     result: operationData(operation),
     busy: operation.status === 'loading',
     scan,
-  } satisfies {
-    operation: AsyncOperationState<IntegrityScanResponse>;
-    result: IntegrityScanResponse | undefined;
-    busy: boolean;
-    scan: (tools: string[]) => Promise<void>;
   };
 }

--- a/apps/tauri/src/features/app-shell/hooks/useExecutableIntegrity.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useExecutableIntegrity.ts
@@ -1,0 +1,43 @@
+import { useCallback, useReducer, useRef } from 'react';
+import { scanExecutableIntegrity } from '../../../lib/tauri';
+import {
+  idleAsyncOperation,
+  reduceAsyncOperation,
+  operationData,
+  type AsyncOperationState,
+} from '../../../model/async';
+import type { IntegrityScanResponse } from '../../../types/workflow';
+
+export const defaultIntegrityTools = ['node', 'bun', 'cargo', 'rustc', 'git', 'java', 'gradle'];
+
+export function useExecutableIntegrity() {
+  const [operation, dispatch] = useReducer(
+    reduceAsyncOperation<IntegrityScanResponse>,
+    idleAsyncOperation<IntegrityScanResponse>(),
+  );
+  const requestRef = useRef(0);
+
+  const scan = useCallback(async (tools: string[]) => {
+    const requestId = ++requestRef.current;
+    dispatch({ type: 'start', requestId });
+
+    try {
+      const response = await scanExecutableIntegrity({ tools: [...tools] });
+      dispatch({ type: 'success', requestId, data: response });
+    } catch (error) {
+      dispatch({ type: 'error', requestId, error: String(error) });
+    }
+  }, []);
+
+  return {
+    operation,
+    result: operationData(operation),
+    busy: operation.status === 'loading',
+    scan,
+  } satisfies {
+    operation: AsyncOperationState<IntegrityScanResponse>;
+    result: IntegrityScanResponse | undefined;
+    busy: boolean;
+    scan: (tools: string[]) => Promise<void>;
+  };
+}

--- a/apps/tauri/src/features/app-shell/views/ExecutableIntegrityView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/ExecutableIntegrityView.test.tsx
@@ -82,7 +82,7 @@ describe('ExecutableIntegrityView', () => {
   it('runs an explicit scan and renders structured integrity and signature evidence', async () => {
     vi.mocked(scanExecutableIntegrity).mockResolvedValue(scanResponse);
 
-    render(<ExecutableIntegrityView />);
+    render(<TestExecutableIntegrityView />);
     expect(screen.getByRole('heading', { name: 'Ready to inspect' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Run integrity scan' })).toBeEnabled();
 
@@ -108,7 +108,7 @@ describe('ExecutableIntegrityView', () => {
   it('passes custom names and paths as one structured tool selection', async () => {
     vi.mocked(scanExecutableIntegrity).mockResolvedValue({ checks: [] });
 
-    render(<ExecutableIntegrityView />);
+    render(<TestExecutableIntegrityView />);
     const input = screen.getByLabelText('Additional tool name or path');
     fireEvent.change(input, { target: { value: '/tmp/tools/my tool' } });
     fireEvent.click(screen.getByRole('button', { name: 'Add' }));
@@ -149,3 +149,8 @@ describe('ExecutableIntegrityView', () => {
     expect(hook.result.current.result?.checks[0].requestedTool).toBe('second');
   });
 });
+
+function TestExecutableIntegrityView() {
+  const integrity = useExecutableIntegrity();
+  return <ExecutableIntegrityView integrity={integrity} />;
+}

--- a/apps/tauri/src/features/app-shell/views/ExecutableIntegrityView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/ExecutableIntegrityView.test.tsx
@@ -1,0 +1,151 @@
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { scanExecutableIntegrity } from '../../../lib/tauri';
+import type {
+  ExecutableObservation,
+  IntegrityScanResponse,
+  SignatureReport,
+} from '../../../types/workflow';
+import { defaultIntegrityTools, useExecutableIntegrity } from '../hooks/useExecutableIntegrity';
+import { ExecutableIntegrityView } from './ExecutableIntegrityView';
+
+vi.mock('../../../lib/tauri', () => ({
+  scanExecutableIntegrity: vi.fn(),
+}));
+
+const hash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+function observation(tool: string, path: string, currentHash = hash): ExecutableObservation {
+  return {
+    requestedTool: tool,
+    resolvedPath: path,
+    canonicalPath: path,
+    sizeBytes: 128,
+    sha256: currentHash,
+    observedAt: '2026-09-07T01:02:03Z',
+  };
+}
+
+function signature(status: SignatureReport['status'], platform: SignatureReport['platform']): SignatureReport {
+  return {
+    status,
+    platform,
+    verificationMessage: status === 'unsupported' ? 'No verifier is implemented.' : undefined,
+  };
+}
+
+const scanResponse: IntegrityScanResponse = {
+  checks: [
+    {
+      requestedTool: 'git',
+      status: 'newBaseline',
+      observation: observation('git', '/usr/bin/git'),
+      signature: signature('valid', 'macos'),
+    },
+    {
+      requestedTool: 'node',
+      status: 'unchanged',
+      observation: observation('node', '/usr/local/bin/node'),
+      signature: signature('unsupported', 'linux'),
+    },
+    {
+      requestedTool: 'cargo',
+      status: 'contentChanged',
+      observation: observation('cargo', '/Users/dev tools/bin/cargo', 'b'.repeat(64)),
+      previousObservation: observation('cargo', '/Users/dev tools/bin/cargo'),
+      signature: signature('unsigned', 'macos'),
+    },
+    {
+      requestedTool: 'rustc',
+      status: 'resolvedPathChanged',
+      observation: observation('rustc', '/opt/rust/bin/rustc'),
+      previousObservation: observation('rustc', '/usr/bin/rustc'),
+      signature: signature('invalid', 'macos'),
+    },
+    {
+      requestedTool: 'java',
+      status: 'missing',
+      failure: { kind: 'notFound', message: 'no PATH candidate found for java' },
+    },
+    {
+      requestedTool: 'gradle',
+      status: 'inspectionFailed',
+      failure: { kind: 'unreadable', message: 'permission denied' },
+      signature: signature('inspectionFailed', 'macos'),
+    },
+  ],
+};
+
+describe('ExecutableIntegrityView', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('runs an explicit scan and renders structured integrity and signature evidence', async () => {
+    vi.mocked(scanExecutableIntegrity).mockResolvedValue(scanResponse);
+
+    render(<ExecutableIntegrityView />);
+    expect(screen.getByRole('heading', { name: 'Ready to inspect' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run integrity scan' })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run integrity scan' }));
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'git' })).toBeInTheDocument());
+    expect(scanExecutableIntegrity).toHaveBeenCalledWith({ tools: defaultIntegrityTools });
+    expect(screen.getByText('6 tools checked')).toBeInTheDocument();
+    expect(screen.getByText('Content changed')).toBeInTheDocument();
+    expect(screen.getByText('Resolved path changed')).toBeInTheDocument();
+    expect(screen.getByText('Missing')).toBeInTheDocument();
+    expect(screen.getAllByText('Inspection failed')).not.toHaveLength(0);
+    expect(screen.getAllByText('/Users/dev tools/bin/cargo')).not.toHaveLength(0);
+    expect(screen.getAllByText(hash)).not.toHaveLength(0);
+    expect(screen.getByText(/not proof of malware or compromise/)).toBeInTheDocument();
+    expect(screen.getAllByText('Unsupported')).not.toHaveLength(0);
+    expect(screen.getAllByText('Unsigned')).not.toHaveLength(0);
+    expect(screen.getAllByText('Invalid')).not.toHaveLength(0);
+    expect(screen.getAllByText('Inspection failed')).toHaveLength(3);
+    expect(screen.getByText('no PATH candidate found for java')).toBeInTheDocument();
+  });
+
+  it('passes custom names and paths as one structured tool selection', async () => {
+    vi.mocked(scanExecutableIntegrity).mockResolvedValue({ checks: [] });
+
+    render(<ExecutableIntegrityView />);
+    const input = screen.getByLabelText('Additional tool name or path');
+    fireEvent.change(input, { target: { value: '/tmp/tools/my tool' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'git' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Run integrity scan' }));
+
+    await waitFor(() => expect(scanExecutableIntegrity).toHaveBeenCalled());
+    expect(scanExecutableIntegrity).toHaveBeenCalledWith({
+      tools: [...defaultIntegrityTools.filter((tool) => tool !== 'git'), '/tmp/tools/my tool'],
+    });
+  });
+
+  it('does not let an older scan overwrite a newer result', async () => {
+    const pending = new Map<string, (response: IntegrityScanResponse) => void>();
+    vi.mocked(scanExecutableIntegrity).mockImplementation(({ tools }) =>
+      new Promise((resolve) => pending.set(tools[0], resolve)),
+    );
+
+    const hook = renderHook(() => useExecutableIntegrity());
+    act(() => {
+      void hook.result.current.scan(['first']);
+      void hook.result.current.scan(['second']);
+    });
+
+    await act(async () => {
+      pending.get('second')?.({
+        checks: [{ requestedTool: 'second', status: 'unchanged' }],
+      });
+    });
+    await waitFor(() => expect(hook.result.current.result?.checks[0].requestedTool).toBe('second'));
+
+    await act(async () => {
+      pending.get('first')?.({
+        checks: [{ requestedTool: 'first', status: 'contentChanged' }],
+      });
+    });
+
+    expect(hook.result.current.result?.checks[0].requestedTool).toBe('second');
+  });
+});

--- a/apps/tauri/src/features/app-shell/views/ExecutableIntegrityView.tsx
+++ b/apps/tauri/src/features/app-shell/views/ExecutableIntegrityView.tsx
@@ -8,7 +8,10 @@ import type {
   SignatureReport,
   SignatureStatus,
 } from '../../../types/workflow';
-import { defaultIntegrityTools, useExecutableIntegrity } from '../hooks/useExecutableIntegrity';
+import {
+  defaultIntegrityTools,
+  type ExecutableIntegrityState,
+} from '../hooks/useExecutableIntegrity';
 
 const integrityStatusLabels: Record<IntegrityStatus, string> = {
   newBaseline: 'New baseline',
@@ -34,8 +37,11 @@ const signaturePlatformLabels = {
   other: 'Other',
 } as const;
 
-export function ExecutableIntegrityView() {
-  const integrity = useExecutableIntegrity();
+export function ExecutableIntegrityView({
+  integrity,
+}: {
+  integrity: ExecutableIntegrityState;
+}) {
   const [selectedTools, setSelectedTools] = useState(defaultIntegrityTools);
   const [customTool, setCustomTool] = useState('');
   const result = integrity.result;

--- a/apps/tauri/src/features/app-shell/views/ExecutableIntegrityView.tsx
+++ b/apps/tauri/src/features/app-shell/views/ExecutableIntegrityView.tsx
@@ -1,0 +1,362 @@
+import { useMemo, useState } from 'react';
+import { AsyncStatePanel } from '../../../components/AsyncStatePanel/AsyncStatePanel';
+import type { AsyncOperationState } from '../../../model/async';
+import type {
+  IntegrityCheck,
+  IntegrityScanResponse,
+  IntegrityStatus,
+  SignatureReport,
+  SignatureStatus,
+} from '../../../types/workflow';
+import { defaultIntegrityTools, useExecutableIntegrity } from '../hooks/useExecutableIntegrity';
+
+const integrityStatusLabels: Record<IntegrityStatus, string> = {
+  newBaseline: 'New baseline',
+  unchanged: 'Unchanged',
+  contentChanged: 'Content changed',
+  resolvedPathChanged: 'Resolved path changed',
+  missing: 'Missing',
+  inspectionFailed: 'Inspection failed',
+};
+
+const signatureStatusLabels: Record<SignatureStatus, string> = {
+  valid: 'Valid',
+  unsigned: 'Unsigned',
+  invalid: 'Invalid',
+  unsupported: 'Unsupported',
+  inspectionFailed: 'Inspection failed',
+};
+
+const signaturePlatformLabels = {
+  macos: 'macOS',
+  windows: 'Windows',
+  linux: 'Linux',
+  other: 'Other',
+} as const;
+
+export function ExecutableIntegrityView() {
+  const integrity = useExecutableIntegrity();
+  const [selectedTools, setSelectedTools] = useState(defaultIntegrityTools);
+  const [customTool, setCustomTool] = useState('');
+  const result = integrity.result;
+
+  const toolChoices = useMemo(
+    () => [
+      ...defaultIntegrityTools,
+      ...selectedTools.filter((tool) => !defaultIntegrityTools.includes(tool)),
+    ],
+    [selectedTools],
+  );
+
+  function toggleTool(tool: string) {
+    setSelectedTools((current) =>
+      current.includes(tool) ? current.filter((value) => value !== tool) : [...current, tool],
+    );
+  }
+
+  function addCustomTool() {
+    const tool = customTool.trim();
+    if (!tool) {
+      return;
+    }
+
+    setSelectedTools((current) => (current.includes(tool) ? current : [...current, tool]));
+    setCustomTool('');
+  }
+
+  return (
+    <div className="integrity-view">
+      <header className="integrity-heading">
+        <div>
+          <p className="eyebrow">Security</p>
+          <h1>Executable Integrity</h1>
+          <p>
+            Inspect the developer tools resolved from PATH and compare their bytes with the local
+            baseline. Inspection reads metadata and bytes only; it never launches a tool.
+          </p>
+        </div>
+      </header>
+
+      <section className="integrity-controls" aria-label="Executable integrity scan controls">
+        <div className="integrity-controls-heading">
+          <div>
+            <p className="control-label">TOOLS TO INSPECT</p>
+            <p className="integrity-caption">
+              Start with DustFril&apos;s supported developer-tool set, or choose a subset.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="button-secondary"
+            onClick={() => setSelectedTools(defaultIntegrityTools)}
+            disabled={integrity.busy}
+          >
+            Restore defaults
+          </button>
+        </div>
+
+        <div className="integrity-tool-grid">
+          {toolChoices.map((tool) => (
+            <label className="integrity-tool-option" key={tool}>
+              <input
+                type="checkbox"
+                checked={selectedTools.includes(tool)}
+                onChange={() => toggleTool(tool)}
+                disabled={integrity.busy}
+              />
+              <span>{tool}</span>
+            </label>
+          ))}
+        </div>
+
+        <div className="integrity-custom-tool">
+          <label htmlFor="integrity-custom-tool">Additional tool name or path</label>
+          <div>
+            <input
+              id="integrity-custom-tool"
+              value={customTool}
+              onChange={(event) => setCustomTool(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  addCustomTool();
+                }
+              }}
+              placeholder="/path/to/tool or tool-name"
+              disabled={integrity.busy}
+              spellCheck={false}
+            />
+            <button
+              type="button"
+              className="button-secondary"
+              onClick={addCustomTool}
+              disabled={integrity.busy || !customTool.trim()}
+            >
+              Add
+            </button>
+          </div>
+          <p>
+            The value is passed as one structured identifier. It is never interpolated into a
+            shell command or executed.
+          </p>
+        </div>
+
+        <div className="integrity-scan-actions">
+          <span>{selectedTools.length} tool{selectedTools.length === 1 ? '' : 's'} selected</span>
+          <button
+            type="button"
+            className="button-confirm"
+            onClick={() => void integrity.scan(selectedTools)}
+            disabled={integrity.busy || selectedTools.length === 0}
+          >
+            {integrity.busy ? 'Scanning…' : 'Run integrity scan'}
+          </button>
+        </div>
+      </section>
+
+      <IntegrityScanContent operation={integrity.operation} result={result} />
+    </div>
+  );
+}
+
+function IntegrityScanContent({
+  operation,
+  result,
+}: {
+  operation: AsyncOperationState<IntegrityScanResponse>;
+  result: IntegrityScanResponse | undefined;
+}) {
+  if (!result && operation.status === 'idle') {
+    return (
+      <AsyncStatePanel
+        status="idle"
+        title="Ready to inspect"
+        description="Run an explicit scan to establish or compare the local executable-integrity baseline."
+      />
+    );
+  }
+
+  if (!result && operation.status === 'loading') {
+    return (
+      <AsyncStatePanel
+        status="loading"
+        title="Inspecting developer tools"
+        description="DustFril is resolving paths, reading metadata, hashing bytes, and collecting supported signature evidence."
+      />
+    );
+  }
+
+  if (!result && operation.status === 'error') {
+    return (
+      <AsyncStatePanel
+        status="error"
+        title="Integrity scan failed"
+        description="The executable-integrity scan could not be completed."
+        error={operation.error}
+      />
+    );
+  }
+
+  if (!result || result.checks.length === 0) {
+    return (
+      <AsyncStatePanel
+        status="empty"
+        title="No tools inspected"
+        description="Select at least one supported developer tool and run the scan again."
+      />
+    );
+  }
+
+  return (
+    <section className="integrity-results" aria-label="Executable integrity results">
+      {operation.status === 'loading' ? (
+        <div className="integrity-inline-status" role="status">
+          Comparing a new scan with the previous result…
+        </div>
+      ) : null}
+      {operation.status === 'error' ? (
+        <div className="integrity-inline-status integrity-inline-status-error" role="status">
+          The latest scan failed: {operation.error}. The result below is from the previous completed scan.
+        </div>
+      ) : null}
+      <IntegritySummary checks={result.checks} />
+      <p className="integrity-interpretation">
+        A changed path or hash is integrity evidence for review, not proof of malware or compromise.
+        Unsigned, invalid, and unsupported signature states are reported as evidence only.
+      </p>
+      <p className="integrity-baseline-note">
+        Core persists each successful observation as the next baseline. Missing or failed
+        observations do not erase the last successful baseline.
+      </p>
+      <div className="integrity-check-list">
+        {result.checks.map((check) => (
+          <IntegrityCheckCard check={check} key={`${check.requestedTool}-${check.observation?.resolvedPath ?? check.status}`} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function IntegritySummary({ checks }: { checks: IntegrityCheck[] }) {
+  const changed = checks.filter((check) =>
+    check.status === 'contentChanged' || check.status === 'resolvedPathChanged',
+  ).length;
+  const unavailable = checks.filter(
+    (check) => check.status === 'missing' || check.status === 'inspectionFailed',
+  ).length;
+  const signatureReview = checks.filter((check) =>
+    check.signature && ['unsigned', 'invalid', 'inspectionFailed'].includes(check.signature.status),
+  ).length;
+
+  return (
+    <div className="integrity-summary-strip" aria-live="polite">
+      <strong>{checks.length} tool{checks.length === 1 ? '' : 's'} checked</strong>
+      <span>{changed} content/path change{changed === 1 ? '' : 's'}</span>
+      <span>{unavailable} unavailable</span>
+      <span>{signatureReview} signature state{signatureReview === 1 ? '' : 's'} to review</span>
+    </div>
+  );
+}
+
+function IntegrityCheckCard({ check }: { check: IntegrityCheck }) {
+  const current = check.observation;
+  const previous = check.previousObservation;
+
+  return (
+    <article className="integrity-check-card">
+      <header className="integrity-check-heading">
+        <div>
+          <p className="control-label">REQUESTED TOOL</p>
+          <h2>{check.requestedTool}</h2>
+        </div>
+        <span className={`integrity-status integrity-status-${check.status}`}>
+          {integrityStatusLabels[check.status]}
+        </span>
+      </header>
+
+      <div className="integrity-evidence-grid">
+        <Evidence label="Resolved path" value={current?.resolvedPath ?? 'Not resolved'} />
+        <Evidence label="Canonical target" value={current?.canonicalPath ?? 'Not available'} />
+        {current?.symlinkTarget ? <Evidence label="Symlink target" value={current.symlinkTarget} /> : null}
+        {current ? <HashEvidence label="Current SHA-256" value={current.sha256} /> : null}
+        {previous ? <HashEvidence label="Previous SHA-256" value={previous.sha256} /> : null}
+        {previous ? <Evidence label="Previous resolved path" value={previous.resolvedPath} /> : null}
+        {current ? <Evidence label="Observed at" value={current.observedAt} /> : null}
+        {current ? <Evidence label="Size" value={`${current.sizeBytes} bytes`} /> : null}
+      </div>
+
+      {check.failure ? (
+        <div className="integrity-evidence-warning">
+          <strong>{check.failure.kind}</strong>
+          <span>{check.failure.message}</span>
+        </div>
+      ) : null}
+
+      <SignatureEvidence report={check.signature} />
+    </article>
+  );
+}
+
+function SignatureEvidence({ report }: { report?: SignatureReport }) {
+  if (!report) {
+    return (
+      <div className="integrity-signature integrity-signature-none">
+        <div>
+          <p className="control-label">SIGNATURE EVIDENCE</p>
+          <p>No signature result is available because the target could not be inspected.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`integrity-signature integrity-signature-${report.status}`}>
+      <div className="integrity-signature-heading">
+        <div>
+          <p className="control-label">
+            SIGNATURE EVIDENCE · {signaturePlatformLabels[report.platform]}
+          </p>
+          <strong>{signatureStatusLabels[report.status]}</strong>
+        </div>
+        <span className={`integrity-status integrity-status-signature-${report.status}`}>
+          {signatureStatusLabels[report.status]}
+        </span>
+      </div>
+      <div className="integrity-evidence-grid">
+        {report.signer ? <Evidence label="Signer / publisher" value={report.signer} /> : null}
+        {report.teamIdentifier ? <Evidence label="Team identifier" value={report.teamIdentifier} /> : null}
+        {report.verificationCode !== undefined ? (
+          <Evidence label="Verification code" value={String(report.verificationCode)} />
+        ) : null}
+        {report.verificationMessage ? <Evidence label="Verifier message" value={report.verificationMessage} /> : null}
+      </div>
+      {report.failure ? (
+        <p className="integrity-signature-detail">
+          {report.failure.kind}: {report.failure.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function Evidence({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="integrity-evidence">
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+function HashEvidence({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="integrity-evidence">
+      <dt>{label}</dt>
+      <dd>
+        <code className="integrity-hash" title={value}>
+          {value}
+        </code>
+      </dd>
+    </div>
+  );
+}

--- a/apps/tauri/src/lib/tauri.ts
+++ b/apps/tauri/src/lib/tauri.ts
@@ -7,6 +7,8 @@ import type {
   CleanupPlanResponse,
   CleanupResultResponse,
   DeleteMode,
+  IntegrityScanOptions,
+  IntegrityScanResponse,
   LifecycleScript,
   RunOptions,
   ScanResponse,
@@ -23,6 +25,7 @@ const commands = {
   analyzeWorkspace: 'analyze_workspace',
   audit: 'audit',
   securityScan: 'security_scan',
+  integrityScan: 'integrity_scan',
   executeCleanup: 'execute_cleanup',
   refreshStorageVolume: 'refresh_storage_volume',
   loadActivityHistory: 'load_activity_history',
@@ -67,6 +70,10 @@ export function auditScripts(options: RunOptions) {
 
 export function securityScan(options: RunOptions) {
   return invoke<SecurityScanResponse>(commands.securityScan, { options });
+}
+
+export function scanExecutableIntegrity(options: IntegrityScanOptions) {
+  return invoke<IntegrityScanResponse>(commands.integrityScan, { options });
 }
 
 export function executeCleanup(

--- a/apps/tauri/src/model/categories.ts
+++ b/apps/tauri/src/model/categories.ts
@@ -119,9 +119,9 @@ export const categoryConfigs: CategoryConfig[] = [
   {
     key: 'security-executable-integrity',
     title: 'Executable Integrity',
-    description: 'Future executable integrity evidence',
+    description: 'Inspect developer-tool paths, hashes, and supported signatures',
     section: 'security',
-    availability: 'planned',
+    availability: 'available',
   },
 ];
 

--- a/apps/tauri/src/styles/style.css
+++ b/apps/tauri/src/styles/style.css
@@ -435,6 +435,376 @@ button:disabled {
   line-height: 1.5;
 }
 
+.integrity-view {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 16px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 28px 30px;
+}
+
+.integrity-heading {
+  display: flex;
+  max-width: 820px;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.integrity-heading h1 {
+  margin: 3px 0 0;
+  color: #f5f7fb;
+  font-size: 24px;
+  letter-spacing: -0.025em;
+}
+
+.integrity-heading p:last-child {
+  max-width: 720px;
+  margin: 6px 0 0;
+  color: #a3adb9;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.integrity-controls,
+.integrity-check-card {
+  max-width: 980px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 8px;
+  background: #222427;
+}
+
+.integrity-controls {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 13px;
+  padding: 15px;
+}
+
+.integrity-controls-heading,
+.integrity-scan-actions,
+.integrity-check-heading,
+.integrity-signature-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.integrity-caption {
+  margin: 5px 0 0;
+  color: #9ca7b3;
+  font-size: 11px;
+}
+
+.integrity-tool-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(115px, 1fr));
+  gap: 7px;
+}
+
+.integrity-tool-option {
+  display: flex;
+  min-height: 31px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 9px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 5px;
+  color: #cdd5dd;
+  font-size: 12px;
+}
+
+.integrity-tool-option:has(input:checked) {
+  border-color: rgba(111, 202, 235, 0.34);
+  background: rgba(71, 175, 215, 0.1);
+  color: #e5f5fb;
+}
+
+.integrity-tool-option input {
+  accent-color: #65c8e9;
+}
+
+.integrity-custom-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.integrity-custom-tool > label {
+  color: #8b96a3;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.integrity-custom-tool > div {
+  display: flex;
+  gap: 7px;
+}
+
+.integrity-custom-tool input {
+  min-width: 0;
+  flex: 1;
+  min-height: 32px;
+  padding: 0 9px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 5px;
+  outline: 0;
+  background: #1d1e21;
+  color: #e3e9ef;
+  font-size: 12px;
+}
+
+.integrity-custom-tool input:focus-visible {
+  border-color: rgba(123, 213, 255, 0.42);
+}
+
+.integrity-custom-tool > p {
+  margin: 0;
+  color: #77818d;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.integrity-scan-actions {
+  align-items: center;
+  color: #8e98a5;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.integrity-results {
+  display: flex;
+  max-width: 980px;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 12px;
+}
+
+.integrity-results > .async-state-panel {
+  max-width: none;
+}
+
+.integrity-inline-status {
+  padding: 8px 10px;
+  border: 1px solid rgba(123, 213, 255, 0.2);
+  border-radius: 5px;
+  background: rgba(71, 175, 215, 0.08);
+  color: #b4e5f5;
+  font-size: 11px;
+}
+
+.integrity-inline-status-error {
+  border-color: rgba(247, 190, 91, 0.25);
+  background: rgba(180, 117, 28, 0.08);
+  color: #f7d797;
+}
+
+.integrity-summary-strip {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px 16px;
+  min-height: 39px;
+  padding: 0 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: #222427;
+  color: #9ea8b3;
+  font-size: 11px;
+}
+
+.integrity-summary-strip strong {
+  color: #edf3f7;
+}
+
+.integrity-interpretation {
+  margin: 0;
+  color: #aeb8c3;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.integrity-baseline-note {
+  margin: -5px 0 0;
+  color: #7f8996;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.integrity-check-list {
+  display: grid;
+  gap: 10px;
+}
+
+.integrity-check-card {
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+  padding: 14px;
+}
+
+.integrity-check-heading h2 {
+  max-width: 650px;
+  margin: 5px 0 0;
+  color: #f0f4f7;
+  font-size: 16px;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.integrity-status {
+  display: inline-flex;
+  min-height: 22px;
+  align-items: center;
+  flex: 0 0 auto;
+  padding: 0 8px;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #c8d0d9;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.integrity-status-newBaseline,
+.integrity-status-unchanged,
+.integrity-status-signature-valid {
+  border-color: rgba(103, 207, 153, 0.25);
+  background: rgba(64, 172, 111, 0.11);
+  color: #b6e7cc;
+}
+
+.integrity-status-contentChanged,
+.integrity-status-resolvedPathChanged,
+.integrity-status-missing,
+.integrity-status-signature-unsigned,
+.integrity-status-signature-invalid {
+  border-color: rgba(247, 190, 91, 0.28);
+  background: rgba(205, 144, 44, 0.12);
+  color: #f4d18f;
+}
+
+.integrity-status-inspectionFailed,
+.integrity-status-signature-inspectionFailed {
+  border-color: rgba(242, 112, 112, 0.25);
+  background: rgba(180, 68, 68, 0.1);
+  color: #f2b6b6;
+}
+
+.integrity-status-signature-unsupported {
+  border-color: rgba(198, 182, 252, 0.24);
+  background: rgba(145, 112, 232, 0.1);
+  color: #d4c7ff;
+}
+
+.integrity-evidence-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 11px 16px;
+}
+
+.integrity-evidence {
+  min-width: 0;
+}
+
+.integrity-evidence dt {
+  margin: 0 0 4px;
+  color: #7f8996;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.integrity-evidence dd {
+  margin: 0;
+  color: #c9d1da;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.integrity-hash {
+  display: block;
+  color: #bceafa;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 11px;
+  line-height: 1.45;
+  user-select: text;
+  word-break: break-all;
+}
+
+.integrity-evidence-warning {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 9px 10px;
+  border: 1px solid rgba(247, 190, 91, 0.23);
+  border-radius: 5px;
+  background: rgba(180, 117, 28, 0.08);
+  color: #d8c18f;
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.integrity-evidence-warning strong {
+  color: #f4d18f;
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.integrity-signature {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 11px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.integrity-signature-heading strong {
+  display: block;
+  margin-top: 5px;
+  color: #e4ebf0;
+  font-size: 13px;
+}
+
+.integrity-signature-valid {
+  border-color: rgba(103, 207, 153, 0.17);
+}
+
+.integrity-signature-unsigned,
+.integrity-signature-invalid {
+  border-color: rgba(247, 190, 91, 0.17);
+}
+
+.integrity-signature-unsupported {
+  border-color: rgba(198, 182, 252, 0.17);
+}
+
+.integrity-signature-detail,
+.integrity-signature-none p {
+  margin: 0;
+  color: #9da8b3;
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
 .workspace-view,
 .overview-view,
 .history-view {
@@ -2070,6 +2440,19 @@ button:disabled {
 
   .overview-view {
     padding: 16px 12px 10px;
+  }
+
+  .integrity-view {
+    padding: 18px 12px 12px;
+  }
+
+  .integrity-controls-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .integrity-controls-heading .button-secondary {
+    align-self: flex-start;
   }
 
   .history-view {

--- a/apps/tauri/src/types/workflow.ts
+++ b/apps/tauri/src/types/workflow.ts
@@ -183,6 +183,83 @@ export type SecurityScanResponse = {
   historyWarning?: string;
 };
 
+export type IntegrityScanOptions = {
+  tools: string[];
+};
+
+export type IntegrityStatus =
+  | 'newBaseline'
+  | 'unchanged'
+  | 'contentChanged'
+  | 'resolvedPathChanged'
+  | 'missing'
+  | 'inspectionFailed';
+
+export type IntegrityFailureKind =
+  | 'invalidToolName'
+  | 'notFound'
+  | 'nonRegularFile'
+  | 'nonExecutable'
+  | 'unreadable'
+  | 'brokenSymlink'
+  | 'symlinkLoop'
+  | 'hashFailed';
+
+export type IntegrityFailure = {
+  kind: IntegrityFailureKind;
+  message: string;
+};
+
+export type ExecutableObservation = {
+  requestedTool: string;
+  resolvedPath: string;
+  canonicalPath: string;
+  symlinkTarget?: string;
+  sizeBytes: number;
+  sha256: string;
+  observedAt: string;
+  versionMetadata?: string;
+};
+
+export type SignatureStatus = 'valid' | 'unsigned' | 'invalid' | 'unsupported' | 'inspectionFailed';
+export type SignaturePlatform = 'macos' | 'windows' | 'linux' | 'other';
+export type SignatureFailureKind =
+  | 'platformUnsupported'
+  | 'verifierUnavailable'
+  | 'verifierFailed'
+  | 'targetMissing'
+  | 'targetUnreadable'
+  | 'targetNonRegularFile'
+  | 'targetChangedDuringVerification';
+
+export type SignatureFailure = {
+  kind: SignatureFailureKind;
+  message: string;
+};
+
+export type SignatureReport = {
+  platform: SignaturePlatform;
+  status: SignatureStatus;
+  signer?: string;
+  teamIdentifier?: string;
+  verificationMessage?: string;
+  verificationCode?: number;
+  failure?: SignatureFailure;
+};
+
+export type IntegrityCheck = {
+  requestedTool: string;
+  status: IntegrityStatus;
+  observation?: ExecutableObservation;
+  previousObservation?: ExecutableObservation;
+  failure?: IntegrityFailure;
+  signature?: SignatureReport;
+};
+
+export type IntegrityScanResponse = {
+  checks: IntegrityCheck[];
+};
+
 export type ActivityKind = 'Scan' | 'Cleanup' | 'Security';
 
 export type ActivityFailure = {

--- a/crates/core/src/integrity/macos.rs
+++ b/crates/core/src/integrity/macos.rs
@@ -243,7 +243,12 @@ mod tests {
         let report = verify(Path::new("/usr/bin/true"));
 
         assert_eq!(report.status, SignatureStatus::Valid);
-        assert_eq!(report.signer.as_deref(), Some("Software Signing"));
+        // The system authority is named "macOS Software Signing" on newer
+        // macOS releases and "Software Signing" on older releases.
+        assert!(matches!(
+            report.signer.as_deref(),
+            Some("Software Signing" | "macOS Software Signing")
+        ));
         assert!(report.team_identifier.is_none());
         assert!(report.failure.is_none());
     }


### PR DESCRIPTION
## Summary

Closes #141.

- Adds a real Security → Executable Integrity Desktop screen.
- Exposes the existing Core resolver, SHA-256 baseline, and platform signature report through the thin `integrity_scan` Tauri command.
- Supports the Core default developer-tool set, subset selection, and structured custom tool/path identifiers without launching inspected executables.
- Renders path, canonical target, current/previous hash, change state, failure details, signer metadata, and all supported signature states.
- Preserves evidence-only wording for changed hashes, unsigned/invalid signatures, and neutral Unsupported states.
- Adds stale-request and DTO/serialization regression coverage and documents the new command.
- Makes the macOS system-signing fixture portable across current and older signer names.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo llvm-cov --workspace --all-features --summary-only`
- `npm test -- --run` (in `apps/tauri`)
- `npm run build` (in `apps/tauri`)
