### PR TITLE
[FEATURE] Expose dependency inventory and baseline comparison in Desktop UI

### DIFF
--- a/apps/tauri/src-tauri/src/contract.rs
+++ b/apps/tauri/src-tauri/src/contract.rs
@@ -6,9 +6,12 @@ use std::{
 use dustfril_core::models::{
     ArtifactChangeKind, ArtifactSizeChange, ArtifactSnapshot, ArtifactSnapshotArtifact,
     ArtifactSnapshotResult, ArtifactSnapshotStatus, CleanupFailureReason, CleanupRecommendation,
-    DeleteMode, DeveloperStorageSummary, Ecosystem, LifecycleScript, LockfileCheck, LockfileKind,
-    LockfileStatus, PackageManager, ProjectIdentity, RecommendationPolicy, RiskLevel, ScriptType,
-    SecurityFinding, SecurityReport, SecurityWarning, StorageSummary, VolumeStorage,
+    DeleteMode, DependencyBaselineStatus, DependencyChange, DependencyChangeKind, DependencyDiff,
+    DependencyEntry, DependencyLockfile, DependencyLockfileStatus, DependencyMetric,
+    DependencyMetricStatus, DependencyReport, DependencyReportStatus, DependencyScope,
+    DeveloperStorageSummary, DuplicateDependency, Ecosystem, LifecycleScript, LockfileCheck,
+    LockfileKind, LockfileStatus, PackageManager, ProjectIdentity, RecommendationPolicy, RiskLevel,
+    ScriptType, SecurityFinding, SecurityReport, SecurityWarning, StorageSummary, VolumeStorage,
     DEFAULT_CLEANUP_AGE_DAYS,
 };
 use serde::{Deserialize, Serialize};
@@ -386,6 +389,136 @@ pub(crate) struct SecurityWarningDto {
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct DependencyInventoryResponse {
+    pub(crate) workspace_path: String,
+    pub(crate) reports: Vec<DependencyReportDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) diff: Option<DependencyDiffDto>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DependencyReportDto {
+    pub(crate) ecosystem: EcosystemDto,
+    pub(crate) status: DependencyReportStatusDto,
+    pub(crate) manifest: String,
+    pub(crate) manifest_format: Option<String>,
+    pub(crate) lockfile: Option<DependencyLockfileDto>,
+    pub(crate) direct_dependency_counts: std::collections::BTreeMap<String, usize>,
+    pub(crate) direct_dependency_total: usize,
+    pub(crate) resolved_dependency_count: DependencyMetricDto,
+    pub(crate) transitive_dependency_count: DependencyMetricDto,
+    pub(crate) duplicate_versions: Vec<DuplicateDependencyDto>,
+    pub(crate) resolved_dependencies: Vec<DependencyEntryDto>,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DependencyMetricDto {
+    pub(crate) value: Option<usize>,
+    pub(crate) status: DependencyMetricStatusDto,
+    pub(crate) reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DependencyLockfileDto {
+    pub(crate) path: String,
+    pub(crate) kind: Option<LockfileKindDto>,
+    pub(crate) format: Option<String>,
+    pub(crate) status: DependencyLockfileStatusDto,
+    pub(crate) reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DuplicateDependencyDto {
+    pub(crate) name: String,
+    pub(crate) versions: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DependencyEntryDto {
+    pub(crate) ecosystem: EcosystemDto,
+    pub(crate) name: String,
+    pub(crate) version: String,
+    pub(crate) source: Option<String>,
+    pub(crate) scope: DependencyScopeDto,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DependencyDiffDto {
+    pub(crate) workspace_id: String,
+    pub(crate) baseline_status: DependencyBaselineStatusDto,
+    pub(crate) added: Vec<DependencyChangeDto>,
+    pub(crate) removed: Vec<DependencyChangeDto>,
+    pub(crate) version_changes: Vec<DependencyChangeDto>,
+    pub(crate) source_changes: Vec<DependencyChangeDto>,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DependencyChangeDto {
+    pub(crate) kind: DependencyChangeKindDto,
+    pub(crate) previous: Option<DependencyEntryDto>,
+    pub(crate) current: Option<DependencyEntryDto>,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DependencyReportStatusDto {
+    Complete,
+    MissingLockfile,
+    Unsupported,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DependencyMetricStatusDto {
+    Available,
+    Unknown,
+    Unsupported,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DependencyLockfileStatusDto {
+    Parsed,
+    Missing,
+    Unsupported,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DependencyScopeDto {
+    Direct,
+    Transitive,
+    Unknown,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DependencyBaselineStatusDto {
+    BaselineCreated,
+    Compared,
+    Unavailable,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DependencyChangeKindDto {
+    Added,
+    Removed,
+    VersionChanged,
+    SourceChanged,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct LockfileCheckDto {
     pub(crate) path: String,
     pub(crate) kind: LockfileKindDto,
@@ -645,6 +778,173 @@ impl From<LockfileStatus> for LockfileStatusDto {
     }
 }
 
+pub(crate) fn dependency_inventory_to_dto(
+    workspace_path: &Path,
+    reports: Vec<DependencyReport>,
+    diff: Option<DependencyDiff>,
+) -> DependencyInventoryResponse {
+    DependencyInventoryResponse {
+        workspace_path: workspace_path.display().to_string(),
+        reports: reports.into_iter().map(Into::into).collect(),
+        diff: diff.map(Into::into),
+    }
+}
+
+impl From<DependencyReport> for DependencyReportDto {
+    fn from(report: DependencyReport) -> Self {
+        Self {
+            ecosystem: report.ecosystem.into(),
+            status: report.status.into(),
+            manifest: report.manifest.display().to_string(),
+            manifest_format: report.manifest_format,
+            lockfile: report.lockfile.map(Into::into),
+            direct_dependency_counts: report.direct_dependency_counts,
+            direct_dependency_total: report.direct_dependency_total,
+            resolved_dependency_count: report.resolved_dependency_count.into(),
+            transitive_dependency_count: report.transitive_dependency_count.into(),
+            duplicate_versions: report
+                .duplicate_versions
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            resolved_dependencies: report
+                .resolved_dependencies
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            warnings: report.warnings,
+        }
+    }
+}
+
+impl From<DependencyMetric> for DependencyMetricDto {
+    fn from(metric: DependencyMetric) -> Self {
+        Self {
+            value: metric.value,
+            status: metric.status.into(),
+            reason: metric.reason,
+        }
+    }
+}
+
+impl From<DependencyLockfile> for DependencyLockfileDto {
+    fn from(lockfile: DependencyLockfile) -> Self {
+        Self {
+            path: lockfile.path.display().to_string(),
+            kind: lockfile.kind.map(Into::into),
+            format: lockfile.format,
+            status: lockfile.status.into(),
+            reason: lockfile.reason,
+        }
+    }
+}
+
+impl From<DuplicateDependency> for DuplicateDependencyDto {
+    fn from(duplicate: DuplicateDependency) -> Self {
+        Self {
+            name: duplicate.name,
+            versions: duplicate.versions,
+        }
+    }
+}
+
+impl From<DependencyEntry> for DependencyEntryDto {
+    fn from(entry: DependencyEntry) -> Self {
+        Self {
+            ecosystem: entry.ecosystem.into(),
+            name: entry.name,
+            version: entry.version,
+            source: entry.source,
+            scope: entry.scope.into(),
+        }
+    }
+}
+
+impl From<DependencyDiff> for DependencyDiffDto {
+    fn from(diff: DependencyDiff) -> Self {
+        Self {
+            workspace_id: diff.workspace_id,
+            baseline_status: diff.baseline_status.into(),
+            added: diff.added.into_iter().map(Into::into).collect(),
+            removed: diff.removed.into_iter().map(Into::into).collect(),
+            version_changes: diff.version_changes.into_iter().map(Into::into).collect(),
+            source_changes: diff.source_changes.into_iter().map(Into::into).collect(),
+            warnings: diff.warnings,
+        }
+    }
+}
+
+impl From<DependencyChange> for DependencyChangeDto {
+    fn from(change: DependencyChange) -> Self {
+        Self {
+            kind: change.kind.into(),
+            previous: change.previous.map(Into::into),
+            current: change.current.map(Into::into),
+        }
+    }
+}
+
+impl From<DependencyReportStatus> for DependencyReportStatusDto {
+    fn from(status: DependencyReportStatus) -> Self {
+        match status {
+            DependencyReportStatus::Complete => Self::Complete,
+            DependencyReportStatus::MissingLockfile => Self::MissingLockfile,
+            DependencyReportStatus::Unsupported => Self::Unsupported,
+        }
+    }
+}
+
+impl From<DependencyMetricStatus> for DependencyMetricStatusDto {
+    fn from(status: DependencyMetricStatus) -> Self {
+        match status {
+            DependencyMetricStatus::Available => Self::Available,
+            DependencyMetricStatus::Unknown => Self::Unknown,
+            DependencyMetricStatus::Unsupported => Self::Unsupported,
+        }
+    }
+}
+
+impl From<DependencyLockfileStatus> for DependencyLockfileStatusDto {
+    fn from(status: DependencyLockfileStatus) -> Self {
+        match status {
+            DependencyLockfileStatus::Parsed => Self::Parsed,
+            DependencyLockfileStatus::Missing => Self::Missing,
+            DependencyLockfileStatus::Unsupported => Self::Unsupported,
+        }
+    }
+}
+
+impl From<DependencyScope> for DependencyScopeDto {
+    fn from(scope: DependencyScope) -> Self {
+        match scope {
+            DependencyScope::Direct => Self::Direct,
+            DependencyScope::Transitive => Self::Transitive,
+            DependencyScope::Unknown => Self::Unknown,
+        }
+    }
+}
+
+impl From<DependencyBaselineStatus> for DependencyBaselineStatusDto {
+    fn from(status: DependencyBaselineStatus) -> Self {
+        match status {
+            DependencyBaselineStatus::BaselineCreated => Self::BaselineCreated,
+            DependencyBaselineStatus::Compared => Self::Compared,
+            DependencyBaselineStatus::Unavailable => Self::Unavailable,
+        }
+    }
+}
+
+impl From<DependencyChangeKind> for DependencyChangeKindDto {
+    fn from(kind: DependencyChangeKind) -> Self {
+        match kind {
+            DependencyChangeKind::Added => Self::Added,
+            DependencyChangeKind::Removed => Self::Removed,
+            DependencyChangeKind::VersionChanged => Self::VersionChanged,
+            DependencyChangeKind::SourceChanged => Self::SourceChanged,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use dustfril_core::models::AnalysisResult;
@@ -704,6 +1004,34 @@ mod tests {
         .unwrap();
         assert_eq!(refresh_options.record_history, Some(false));
         assert_eq!(refresh_options.record_artifact_snapshot, Some(false));
+    }
+
+    #[test]
+    fn dependency_inventory_wire_format_preserves_availability_and_baseline_state() {
+        let response = dependency_inventory_to_dto(
+            Path::new("/workspace"),
+            vec![DependencyReport::unsupported(
+                Ecosystem::Node,
+                Path::new("/workspace/package.json").to_path_buf(),
+                "unsupported package manager",
+            )],
+            Some(DependencyDiff::empty(
+                "v1:/workspace",
+                DependencyBaselineStatus::Unavailable,
+            )),
+        );
+
+        let value = serde_json::to_value(response).unwrap();
+        assert_eq!(value["workspacePath"], "/workspace");
+        assert_eq!(value["reports"][0]["ecosystem"], "Node");
+        assert_eq!(value["reports"][0]["status"], "unsupported");
+        assert_eq!(
+            value["reports"][0]["resolvedDependencyCount"]["status"],
+            "unsupported"
+        );
+        assert_eq!(value["diff"]["workspaceId"], "v1:/workspace");
+        assert_eq!(value["diff"]["baselineStatus"], "unavailable");
+        assert!(value["diff"]["added"].as_array().unwrap().is_empty());
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/contract.rs
+++ b/apps/tauri/src-tauri/src/contract.rs
@@ -40,6 +40,14 @@ impl RunOptions {
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DependencyBaselineAcceptOptions {
+    pub(crate) root: Option<String>,
+    pub(crate) ecosystems: Vec<EcosystemDto>,
+    pub(crate) expected_inventory_fingerprint: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(crate) struct ExecuteCleanupRequest {
     pub(crate) root: String,
     pub(crate) ecosystems: Vec<EcosystemDto>,
@@ -390,6 +398,7 @@ pub(crate) struct SecurityWarningDto {
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DependencyInventoryResponse {
+    pub(crate) inventory_fingerprint: String,
     pub(crate) workspace_path: String,
     pub(crate) reports: Vec<DependencyReportDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -782,8 +791,10 @@ pub(crate) fn dependency_inventory_to_dto(
     workspace_path: &Path,
     reports: Vec<DependencyReport>,
     diff: Option<DependencyDiff>,
+    inventory_fingerprint: String,
 ) -> DependencyInventoryResponse {
     DependencyInventoryResponse {
+        inventory_fingerprint,
         workspace_path: workspace_path.display().to_string(),
         reports: reports.into_iter().map(Into::into).collect(),
         diff: diff.map(Into::into),
@@ -1019,9 +1030,11 @@ mod tests {
                 "v1:/workspace",
                 DependencyBaselineStatus::Unavailable,
             )),
+            "fingerprint-1".to_owned(),
         );
 
         let value = serde_json::to_value(response).unwrap();
+        assert_eq!(value["inventoryFingerprint"], "fingerprint-1");
         assert_eq!(value["workspacePath"], "/workspace");
         assert_eq!(value["reports"][0]["ecosystem"], "Node");
         assert_eq!(value["reports"][0]["status"], "unsupported");
@@ -1032,6 +1045,19 @@ mod tests {
         assert_eq!(value["diff"]["workspaceId"], "v1:/workspace");
         assert_eq!(value["diff"]["baselineStatus"], "unavailable");
         assert!(value["diff"]["added"].as_array().unwrap().is_empty());
+
+        let accept_options: DependencyBaselineAcceptOptions = serde_json::from_value(json!({
+            "root": "/workspace",
+            "ecosystems": ["Node"],
+            "expectedInventoryFingerprint": "fingerprint-1"
+        }))
+        .unwrap();
+        assert_eq!(accept_options.root.as_deref(), Some("/workspace"));
+        assert_eq!(accept_options.ecosystems, vec![EcosystemDto::Node]);
+        assert_eq!(
+            accept_options.expected_inventory_fingerprint,
+            "fingerprint-1"
+        );
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -20,14 +20,14 @@ use contract::{
     project_identity_to_dto, storage_summary_to_dto, volume_storage_to_dto, AnalysisResponse,
     ArtifactAnalysisDto, ArtifactDto, CleanupCandidateDto, CleanupFailureDto,
     CleanupHistoryEntryDto, CleanupPlanResponse, CleanupResultResponse,
-    DependencyInventoryResponse, ExecuteCleanupRequest, LifecycleScriptDto, RunOptions,
-    ScanResponse, SecurityScanResponse, StorageSummaryDto, VolumeStorageDto,
-    WorkspaceAnalysisResponse,
+    DependencyBaselineAcceptOptions, DependencyInventoryResponse, ExecuteCleanupRequest,
+    LifecycleScriptDto, RunOptions, ScanResponse, SecurityScanResponse, StorageSummaryDto,
+    VolumeStorageDto, WorkspaceAnalysisResponse,
 };
 use dustfril_core::{
     api,
     error::DustError,
-    models::{AnalysisResult, ArtifactAnalysis, ArtifactSelection, Ecosystem},
+    models::{AnalysisResult, ArtifactAnalysis, ArtifactSelection, DependencyReport, Ecosystem},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -152,6 +152,22 @@ fn discover_workspace_root(start: &Path) -> Option<PathBuf> {
 fn default_root_path() -> Result<PathBuf, String> {
     let current_dir = env::current_dir().map_err(|error| error.to_string())?;
     Ok(discover_workspace_root(&current_dir).unwrap_or(current_dir))
+}
+
+fn verify_dependency_inventory_fingerprint(
+    reports: &[DependencyReport],
+    expected: &str,
+) -> Result<String, String> {
+    let actual =
+        api::dependency_inventory_fingerprint(reports).map_err(|error| error.to_string())?;
+    if actual != expected {
+        return Err(
+            "Dependency inventory changed since it was reviewed. Compare again before accepting the baseline."
+                .to_owned(),
+        );
+    }
+
+    Ok(actual)
 }
 
 fn system_time_to_ms(value: std::time::SystemTime) -> Option<u64> {
@@ -566,7 +582,14 @@ async fn load_dependency_inventory(
     tokio::task::spawn_blocking(move || {
         let reports =
             api::dependency_report(&root, &ecosystems).map_err(|error| error.to_string())?;
-        Ok(dependency_inventory_to_dto(&root, reports, None))
+        let inventory_fingerprint =
+            api::dependency_inventory_fingerprint(&reports).map_err(|error| error.to_string())?;
+        Ok(dependency_inventory_to_dto(
+            &root,
+            reports,
+            None,
+            inventory_fingerprint,
+        ))
     })
     .await
     .map_err(|error| error.to_string())?
@@ -585,7 +608,14 @@ async fn compare_dependency_baseline(
             api::dependency_report(&root, &ecosystems).map_err(|error| error.to_string())?;
         let diff = api::dependency_diff(&root, &reports, &baseline_path)
             .map_err(|error| error.to_string())?;
-        Ok(dependency_inventory_to_dto(&root, reports, Some(diff)))
+        let inventory_fingerprint =
+            api::dependency_inventory_fingerprint(&reports).map_err(|error| error.to_string())?;
+        Ok(dependency_inventory_to_dto(
+            &root,
+            reports,
+            Some(diff),
+            inventory_fingerprint,
+        ))
     })
     .await
     .map_err(|error| error.to_string())?
@@ -593,20 +623,28 @@ async fn compare_dependency_baseline(
 
 #[tauri::command]
 async fn accept_dependency_baseline(
-    options: RunOptions,
+    options: DependencyBaselineAcceptOptions,
 ) -> Result<DependencyInventoryResponse, String> {
     let root = resolve_root(options.root)?;
     let ecosystems: Vec<_> = options.ecosystems.into_iter().map(Into::into).collect();
+    let expected_inventory_fingerprint = options.expected_inventory_fingerprint;
     let baseline_path = api::dependency_baseline_path().map_err(|error| error.to_string())?;
 
     tokio::task::spawn_blocking(move || {
         let reports =
             api::dependency_report(&root, &ecosystems).map_err(|error| error.to_string())?;
+        let inventory_fingerprint =
+            verify_dependency_inventory_fingerprint(&reports, &expected_inventory_fingerprint)?;
         api::accept_dependency_baseline(&root, &reports, &baseline_path)
             .map_err(|error| error.to_string())?;
         let diff = api::dependency_diff(&root, &reports, &baseline_path)
             .map_err(|error| error.to_string())?;
-        Ok(dependency_inventory_to_dto(&root, reports, Some(diff)))
+        Ok(dependency_inventory_to_dto(
+            &root,
+            reports,
+            Some(diff),
+            inventory_fingerprint,
+        ))
     })
     .await
     .map_err(|error| error.to_string())?
@@ -787,5 +825,28 @@ mod tests {
 
         assert!(snapshot.is_none());
         assert!(warning.is_none());
+    }
+
+    #[test]
+    fn dependency_acceptance_rejects_an_inventory_that_changed_after_review() {
+        let original = DependencyReport::unsupported(
+            Ecosystem::Node,
+            PathBuf::from("/workspace/package.json"),
+            "unsupported package manager",
+        );
+        let expected =
+            api::dependency_inventory_fingerprint(std::slice::from_ref(&original)).unwrap();
+        let mut changed = original;
+        changed.warnings.push("changed after review".to_owned());
+
+        assert!(
+            verify_dependency_inventory_fingerprint(std::slice::from_ref(&changed), &expected,)
+                .is_err()
+        );
+        assert_eq!(
+            verify_dependency_inventory_fingerprint(std::slice::from_ref(&changed), &expected)
+                .unwrap_err(),
+            "Dependency inventory changed since it was reviewed. Compare again before accepting the baseline."
+        );
     }
 }

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -16,11 +16,12 @@ use std::{
 };
 
 use contract::{
-    artifact_path, artifact_snapshot_to_dto, cleanup_failure_reason, project_identity_to_dto,
-    storage_summary_to_dto, volume_storage_to_dto, AnalysisResponse, ArtifactAnalysisDto,
-    ArtifactDto, CleanupCandidateDto, CleanupFailureDto, CleanupHistoryEntryDto,
-    CleanupPlanResponse, CleanupResultResponse, ExecuteCleanupRequest, LifecycleScriptDto,
-    RunOptions, ScanResponse, SecurityScanResponse, StorageSummaryDto, VolumeStorageDto,
+    artifact_path, artifact_snapshot_to_dto, cleanup_failure_reason, dependency_inventory_to_dto,
+    project_identity_to_dto, storage_summary_to_dto, volume_storage_to_dto, AnalysisResponse,
+    ArtifactAnalysisDto, ArtifactDto, CleanupCandidateDto, CleanupFailureDto,
+    CleanupHistoryEntryDto, CleanupPlanResponse, CleanupResultResponse,
+    DependencyInventoryResponse, ExecuteCleanupRequest, LifecycleScriptDto, RunOptions,
+    ScanResponse, SecurityScanResponse, StorageSummaryDto, VolumeStorageDto,
     WorkspaceAnalysisResponse,
 };
 use dustfril_core::{
@@ -556,6 +557,62 @@ async fn load_cleanup_history() -> Result<Vec<CleanupHistoryEntryDto>, String> {
 }
 
 #[tauri::command]
+async fn load_dependency_inventory(
+    options: RunOptions,
+) -> Result<DependencyInventoryResponse, String> {
+    let root = resolve_root(options.root)?;
+    let ecosystems: Vec<_> = options.ecosystems.into_iter().map(Into::into).collect();
+
+    tokio::task::spawn_blocking(move || {
+        let reports =
+            api::dependency_report(&root, &ecosystems).map_err(|error| error.to_string())?;
+        Ok(dependency_inventory_to_dto(&root, reports, None))
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
+async fn compare_dependency_baseline(
+    options: RunOptions,
+) -> Result<DependencyInventoryResponse, String> {
+    let root = resolve_root(options.root)?;
+    let ecosystems: Vec<_> = options.ecosystems.into_iter().map(Into::into).collect();
+    let baseline_path = api::dependency_baseline_path().map_err(|error| error.to_string())?;
+
+    tokio::task::spawn_blocking(move || {
+        let reports =
+            api::dependency_report(&root, &ecosystems).map_err(|error| error.to_string())?;
+        let diff = api::dependency_diff(&root, &reports, &baseline_path)
+            .map_err(|error| error.to_string())?;
+        Ok(dependency_inventory_to_dto(&root, reports, Some(diff)))
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
+async fn accept_dependency_baseline(
+    options: RunOptions,
+) -> Result<DependencyInventoryResponse, String> {
+    let root = resolve_root(options.root)?;
+    let ecosystems: Vec<_> = options.ecosystems.into_iter().map(Into::into).collect();
+    let baseline_path = api::dependency_baseline_path().map_err(|error| error.to_string())?;
+
+    tokio::task::spawn_blocking(move || {
+        let reports =
+            api::dependency_report(&root, &ecosystems).map_err(|error| error.to_string())?;
+        api::accept_dependency_baseline(&root, &reports, &baseline_path)
+            .map_err(|error| error.to_string())?;
+        let diff = api::dependency_diff(&root, &reports, &baseline_path)
+            .map_err(|error| error.to_string())?;
+        Ok(dependency_inventory_to_dto(&root, reports, Some(diff)))
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
 async fn audit(options: RunOptions) -> Result<Vec<LifecycleScriptDto>, String> {
     let root = resolve_root(options.root)?;
     let ecosystems: Vec<_> = options.ecosystems.into_iter().map(Into::into).collect();
@@ -616,6 +673,9 @@ pub fn run() {
             load_activity_history,
             clear_activity_history,
             load_cleanup_history,
+            load_dependency_inventory,
+            compare_dependency_baseline,
+            accept_dependency_baseline,
             audit,
             security_scan
         ])

--- a/apps/tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.test.tsx
@@ -63,7 +63,7 @@ describe('AppShell Overview navigation', () => {
     ['Node.js', false],
     ['Java', false],
     ['Cache', true],
-    ['Dependencies', true],
+    ['Dependencies', false],
     ['Artifact History', true],
     ['Activity', false],
     ['Supply Chain', true],

--- a/apps/tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.tsx
@@ -5,6 +5,7 @@ import { pathBreadcrumb } from '../../model/presentation';
 import { AppHeader } from './components/AppHeader';
 import { useAppState } from './hooks/useAppState';
 import { HistoryView } from './views/HistoryView';
+import { DependenciesView } from './views/DependenciesView';
 import { ModulePlaceholderView } from './views/ModulePlaceholderView';
 import { OverviewView } from './views/OverviewView';
 import { WorkspaceView } from './views/WorkspaceView';
@@ -14,6 +15,7 @@ export function AppShell() {
   const activeConfig = categoryConfig(app.activeCategory);
   const showingCleanup = activeConfig?.ecosystem !== undefined;
   const showingWorkspace = app.activeCategory === 'workspace' || showingCleanup;
+  const showingDependencies = app.activeCategory === 'workspace-dependencies';
   const showingActivity =
     app.activeCategory === 'history' || app.activeCategory === 'workspace-activity';
 
@@ -85,7 +87,24 @@ export function AppShell() {
             />
           ) : null}
 
-          {app.activeCategory !== 'overview' && !showingWorkspace && !showingActivity && activeConfig ? (
+          {showingDependencies ? (
+            <DependenciesView
+              root={app.root}
+              result={app.dependencyResult}
+              operationStatus={app.dependencyOperation.status}
+              busy={app.busyAction !== null}
+              error={app.error}
+              onLoad={app.handleLoadDependencyInventory}
+              onCompare={app.handleCompareDependencyBaseline}
+              onAccept={app.handleAcceptDependencyBaseline}
+            />
+          ) : null}
+
+          {app.activeCategory !== 'overview' &&
+          !showingWorkspace &&
+          !showingActivity &&
+          !showingDependencies &&
+          activeConfig ? (
             <ModulePlaceholderView
               config={activeConfig}
               onReturnToOverview={() => app.setActiveCategory('overview')}

--- a/apps/tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useAppState.ts
@@ -2,10 +2,13 @@ import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { formatBytes } from '../../../lib/format';
 import {
   analyzeWorkspace,
+  acceptDependencyBaseline,
   chooseWorkspaceFolder,
+  compareDependencyBaseline,
   clearActivityHistory,
   defaultRoot,
   executeCleanup,
+  loadDependencyInventory,
   loadActivityHistory,
   refreshStorageVolume,
 } from '../../../lib/tauri';
@@ -21,6 +24,7 @@ import type {
   CleanupPlanResponse,
   CleanupResultResponse,
   DeleteMode,
+  DependencyInventoryResponse,
   StorageSummary,
   VolumeStorage,
 } from '../../../types/workflow';
@@ -44,6 +48,7 @@ export function useAppState() {
   const [analysisResult, setAnalysisResult] = useState<AnalysisResponse | null>(null);
   const [cleanupPlan, setCleanupPlan] = useState<CleanupPlanResponse | null>(null);
   const [storageSummary, setStorageSummary] = useState<StorageSummary | null>(null);
+  const [dependencyResult, setDependencyResult] = useState<DependencyInventoryResponse | null>(null);
   const [historyEntries, setHistoryEntries] = useState<ActivityRecord[]>([]);
   const [selectedCleanupPaths, setSelectedCleanupPaths] = useState<string[]>([]);
   const [cleanupReviewPaths, setCleanupReviewPaths] = useState<string[]>([]);
@@ -53,7 +58,12 @@ export function useAppState() {
     reduceAsyncOperation<WorkspaceAnalysisResponse>,
     idleAsyncOperation<WorkspaceAnalysisResponse>(),
   );
+  const [dependencyOperation, dispatchDependencyOperation] = useReducer(
+    reduceAsyncOperation<DependencyInventoryResponse>,
+    idleAsyncOperation<DependencyInventoryResponse>(),
+  );
   const workspaceRequestRef = useRef(0);
+  const dependencyRequestRef = useRef(0);
   const actionRequestRef = useRef(0);
 
   useEffect(() => {
@@ -150,6 +160,12 @@ export function useAppState() {
       requestId: workspaceRequestRef.current,
     });
     actionRequestRef.current += 1;
+    dependencyRequestRef.current += 1;
+    dispatchDependencyOperation({
+      type: 'invalidate',
+      requestId: dependencyRequestRef.current,
+    });
+    setDependencyResult(null);
     setRoot(nextRoot);
     setError(null);
     setAnalysisResult(null);
@@ -272,6 +288,61 @@ export function useAppState() {
     }
 
     await analyzeWorkspaceWithPolicy(nextAgeDays, false, false);
+  }
+
+  async function runDependencyAction(
+    action: string,
+    operation: () => Promise<DependencyInventoryResponse>,
+  ) {
+    if (busyAction !== null || !root) {
+      return;
+    }
+
+    const requestId = ++dependencyRequestRef.current;
+    setBusyAction(action);
+    setError(null);
+    dispatchDependencyOperation({ type: 'start', requestId });
+
+    try {
+      const response = await operation();
+      if (requestId !== dependencyRequestRef.current) {
+        return;
+      }
+
+      setDependencyResult(response);
+      dispatchDependencyOperation({ type: 'success', requestId, data: response });
+    } catch (invokeError) {
+      if (requestId === dependencyRequestRef.current) {
+        dispatchDependencyOperation({
+          type: 'error',
+          requestId,
+          error: String(invokeError),
+        });
+        setError(String(invokeError));
+      }
+    } finally {
+      if (requestId === dependencyRequestRef.current) {
+        setBusyAction(null);
+      }
+    }
+  }
+
+  async function handleLoadDependencyInventory() {
+    await runDependencyAction('dependency-load', () =>
+      loadDependencyInventory({ root, ecosystems: ['Node', 'Rust'] }),
+    );
+  }
+
+  async function handleCompareDependencyBaseline() {
+    await runDependencyAction('dependency-compare', () =>
+      compareDependencyBaseline({ root, ecosystems: ['Node', 'Rust'] }),
+    );
+  }
+
+  async function handleAcceptDependencyBaseline() {
+    await runDependencyAction('dependency-accept', () =>
+      acceptDependencyBaseline({ root, ecosystems: ['Node', 'Rust'] }),
+    );
   }
 
   async function handleClearHistory() {
@@ -452,6 +523,7 @@ export function useAppState() {
     analysisResult,
     cleanupPlan,
     storageSummary,
+    dependencyResult,
     selectedCleanupItems: cleanupReviewItems,
     selectedCleanupPaths,
     selectedCandidateBytes: cleanupReviewTotalBytes,
@@ -462,6 +534,7 @@ export function useAppState() {
     confirmDialogOpen,
     confirmSamplePaths,
     workspaceOperation,
+    dependencyOperation,
     canAnalyze,
     canReviewCleanup,
     summary,
@@ -477,6 +550,9 @@ export function useAppState() {
     handleChooseWorkspace,
     handleAnalyzeWorkspace,
     handleCleanupAgeChange,
+    handleLoadDependencyInventory,
+    handleCompareDependencyBaseline,
+    handleAcceptDependencyBaseline,
     handleClearHistory,
     handleRequestCleanup,
     handleConfirmCleanup,

--- a/apps/tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useAppState.ts
@@ -340,8 +340,16 @@ export function useAppState() {
   }
 
   async function handleAcceptDependencyBaseline() {
+    if (!dependencyResult) {
+      return;
+    }
+
     await runDependencyAction('dependency-accept', () =>
-      acceptDependencyBaseline({ root, ecosystems: ['Node', 'Rust'] }),
+      acceptDependencyBaseline({
+        root,
+        ecosystems: ['Node', 'Rust'],
+        expectedInventoryFingerprint: dependencyResult.inventoryFingerprint,
+      }),
     );
   }
 

--- a/apps/tauri/src/features/app-shell/views/DependenciesView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/DependenciesView.test.tsx
@@ -156,6 +156,7 @@ const diff: DependencyDiff = {
 };
 
 const result: DependencyInventoryResponse = {
+  inventoryFingerprint: 'fingerprint-1',
   workspacePath: '/workspace',
   reports: [nodeReport, incompleteRustReport],
   diff: null,

--- a/apps/tauri/src/features/app-shell/views/DependenciesView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/DependenciesView.test.tsx
@@ -1,0 +1,291 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { DependenciesView } from './DependenciesView';
+import type {
+  DependencyDiff,
+  DependencyInventoryResponse,
+  DependencyReport,
+} from '../../../types/workflow';
+
+function metric(value: number | null, status: 'available' | 'unknown' | 'unsupported', reason: string | null = null) {
+  return { value, status, reason };
+}
+
+const nodeReport: DependencyReport = {
+  ecosystem: 'Node',
+  status: 'complete',
+  manifest: '/workspace/package.json',
+  manifestFormat: 'package.json',
+  lockfile: {
+    path: '/workspace/package-lock.json',
+    kind: 'PackageLockJson',
+    format: 'package-lock.json',
+    status: 'parsed',
+    reason: null,
+  },
+  directDependencyCounts: {
+    dependencies: 1,
+    devDependencies: 1,
+    optionalDependencies: 0,
+    peerDependencies: 0,
+  },
+  directDependencyTotal: 2,
+  resolvedDependencyCount: metric(3, 'available'),
+  transitiveDependencyCount: metric(1, 'available'),
+  duplicateVersions: [{ name: 'shared', versions: ['1.0.0', '2.0.0'] }],
+  resolvedDependencies: [
+    {
+      ecosystem: 'Node',
+      name: 'shared',
+      version: '1.0.0',
+      source: 'https://registry.npmjs.org/shared',
+      scope: 'direct',
+    },
+    {
+      ecosystem: 'Node',
+      name: 'shared',
+      version: '2.0.0',
+      source: null,
+      scope: 'transitive',
+    },
+  ],
+  warnings: [],
+};
+
+const incompleteRustReport: DependencyReport = {
+  ecosystem: 'Rust',
+  status: 'missingLockfile',
+  manifest: '/workspace/Cargo.toml',
+  manifestFormat: 'Cargo.toml',
+  lockfile: {
+    path: '/workspace/Cargo.lock',
+    kind: 'CargoLock',
+    format: 'Cargo.lock',
+    status: 'missing',
+    reason: 'Cargo.lock is missing',
+  },
+  directDependencyCounts: {
+    dependencies: 1,
+    'dev-dependencies': 0,
+    'build-dependencies': 0,
+  },
+  directDependencyTotal: 1,
+  resolvedDependencyCount: metric(null, 'unknown', 'Cargo.lock is missing'),
+  transitiveDependencyCount: metric(null, 'unknown', 'Cargo.lock is missing'),
+  duplicateVersions: [],
+  resolvedDependencies: [],
+  warnings: ['Cargo.lock is missing'],
+};
+
+const unsupportedReport: DependencyReport = {
+  ecosystem: 'Rust',
+  status: 'unsupported',
+  manifest: '/workspace/Cargo.toml',
+  manifestFormat: 'Cargo.toml',
+  lockfile: null,
+  directDependencyCounts: {},
+  directDependencyTotal: 0,
+  resolvedDependencyCount: metric(null, 'unsupported', 'Cargo workspaces are not supported'),
+  transitiveDependencyCount: metric(null, 'unsupported', 'Cargo workspaces are not supported'),
+  duplicateVersions: [],
+  resolvedDependencies: [],
+  warnings: ['Cargo workspaces are not supported'],
+};
+
+const diff: DependencyDiff = {
+  workspaceId: 'v1:/workspace',
+  baselineStatus: 'compared',
+  added: [{
+    kind: 'added',
+    previous: null,
+    current: {
+      ecosystem: 'Node',
+      name: 'added-package',
+      version: '1.0.0',
+      source: null,
+      scope: 'direct',
+    },
+  }],
+  removed: [{
+    kind: 'removed',
+    previous: {
+      ecosystem: 'Node',
+      name: 'removed-package',
+      version: '1.0.0',
+      source: null,
+      scope: 'transitive',
+    },
+    current: null,
+  }],
+  versionChanges: [{
+    kind: 'versionChanged',
+    previous: {
+      ecosystem: 'Node',
+      name: 'versioned-package',
+      version: '1.0.0',
+      source: null,
+      scope: 'direct',
+    },
+    current: {
+      ecosystem: 'Node',
+      name: 'versioned-package',
+      version: '2.0.0',
+      source: null,
+      scope: 'direct',
+    },
+  }],
+  sourceChanges: [{
+    kind: 'sourceChanged',
+    previous: {
+      ecosystem: 'Node',
+      name: 'source-package',
+      version: '1.0.0',
+      source: 'registry-a',
+      scope: 'transitive',
+    },
+    current: {
+      ecosystem: 'Node',
+      name: 'source-package',
+      version: '1.0.0',
+      source: 'registry-b',
+      scope: 'transitive',
+    },
+  }],
+  warnings: [],
+};
+
+const result: DependencyInventoryResponse = {
+  workspacePath: '/workspace',
+  reports: [nodeReport, incompleteRustReport],
+  diff: null,
+};
+
+function renderView(overrides: Partial<ComponentProps<typeof DependenciesView>> = {}) {
+  return render(
+    <DependenciesView
+      root="/workspace"
+      result={result}
+      operationStatus="success"
+      busy={false}
+      error={null}
+      onLoad={vi.fn()}
+      onCompare={vi.fn()}
+      onAccept={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe('DependenciesView', () => {
+  it('renders category counts, duplicate versions, scopes, and unavailable metrics faithfully', () => {
+    renderView();
+
+    expect(screen.getByRole('heading', { name: 'Dependencies' })).toBeInTheDocument();
+    expect(screen.getAllByText('dependencies').length).toBeGreaterThan(0);
+    expect(screen.getByText('devDependencies')).toBeInTheDocument();
+    expect(screen.getAllByText('Duplicate resolved versions').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('shared').length).toBeGreaterThan(0);
+    expect(screen.getByText('1.0.0 · 2.0.0')).toBeInTheDocument();
+    expect(screen.getAllByText('Direct').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Transitive').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Unknown').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Cargo.lock is missing').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Resolved packages').length).toBeGreaterThan(0);
+  });
+
+  it('renders all factual baseline change groups and keeps comparison context visible', () => {
+    renderView({ result: { ...result, diff } });
+
+    expect(screen.getByText('Baseline comparison')).toBeInTheDocument();
+    expect(screen.getByText('v1:/workspace')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Added' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Removed' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Version changed' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Source changed' })).toBeInTheDocument();
+    expect(screen.getByText('added-package')).toBeInTheDocument();
+    expect(screen.getByText('removed-package')).toBeInTheDocument();
+    expect(screen.getByText('1.0.0 → 2.0.0')).toBeInTheDocument();
+    expect(screen.getByText(/1\.0\.0 · registry-a/)).toBeInTheDocument();
+    expect(screen.getByText(/1\.0\.0 · registry-b/)).toBeInTheDocument();
+    expect(screen.getByText(/Compare does not update the accepted baseline/)).toBeInTheDocument();
+  });
+
+  it('requires deliberate actions and does not compare or accept while rendering', () => {
+    const onLoad = vi.fn();
+    const onCompare = vi.fn();
+    const onAccept = vi.fn();
+    renderView({ onLoad, onCompare, onAccept });
+
+    expect(onLoad).not.toHaveBeenCalled();
+    expect(onCompare).not.toHaveBeenCalled();
+    expect(onAccept).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load Inventory' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Compare Baseline' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Accept Baseline' }));
+
+    expect(onLoad).toHaveBeenCalledOnce();
+    expect(onCompare).toHaveBeenCalledOnce();
+    expect(onAccept).toHaveBeenCalledOnce();
+  });
+
+  it('does not turn malformed input into a clean empty inventory', () => {
+    renderView({
+      result: null,
+      operationStatus: 'error',
+      error: 'malformed package-lock.json',
+    });
+
+    expect(screen.getByRole('heading', { name: 'Dependency inventory failed' })).toBeInTheDocument();
+    expect(screen.getAllByText('malformed package-lock.json').length).toBeGreaterThan(0);
+    expect(screen.queryByText('No logical dependency changes detected.')).not.toBeInTheDocument();
+    expect(screen.queryByText('0 dependencies')).not.toBeInTheDocument();
+  });
+
+  it('renders unsupported reports separately from missing lockfiles', () => {
+    renderView({ result: { ...result, reports: [unsupportedReport] } });
+
+    expect(screen.getByRole('heading', { name: 'Unsupported' })).toBeInTheDocument();
+    expect(screen.getAllByText('Cargo workspaces are not supported').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Missing lockfile')).not.toBeInTheDocument();
+  });
+
+  it('keeps first-observation and unavailable baseline states explicit', () => {
+    const firstObservation = renderView({
+      result: {
+        ...result,
+        diff: {
+          ...diff,
+          baselineStatus: 'baselineCreated',
+          added: [],
+          removed: [],
+          versionChanges: [],
+          sourceChanges: [],
+        },
+      },
+    });
+
+    expect(screen.getByText(/first complete observation established the baseline/)).toBeInTheDocument();
+    expect(screen.getByText('No logical dependency changes detected.')).toBeInTheDocument();
+    firstObservation.unmount();
+
+    renderView({
+      result: {
+        ...result,
+        reports: [incompleteRustReport],
+        diff: {
+          ...diff,
+          baselineStatus: 'unavailable',
+          added: [],
+          removed: [],
+          versionChanges: [],
+          sourceChanges: [],
+        },
+      },
+    });
+
+    expect(screen.getByText(/Comparison is unavailable/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Accept Baseline' })).toBeDisabled();
+  });
+});

--- a/apps/tauri/src/features/app-shell/views/DependenciesView.tsx
+++ b/apps/tauri/src/features/app-shell/views/DependenciesView.tsx
@@ -23,7 +23,8 @@ type DependenciesViewProps = {
 
 export function DependenciesView(props: DependenciesViewProps) {
   const completeReportAvailable = Boolean(
-    props.result?.reports.some((report) => report.status === 'complete'),
+    props.result?.inventoryFingerprint &&
+      props.result.reports.some((report) => report.status === 'complete'),
   );
 
   return (

--- a/apps/tauri/src/features/app-shell/views/DependenciesView.tsx
+++ b/apps/tauri/src/features/app-shell/views/DependenciesView.tsx
@@ -1,0 +1,424 @@
+import { AsyncStatePanel } from '../../../components/AsyncStatePanel/AsyncStatePanel';
+import { formatCount } from '../../../lib/format';
+import type { AsyncOperationStatus } from '../../../model/async';
+import type {
+  DependencyChange,
+  DependencyDiff,
+  DependencyEntry,
+  DependencyInventoryResponse,
+  DependencyMetric,
+  DependencyReport,
+} from '../../../types/workflow';
+
+type DependenciesViewProps = {
+  root: string;
+  result: DependencyInventoryResponse | null;
+  operationStatus: AsyncOperationStatus;
+  busy: boolean;
+  error: string | null;
+  onLoad: () => void | Promise<void>;
+  onCompare: () => void | Promise<void>;
+  onAccept: () => void | Promise<void>;
+};
+
+export function DependenciesView(props: DependenciesViewProps) {
+  const completeReportAvailable = Boolean(
+    props.result?.reports.some((report) => report.status === 'complete'),
+  );
+
+  return (
+    <div className="dependencies-view">
+      <div className="dependencies-heading">
+        <div>
+          <p className="eyebrow">Workspace</p>
+          <h1>Dependencies</h1>
+          <p className="dependencies-heading-path" title={props.root}>
+            {props.root || 'No workspace selected'}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="button-secondary"
+          onClick={() => void props.onLoad()}
+          disabled={props.busy || !props.root}
+        >
+          Load Inventory
+        </button>
+      </div>
+
+      <div className="dependencies-toolbar">
+        <div>
+          <strong>Read-only inventory</strong>
+          <span>Manifests and lockfiles only. Installed dependency trees are not scanned.</span>
+        </div>
+        <div className="dependencies-actions">
+          <button
+            type="button"
+            className="button-secondary"
+            onClick={() => void props.onCompare()}
+            disabled={props.busy || !props.root}
+          >
+            Compare Baseline
+          </button>
+          <button
+            type="button"
+            className="button-primary"
+            onClick={() => void props.onAccept()}
+            disabled={props.busy || !completeReportAvailable}
+          >
+            Accept Baseline
+          </button>
+        </div>
+      </div>
+
+      {props.error && props.operationStatus === 'error' ? (
+        <div className="dependencies-notice dependencies-notice-error" role="alert">
+          {props.error}
+        </div>
+      ) : null}
+
+      {props.operationStatus === 'loading' && !props.result ? (
+        <AsyncStatePanel
+          status="loading"
+          title="Loading dependency inventory"
+          description="DustFril is reading supported manifests and lockfiles."
+        />
+      ) : props.result ? (
+        <div className="dependencies-content">
+          {props.operationStatus === 'loading' ? (
+            <div className="dependencies-notice" role="status">
+              Refreshing the inventory…
+            </div>
+          ) : null}
+          <InventorySection reports={props.result.reports} />
+          {props.result.diff ? <BaselineSection diff={props.result.diff} /> : null}
+        </div>
+      ) : props.operationStatus === 'error' ? (
+        <AsyncStatePanel
+          status="error"
+          title="Dependency inventory failed"
+          description="The inventory could not be read. A parse failure is not treated as zero dependencies."
+          error={props.error ?? undefined}
+        />
+      ) : (
+        <AsyncStatePanel
+          status="idle"
+          title="Inspect this workspace"
+          description="Load the current dependency inventory, or compare it with the stored accepted baseline."
+        />
+      )}
+    </div>
+  );
+}
+
+function InventorySection({ reports }: { reports: DependencyReport[] }) {
+  return (
+    <section className="dependencies-section" aria-labelledby="dependency-inventory-heading">
+      <div className="dependencies-section-heading">
+        <div>
+          <p className="eyebrow" id="dependency-inventory-heading">
+            Current inventory
+          </p>
+          <p>Counts and package entries retain the distinctions reported by Core.</p>
+        </div>
+        <span className="dependencies-section-count">
+          {formatCount(reports.length)} report{reports.length === 1 ? '' : 's'}
+        </span>
+      </div>
+      <div className="dependency-report-grid">
+        {reports.map((report) => (
+          <DependencyReportCard key={report.ecosystem} report={report} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DependencyReportCard({ report }: { report: DependencyReport }) {
+  return (
+    <article className={`dependency-report dependency-report-${report.status}`}>
+      <div className="dependency-report-header">
+        <div>
+          <p className="eyebrow">{report.ecosystem}</p>
+          <h2>{reportStatusLabel(report.status)}</h2>
+        </div>
+        <span className="dependency-status-badge">{reportStatusLabel(report.status)}</span>
+      </div>
+
+      <dl className="dependency-context">
+        <div>
+          <dt>Manifest</dt>
+          <dd title={report.manifest}>{report.manifest}</dd>
+        </div>
+        <div>
+          <dt>Format</dt>
+          <dd>{report.manifestFormat ?? 'Not reported'}</dd>
+        </div>
+        {report.lockfile ? (
+          <div>
+            <dt>Lockfile</dt>
+            <dd title={report.lockfile.path}>
+              {report.lockfile.kind ?? 'Unrecognized format'} · {lockfileStatusLabel(report.lockfile.status)}
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+
+      <div className="dependency-metrics">
+        <MetricCard label="Unique direct" value={formatCount(report.directDependencyTotal)} />
+        <MetricCard label="Resolved packages" metric={report.resolvedDependencyCount} />
+        <MetricCard label="Transitive" metric={report.transitiveDependencyCount} />
+      </div>
+
+      <section className="dependency-category-section" aria-label={`${report.ecosystem} direct categories`}>
+        <div className="dependency-subheading">
+          <h3>Direct dependency categories</h3>
+          <span>Declared in the manifest</span>
+        </div>
+        <div className="dependency-category-list">
+          {Object.entries(report.directDependencyCounts).map(([category, count]) => (
+            <div className="dependency-category-row" key={category}>
+              <span>{category}</span>
+              <strong>{formatCount(count)}</strong>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="dependency-duplicate-section" aria-label={`${report.ecosystem} duplicate versions`}>
+        <div className="dependency-subheading">
+          <h3>Duplicate resolved versions</h3>
+          <span>{formatCount(report.duplicateVersions.length)} package(s)</span>
+        </div>
+        {report.duplicateVersions.length ? (
+          <ul className="dependency-duplicate-list">
+            {report.duplicateVersions.map((duplicate) => (
+              <li key={duplicate.name}>
+                <strong>{duplicate.name}</strong>
+                <span>{duplicate.versions.join(' · ')}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="dependency-muted">No duplicate resolved versions reported.</p>
+        )}
+      </section>
+
+      <section className="dependency-entry-section" aria-label={`${report.ecosystem} resolved packages`}>
+        <div className="dependency-subheading">
+          <h3>Resolved packages</h3>
+          <span>{formatCount(report.resolvedDependencies.length)} entries</span>
+        </div>
+        {report.resolvedDependencies.length ? (
+          <div className="dependency-entry-list" role="table" aria-label={`${report.ecosystem} resolved packages`}>
+            <div className="dependency-entry-row dependency-entry-header" role="row">
+              <span role="columnheader">Package</span>
+              <span role="columnheader">Version</span>
+              <span role="columnheader">Scope</span>
+              <span role="columnheader">Source</span>
+            </div>
+            {report.resolvedDependencies.map((entry) => (
+              <DependencyEntryRow entry={entry} key={entryKey(entry)} />
+            ))}
+          </div>
+        ) : (
+          <p className="dependency-muted">No resolved package entries are available.</p>
+        )}
+      </section>
+
+      {report.warnings.length ? <WarningList warnings={report.warnings} /> : null}
+    </article>
+  );
+}
+
+function MetricCard({ label, metric, value }: { label: string; metric?: DependencyMetric; value?: string }) {
+  const available = metric?.status === 'available' && metric.value !== null;
+
+  return (
+    <div className="dependency-metric-card">
+      <span>{label}</span>
+      <strong>{metric ? (available ? formatCount(metric.value ?? 0) : metricStatusLabel(metric.status)) : value}</strong>
+      {metric && !available && metric.reason ? <small>{metric.reason}</small> : null}
+    </div>
+  );
+}
+
+function DependencyEntryRow({ entry }: { entry: DependencyEntry }) {
+  return (
+    <div className="dependency-entry-row" role="row">
+      <strong title={entry.name}>{entry.name}</strong>
+      <span>{entry.version}</span>
+      <span className={`dependency-scope dependency-scope-${entry.scope}`}>{scopeLabel(entry.scope)}</span>
+      <span title={entry.source ?? undefined}>{entry.source ?? 'Not reported'}</span>
+    </div>
+  );
+}
+
+function BaselineSection({ diff }: { diff: DependencyDiff }) {
+  const groups: Array<{ label: string; changes: DependencyChange[]; className: string }> = [
+    { label: 'Added', changes: diff.added, className: 'added' },
+    { label: 'Removed', changes: diff.removed, className: 'removed' },
+    { label: 'Version changed', changes: diff.versionChanges, className: 'version' },
+    { label: 'Source changed', changes: diff.sourceChanges, className: 'source' },
+  ];
+
+  return (
+    <section className="dependencies-section" aria-labelledby="dependency-baseline-heading">
+      <div className="dependencies-section-heading">
+        <div>
+          <p className="eyebrow" id="dependency-baseline-heading">
+            Baseline comparison
+          </p>
+          <p>{baselineSummary(diff)}</p>
+        </div>
+        <span className="dependencies-section-count">{baselineStatusLabel(diff.baselineStatus)}</span>
+      </div>
+      <div className="dependency-baseline-context">
+        <span>Workspace identity</span>
+        <code title={diff.workspaceId}>{diff.workspaceId}</code>
+      </div>
+
+      {diff.warnings.length ? <WarningList warnings={diff.warnings} /> : null}
+      {diff.baselineStatus === 'unavailable' ? (
+        <div className="dependencies-notice dependencies-notice-warning" role="status">
+          Comparison is unavailable because no complete inventory was returned. The stored baseline was not changed.
+        </div>
+      ) : null}
+      {!hasDependencyChanges(diff) ? (
+        <p className="dependency-empty-diff">No logical dependency changes detected.</p>
+      ) : (
+        <div className="dependency-change-groups">
+          {groups.map((group) =>
+            group.changes.length ? (
+              <section className={`dependency-change-group dependency-change-${group.className}`} key={group.label}>
+                <div className="dependency-subheading">
+                  <h3>{group.label}</h3>
+                  <span>{formatCount(group.changes.length)}</span>
+                </div>
+                <div className="dependency-change-list">
+                  {group.changes.map((change, index) => (
+                    <DependencyChangeRow key={`${group.label}-${index}-${changeKey(change)}`} change={change} />
+                  ))}
+                </div>
+              </section>
+            ) : null,
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DependencyChangeRow({ change }: { change: DependencyChange }) {
+  const previous = change.previous;
+  const current = change.current;
+  const entry = current ?? previous;
+
+  return (
+    <div className="dependency-change-row">
+      <div>
+        <strong>{entry?.name ?? 'Unknown package'}</strong>
+        <span>{entry ? `${entry.ecosystem} · ${scopeLabel(entry.scope)}` : 'No package context reported'}</span>
+      </div>
+      {previous && current ? (
+        <div className="dependency-change-transition">
+          <span>{dependencyLabel(previous)} → {dependencyLabel(current)}</span>
+        </div>
+      ) : (
+        <div className="dependency-change-transition">
+          <span>{entry ? dependencyLabel(entry) : 'No version reported'}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WarningList({ warnings }: { warnings: string[] }) {
+  return (
+    <ul className="dependency-warning-list">
+      {warnings.map((warning) => <li key={warning}>{warning}</li>)}
+    </ul>
+  );
+}
+
+function entryKey(entry: DependencyEntry) {
+  return `${entry.ecosystem}-${entry.name}-${entry.version}-${entry.source ?? 'unknown'}-${entry.scope}`;
+}
+
+function changeKey(change: DependencyChange) {
+  return `${change.current ? entryKey(change.current) : ''}-${change.previous ? entryKey(change.previous) : ''}`;
+}
+
+function dependencyLabel(entry: DependencyEntry) {
+  return `${entry.version}${entry.source ? ` · ${entry.source}` : ''}`;
+}
+
+function reportStatusLabel(status: DependencyReport['status']) {
+  switch (status) {
+    case 'complete':
+      return 'Complete';
+    case 'missingLockfile':
+      return 'Missing lockfile';
+    case 'unsupported':
+      return 'Unsupported';
+  }
+}
+
+function metricStatusLabel(status: DependencyMetric['status']) {
+  return status === 'unknown' ? 'Unknown' : 'Unsupported';
+}
+
+function lockfileStatusLabel(status: NonNullable<DependencyReport['lockfile']>['status']) {
+  switch (status) {
+    case 'parsed':
+      return 'Parsed';
+    case 'missing':
+      return 'Missing';
+    case 'unsupported':
+      return 'Unsupported';
+  }
+}
+
+function scopeLabel(scope: DependencyEntry['scope']) {
+  switch (scope) {
+    case 'direct':
+      return 'Direct';
+    case 'transitive':
+      return 'Transitive';
+    case 'unknown':
+      return 'Unknown';
+  }
+}
+
+function baselineStatusLabel(status: DependencyDiff['baselineStatus']) {
+  switch (status) {
+    case 'baselineCreated':
+      return 'Baseline created';
+    case 'compared':
+      return 'Compared';
+    case 'unavailable':
+      return 'Unavailable';
+  }
+}
+
+function baselineSummary(diff: DependencyDiff) {
+  switch (diff.baselineStatus) {
+    case 'baselineCreated':
+      return 'The first complete observation established the baseline. No dependencies are treated as newly added.';
+    case 'compared':
+      return hasDependencyChanges(diff)
+        ? 'Changes are shown below. Compare does not update the accepted baseline.'
+        : 'The current logical inventory matches the accepted baseline.';
+    case 'unavailable':
+      return 'A complete inventory is required before the current state can be compared.';
+  }
+}
+
+function hasDependencyChanges(diff: DependencyDiff) {
+  return Boolean(
+    diff.added.length ||
+      diff.removed.length ||
+      diff.versionChanges.length ||
+      diff.sourceChanges.length,
+  );
+}

--- a/apps/tauri/src/lib/tauri.ts
+++ b/apps/tauri/src/lib/tauri.ts
@@ -7,6 +7,7 @@ import type {
   CleanupPlanResponse,
   CleanupResultResponse,
   DeleteMode,
+  DependencyInventoryResponse,
   LifecycleScript,
   RunOptions,
   ScanResponse,
@@ -28,6 +29,9 @@ const commands = {
   loadActivityHistory: 'load_activity_history',
   clearActivityHistory: 'clear_activity_history',
   loadCleanupHistory: 'load_cleanup_history',
+  loadDependencyInventory: 'load_dependency_inventory',
+  compareDependencyBaseline: 'compare_dependency_baseline',
+  acceptDependencyBaseline: 'accept_dependency_baseline',
 } as const;
 
 export function defaultRoot() {
@@ -91,4 +95,16 @@ export function loadActivityHistory() {
 
 export function clearActivityHistory() {
   return invoke<void>(commands.clearActivityHistory);
+}
+
+export function loadDependencyInventory(options: RunOptions) {
+  return invoke<DependencyInventoryResponse>(commands.loadDependencyInventory, { options });
+}
+
+export function compareDependencyBaseline(options: RunOptions) {
+  return invoke<DependencyInventoryResponse>(commands.compareDependencyBaseline, { options });
+}
+
+export function acceptDependencyBaseline(options: RunOptions) {
+  return invoke<DependencyInventoryResponse>(commands.acceptDependencyBaseline, { options });
 }

--- a/apps/tauri/src/lib/tauri.ts
+++ b/apps/tauri/src/lib/tauri.ts
@@ -7,6 +7,7 @@ import type {
   CleanupPlanResponse,
   CleanupResultResponse,
   DeleteMode,
+  DependencyBaselineAcceptOptions,
   DependencyInventoryResponse,
   LifecycleScript,
   RunOptions,
@@ -105,6 +106,6 @@ export function compareDependencyBaseline(options: RunOptions) {
   return invoke<DependencyInventoryResponse>(commands.compareDependencyBaseline, { options });
 }
 
-export function acceptDependencyBaseline(options: RunOptions) {
+export function acceptDependencyBaseline(options: DependencyBaselineAcceptOptions) {
   return invoke<DependencyInventoryResponse>(commands.acceptDependencyBaseline, { options });
 }

--- a/apps/tauri/src/model/categories.test.ts
+++ b/apps/tauri/src/model/categories.test.ts
@@ -31,6 +31,7 @@ describe('desktop module navigation', () => {
     expect(categoryConfig('cleanup-node')?.availability).toBe('available');
     expect(categoryConfig('cleanup-java')?.availability).toBe('available');
     expect(categoryConfig('workspace-activity')?.availability).toBe('available');
+    expect(categoryConfig('workspace-dependencies')?.availability).toBe('available');
     expect(categoryConfig('cleanup-cache')?.availability).toBe('planned');
     expect(categoryConfig('security-supply-chain')?.availability).toBe('planned');
     expect(categoryConfig('workspace-artifact-history')?.availability).toBe('planned');

--- a/apps/tauri/src/model/categories.ts
+++ b/apps/tauri/src/model/categories.ts
@@ -84,9 +84,9 @@ export const categoryConfigs: CategoryConfig[] = [
   {
     key: 'workspace-dependencies',
     title: 'Dependencies',
-    description: 'Future dependency inventory and comparison',
+    description: 'Manifest and lockfile inventory with explicit baseline comparison',
     section: 'workspace',
-    availability: 'planned',
+    availability: 'available',
   },
   {
     key: 'workspace-artifact-history',

--- a/apps/tauri/src/styles/style.css
+++ b/apps/tauri/src/styles/style.css
@@ -348,6 +348,575 @@ button:disabled {
   padding: 28px 30px;
 }
 
+.dependencies-view {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 14px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 22px 24px 28px;
+}
+
+.dependencies-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  min-width: 0;
+}
+
+.dependencies-heading h1 {
+  margin: 3px 0 0;
+  color: #f7f9fc;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+}
+
+.dependencies-heading-path {
+  max-width: 720px;
+  margin: 5px 0 0;
+  overflow: hidden;
+  color: #87919e;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependencies-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 11px 13px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  background: #25272a;
+}
+
+.dependencies-toolbar > div:first-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.dependencies-toolbar strong {
+  color: #eaf0f4;
+  font-size: 12px;
+}
+
+.dependencies-toolbar span {
+  color: #8f99a6;
+  font-size: 11px;
+}
+
+.dependencies-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 7px;
+}
+
+.button-primary {
+  min-height: 32px;
+  padding: 0 12px;
+  border: 1px solid rgba(127, 211, 244, 0.45);
+  border-radius: 5px;
+  background: #2d9bc4;
+  color: #06151d;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.button-primary:hover:not(:disabled) {
+  background: #57b9df;
+}
+
+.button-primary:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.dependencies-notice {
+  padding: 9px 11px;
+  border: 1px solid rgba(123, 213, 255, 0.2);
+  border-radius: 6px;
+  background: rgba(71, 175, 215, 0.08);
+  color: #b7e8f9;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.dependencies-notice-warning {
+  border-color: rgba(247, 190, 91, 0.28);
+  background: rgba(180, 117, 28, 0.1);
+  color: #f7d797;
+}
+
+.dependencies-notice-error {
+  border-color: rgba(240, 112, 112, 0.28);
+  background: rgba(191, 68, 68, 0.1);
+  color: #f0b7b7;
+}
+
+.dependencies-content {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.dependencies-section {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  background: #222427;
+}
+
+.dependencies-section-heading,
+.dependency-report-header,
+.dependency-subheading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.dependencies-section-heading > div,
+.dependency-report-header > div {
+  min-width: 0;
+}
+
+.dependencies-section-heading p:last-child {
+  margin: 4px 0 0;
+  color: #8d97a4;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.dependencies-section-count {
+  flex: 0 0 auto;
+  color: #a9dff0;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.dependency-report-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.dependency-report {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 13px;
+  padding: 13px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: #292a2d;
+}
+
+.dependency-report-missingLockfile {
+  border-color: rgba(247, 190, 91, 0.24);
+}
+
+.dependency-report-unsupported {
+  border-color: rgba(198, 182, 252, 0.2);
+}
+
+.dependency-report-header h2 {
+  margin: 3px 0 0;
+  color: #f0f4f7;
+  font-size: 16px;
+}
+
+.dependency-status-badge,
+.dependency-scope {
+  display: inline-flex;
+  width: fit-content;
+  min-height: 21px;
+  align-items: center;
+  padding: 0 7px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.dependency-status-badge {
+  background: rgba(103, 207, 153, 0.11);
+  color: #b6e7cc;
+}
+
+.dependency-report-missingLockfile .dependency-status-badge {
+  background: rgba(205, 144, 44, 0.12);
+  color: #f4d18f;
+}
+
+.dependency-report-unsupported .dependency-status-badge {
+  background: rgba(145, 112, 232, 0.13);
+  color: #d4c7ff;
+}
+
+.dependency-context,
+.dependency-context > div {
+  min-width: 0;
+}
+
+.dependency-context {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+}
+
+.dependency-context dt {
+  margin-bottom: 2px;
+  color: #77818d;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dependency-context dd {
+  margin: 0;
+  overflow: hidden;
+  color: #c8d0d8;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependency-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.dependency-metric-card {
+  display: flex;
+  min-width: 0;
+  min-height: 70px;
+  flex-direction: column;
+  gap: 4px;
+  padding: 9px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.dependency-metric-card > span {
+  color: #89939f;
+  font-size: 10px;
+}
+
+.dependency-metric-card strong {
+  overflow: hidden;
+  color: #f0f4f8;
+  font-size: 17px;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependency-metric-card small {
+  display: -webkit-box;
+  overflow: hidden;
+  color: #a3adb9;
+  font-size: 9px;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.dependency-category-section,
+.dependency-duplicate-section,
+.dependency-entry-section {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.dependency-subheading {
+  align-items: baseline;
+}
+
+.dependency-subheading h3 {
+  margin: 0;
+  color: #dfe6ec;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.dependency-subheading span {
+  color: #77818d;
+  font-size: 10px;
+}
+
+.dependency-category-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px 12px;
+}
+
+.dependency-category-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 9px;
+  min-width: 0;
+  padding: 5px 7px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.035);
+  color: #aeb8c3;
+  font-size: 10px;
+}
+
+.dependency-category-row strong {
+  color: #e7edf1;
+  font-variant-numeric: tabular-nums;
+}
+
+.dependency-duplicate-list,
+.dependency-warning-list {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.dependency-duplicate-list li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 7px;
+  border-radius: 4px;
+  background: rgba(247, 190, 91, 0.07);
+  font-size: 10px;
+}
+
+.dependency-duplicate-list strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #e8d2a4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependency-duplicate-list span {
+  flex: 0 0 auto;
+  color: #c8b98e;
+  font-variant-numeric: tabular-nums;
+}
+
+.dependency-entry-list {
+  min-width: 0;
+  max-height: 270px;
+  overflow: auto;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+}
+
+.dependency-entry-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 1.25fr) minmax(65px, 0.7fr) 88px minmax(100px, 1.45fr);
+  align-items: center;
+  gap: 9px;
+  min-width: 500px;
+  min-height: 31px;
+  padding: 0 7px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.045);
+  color: #b8c2cc;
+  font-size: 10px;
+}
+
+.dependency-entry-row:last-child {
+  border-bottom: 0;
+}
+
+.dependency-entry-row > * {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependency-entry-row strong {
+  color: #e6edf2;
+  font-weight: 650;
+}
+
+.dependency-entry-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  min-height: 28px;
+  background: #25272a;
+  color: #828c99;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dependency-scope-direct {
+  background: rgba(103, 207, 153, 0.1);
+  color: #b6e7cc;
+}
+
+.dependency-scope-transitive {
+  background: rgba(103, 190, 225, 0.1);
+  color: #acdcec;
+}
+
+.dependency-scope-unknown {
+  background: rgba(255, 255, 255, 0.08);
+  color: #bdc5ce;
+}
+
+.dependency-muted,
+.dependency-empty-diff {
+  margin: 0;
+  color: #89939f;
+  font-size: 11px;
+}
+
+.dependency-warning-list {
+  padding: 8px 10px 8px 27px;
+  border: 1px solid rgba(247, 190, 91, 0.2);
+  border-radius: 5px;
+  background: rgba(180, 117, 28, 0.08);
+  color: #f3d28f;
+  font-size: 10px;
+  line-height: 1.45;
+  list-style: disc;
+}
+
+.dependency-baseline-context {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+  padding: 8px 9px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.035);
+  color: #89939f;
+  font-size: 10px;
+}
+
+.dependency-baseline-context code {
+  min-width: 0;
+  overflow: hidden;
+  color: #c8dff0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependency-change-groups {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.dependency-change-group {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 7px;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.dependency-change-added h3,
+.dependency-change-added .dependency-subheading span {
+  color: #a9dfc0;
+}
+
+.dependency-change-removed h3,
+.dependency-change-removed .dependency-subheading span {
+  color: #e8abab;
+}
+
+.dependency-change-version h3,
+.dependency-change-version .dependency-subheading span,
+.dependency-change-source h3,
+.dependency-change-source .dependency-subheading span {
+  color: #f0d08f;
+}
+
+.dependency-change-list {
+  display: grid;
+  gap: 5px;
+}
+
+.dependency-change-row {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  padding: 7px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 10px;
+}
+
+.dependency-change-row > div:first-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.dependency-change-row strong {
+  overflow: hidden;
+  color: #e8edf1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependency-change-row > div:first-child span {
+  overflow: hidden;
+  color: #818b97;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependency-change-transition {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+  color: #bfc8d0;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.dependency-change-transition span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .module-placeholder-heading {
   display: flex;
   max-width: 680px;
@@ -2132,6 +2701,29 @@ button:disabled {
     padding: 6px 12px;
   }
 
+  .dependencies-view {
+    padding: 16px 12px 22px;
+  }
+
+  .dependencies-toolbar,
+  .dependencies-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .dependencies-actions {
+    width: 100%;
+  }
+
+  .dependencies-actions button {
+    flex: 1;
+  }
+
+  .dependency-report-grid,
+  .dependency-change-groups {
+    grid-template-columns: 1fr;
+  }
+
 }
 
 @media (max-width: 560px) {
@@ -2160,5 +2752,20 @@ button:disabled {
 
   .overview-summary-grid {
     grid-template-columns: 1fr;
+  }
+
+  .dependency-metrics,
+  .dependency-category-list {
+    grid-template-columns: 1fr;
+  }
+
+  .dependency-change-row {
+    grid-template-columns: 1fr;
+    gap: 5px;
+  }
+
+  .dependency-change-transition {
+    justify-content: flex-start;
+    text-align: left;
   }
 }

--- a/apps/tauri/src/types/workflow.ts
+++ b/apps/tauri/src/types/workflow.ts
@@ -249,6 +249,7 @@ export type DependencyDiff = {
 };
 
 export type DependencyInventoryResponse = {
+  inventoryFingerprint: string;
   workspacePath: string;
   reports: DependencyReport[];
   diff: DependencyDiff | null;
@@ -334,6 +335,12 @@ export type RunOptions = {
   recordHistory?: boolean;
   cleanupAgeDays?: number;
   recordArtifactSnapshot?: boolean;
+};
+
+export type DependencyBaselineAcceptOptions = {
+  root: string;
+  ecosystems: Ecosystem[];
+  expectedInventoryFingerprint: string;
 };
 
 export const ecosystems: Ecosystem[] = ['Rust', 'Node', 'Java'];

--- a/apps/tauri/src/types/workflow.ts
+++ b/apps/tauri/src/types/workflow.ts
@@ -183,6 +183,77 @@ export type SecurityScanResponse = {
   historyWarning?: string;
 };
 
+export type DependencyReportStatus = 'complete' | 'missingLockfile' | 'unsupported';
+export type DependencyMetricStatus = 'available' | 'unknown' | 'unsupported';
+export type DependencyLockfileStatus = 'parsed' | 'missing' | 'unsupported';
+export type DependencyScope = 'direct' | 'transitive' | 'unknown';
+export type DependencyBaselineStatus = 'baselineCreated' | 'compared' | 'unavailable';
+export type DependencyChangeKind = 'added' | 'removed' | 'versionChanged' | 'sourceChanged';
+
+export type DependencyMetric = {
+  value: number | null;
+  status: DependencyMetricStatus;
+  reason: string | null;
+};
+
+export type DependencyLockfile = {
+  path: string;
+  kind: 'PackageLockJson' | 'PnpmLockYaml' | 'BunLock' | 'CargoLock' | null;
+  format: string | null;
+  status: DependencyLockfileStatus;
+  reason: string | null;
+};
+
+export type DuplicateDependency = {
+  name: string;
+  versions: string[];
+};
+
+export type DependencyEntry = {
+  ecosystem: Ecosystem;
+  name: string;
+  version: string;
+  source: string | null;
+  scope: DependencyScope;
+};
+
+export type DependencyReport = {
+  ecosystem: Ecosystem;
+  status: DependencyReportStatus;
+  manifest: string;
+  manifestFormat: string | null;
+  lockfile: DependencyLockfile | null;
+  directDependencyCounts: Record<string, number>;
+  directDependencyTotal: number;
+  resolvedDependencyCount: DependencyMetric;
+  transitiveDependencyCount: DependencyMetric;
+  duplicateVersions: DuplicateDependency[];
+  resolvedDependencies: DependencyEntry[];
+  warnings: string[];
+};
+
+export type DependencyChange = {
+  kind: DependencyChangeKind;
+  previous: DependencyEntry | null;
+  current: DependencyEntry | null;
+};
+
+export type DependencyDiff = {
+  workspaceId: string;
+  baselineStatus: DependencyBaselineStatus;
+  added: DependencyChange[];
+  removed: DependencyChange[];
+  versionChanges: DependencyChange[];
+  sourceChanges: DependencyChange[];
+  warnings: string[];
+};
+
+export type DependencyInventoryResponse = {
+  workspacePath: string;
+  reports: DependencyReport[];
+  diff: DependencyDiff | null;
+};
+
 export type ActivityKind = 'Scan' | 'Cleanup' | 'Security';
 
 export type ActivityFailure = {

--- a/crates/core/src/api/dependency.rs
+++ b/crates/core/src/api/dependency.rs
@@ -1,8 +1,10 @@
 use std::path::{Path, PathBuf};
 
+use sha2::{Digest, Sha256};
+
 use crate::{
     dependency, dependency_baseline,
-    error::DustResult,
+    error::{DustError, DustResult},
     models::{DependencyDiff, DependencyReport, Ecosystem},
 };
 
@@ -23,6 +25,18 @@ pub fn dependency_exposure_report(
     ecosystems: &[Ecosystem],
 ) -> DustResult<Vec<DependencyReport>> {
     dependency_report(root, ecosystems)
+}
+
+/// Returns a stable identifier for the structured inventory observed by a
+/// caller. The identifier lets an integration bind an explicit baseline
+/// acceptance to the inventory that was shown for review.
+pub fn dependency_inventory_fingerprint(reports: &[DependencyReport]) -> DustResult<String> {
+    let serialized = serde_json::to_vec(reports).map_err(|error| {
+        DustError::DependencyState(format!(
+            "failed to fingerprint dependency inventory: {error}"
+        ))
+    })?;
+    Ok(format!("{:x}", Sha256::digest(serialized)))
 }
 
 /// Returns the OS-specific local path used for dependency baselines.
@@ -136,5 +150,38 @@ mod tests {
         accept_dependency_baseline(temp_dir.path(), &current_reports, &baseline_path).unwrap();
         let accepted = dependency_diff(temp_dir.path(), &current_reports, &baseline_path).unwrap();
         assert!(!accepted.has_changes());
+    }
+
+    #[test]
+    fn api_fingerprint_is_stable_and_changes_with_the_observed_inventory() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{"name":"demo","dependencies":{"left-pad":"1.0.0"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("package-lock.json"),
+            r#"{"lockfileVersion":3,"packages":{"":{"name":"demo"},"node_modules/left-pad":{"version":"1.0.0"}}}"#,
+        )
+        .unwrap();
+
+        let first = dependency_report(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+        let first_fingerprint = dependency_inventory_fingerprint(&first).unwrap();
+        assert_eq!(
+            first_fingerprint,
+            dependency_inventory_fingerprint(&first).unwrap()
+        );
+
+        fs::write(
+            temp_dir.path().join("package-lock.json"),
+            r#"{"lockfileVersion":3,"packages":{"":{"name":"demo"},"node_modules/left-pad":{"version":"2.0.0"}}}"#,
+        )
+        .unwrap();
+        let changed = dependency_report(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+        assert_ne!(
+            first_fingerprint,
+            dependency_inventory_fingerprint(&changed).unwrap()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add a real Workspace > Dependencies view backed by the Core dependency inventory API.
- Expose Node and Rust dependency categories, direct/transitive counts, duplicates, resolved entries, warnings, and explicit incomplete/unsupported states.
- Add separate Compare Baseline and Accept Baseline actions with the Core baseline persistence semantics.
- Bind Accept Baseline to the inventory reviewed by the user: Load and Compare return a Core-derived inventory fingerprint, and Accept rejects the operation when the current inventory differs.
- Keep frontend parsing and filesystem traversal out of the UI; all dependency parsing remains in Core.

## Related issue

Closes #139

## Validation

- cargo fmt --all -- --check — passed
- cargo clippy --workspace --all-targets -- -D warnings — passed
- npm test -- --run (from apps/tauri) — 13 files / 53 tests passed
- npm run build (from apps/tauri) — passed
- cargo test -p dustfril-core dependency — 27 tests passed
- cargo test -p dustfril-tauri dependency — 2 tests passed
- cargo test --workspace — 302 passed; 1 existing host-environment-dependent test failed:
  - macOS signing fixture expected Software Signing, host returned macOS Software Signing
- cargo llvm-cov --workspace --all-features --summary-only — 301 passed; 2 existing host-environment-dependent tests failed:
  - macOS signing fixture expected Software Signing, host returned macOS Software Signing
  - filesystem capacity fixture observed a changing available-byte value
