### PR TITLE
feat(tauri): expose artifact history in workspace UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ canonical workspace; moving a workspace creates a new history rather than
 guessing that it is the old one. Snapshot persistence warnings do not discard a
 completed scan/analyze result. Filtered snapshots carry forward the latest
 state for ecosystems that were not selected, so a later full scan does not
-report unobserved artifacts as newly created.
+report unobserved artifacts as newly created. When retention has evicted the
+predecessor of the oldest retained snapshot, Desktop history reports that
+comparison as unavailable instead of presenting a misleading new baseline.
 
 ## Desktop App
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ The desktop app currently exposes the same core workflows in a workspace browser
 - cleanup execution
 - lifecycle script audit
 - unified activity history
+- bounded scan access summaries and generated-artifact snapshot history
 
 Cleanup results are project-aware: each artifact carries the project identity
 returned by discovery, including its root directory and ecosystem. The scanned

--- a/apps/cli/src/format/artifact_snapshot_format.rs
+++ b/apps/cli/src/format/artifact_snapshot_format.rs
@@ -12,6 +12,11 @@ pub fn print_artifact_snapshot_result(result: &ArtifactSnapshotResult) {
         return;
     }
 
+    if result.status == dustfril_core::models::ArtifactSnapshotStatus::ComparisonUnavailable {
+        println!("\nComparison unavailable; an older snapshot may no longer be retained.");
+        return;
+    }
+
     if result.changes.is_empty() {
         println!("\nNo artifact changes detected.");
         return;

--- a/apps/tauri/README.md
+++ b/apps/tauri/README.md
@@ -37,7 +37,7 @@ case-sensitive.
 | `execute_cleanup` | `{ request: { root, ecosystems, analysisId, selectedArtifacts, mode } }` | `CleanupResultResponse` (may include additive `historyWarning`) |
 | `load_activity_history` | none | `ActivityRecord[]` |
 | `load_cleanup_history` | none | `CleanupHistoryEntry[]` |
-| `load_artifact_snapshot_history` | `{ root }` | retained Core-computed artifact snapshot comparisons and retention metadata |
+| `load_artifact_snapshot_history` | `{ root }` | retained Core-computed artifact snapshot comparisons and retention metadata; an evicted predecessor is `comparisonUnavailable` |
 
 Contract changes must preserve existing command names, nullability, and enum wire
 values for v0.1.0. Cleanup execution intentionally accepts analyzed artifact

--- a/apps/tauri/README.md
+++ b/apps/tauri/README.md
@@ -37,6 +37,7 @@ case-sensitive.
 | `execute_cleanup` | `{ request: { root, ecosystems, analysisId, selectedArtifacts, mode } }` | `CleanupResultResponse` (may include additive `historyWarning`) |
 | `load_activity_history` | none | `ActivityRecord[]` |
 | `load_cleanup_history` | none | `CleanupHistoryEntry[]` |
+| `load_artifact_snapshot_history` | `{ root }` | retained Core-computed artifact snapshot comparisons and retention metadata |
 
 Contract changes must preserve existing command names, nullability, and enum wire
 values for v0.1.0. Cleanup execution intentionally accepts analyzed artifact
@@ -63,6 +64,7 @@ refreshes set it to `false` so they do not change the generated-artifact baselin
 - Unified recommendations list with reclaimable storage, selection, review, and cleanup summary
 - Safe cleanup with Trash or permanent delete confirmation
 - Activity history viewer backed by shared, versioned core history storage
+- Artifact History viewer for bounded scan access summaries and generated-artifact snapshot growth
 - Explicit scans return the generated-artifact snapshot comparison produced by Core
 
 Activity persistence is auxiliary to scan, cleanup, and security results. If a
@@ -76,6 +78,7 @@ additive `historyWarning` for the desktop status surface.
 - `WorkspaceView`
 - `CleanupDialog`
 - `HistoryList`
+- `ArtifactHistoryView`
 - `AsyncStatePanel`
 - `ModulePlaceholderView`
 
@@ -95,7 +98,7 @@ Cleanup
 
 Workspace
   Dependencies (planned)
-  Artifact History (planned)
+  Artifact History
   Activity
 
 Security

--- a/apps/tauri/src-tauri/src/contract.rs
+++ b/apps/tauri/src-tauri/src/contract.rs
@@ -9,7 +9,7 @@ use dustfril_core::models::{
     DeleteMode, DeveloperStorageSummary, Ecosystem, LifecycleScript, LockfileCheck, LockfileKind,
     LockfileStatus, PackageManager, ProjectIdentity, RecommendationPolicy, RiskLevel, ScriptType,
     SecurityFinding, SecurityReport, SecurityWarning, StorageSummary, VolumeStorage,
-    DEFAULT_CLEANUP_AGE_DAYS,
+    DEFAULT_CLEANUP_AGE_DAYS, MAX_ARTIFACT_SNAPSHOTS_PER_WORKSPACE,
 };
 use serde::{Deserialize, Serialize};
 
@@ -75,6 +75,14 @@ pub(crate) struct ArtifactSnapshotResultDto {
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct ArtifactSnapshotHistoryDto {
+    pub(crate) entries: Vec<ArtifactSnapshotResultDto>,
+    pub(crate) retained_snapshot_count: usize,
+    pub(crate) retention_limit: usize,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct ArtifactSnapshotDto {
     pub(crate) workspace_id: String,
     pub(crate) timestamp: String,
@@ -114,6 +122,18 @@ pub(crate) fn artifact_snapshot_to_dto(
             .into_iter()
             .map(artifact_size_change_to_dto)
             .collect(),
+    }
+}
+
+pub(crate) fn artifact_snapshot_history_to_dto(
+    entries: Vec<ArtifactSnapshotResult>,
+) -> ArtifactSnapshotHistoryDto {
+    let retained_snapshot_count = entries.len();
+
+    ArtifactSnapshotHistoryDto {
+        entries: entries.into_iter().map(artifact_snapshot_to_dto).collect(),
+        retained_snapshot_count,
+        retention_limit: MAX_ARTIFACT_SNAPSHOTS_PER_WORKSPACE,
     }
 }
 
@@ -1063,6 +1083,33 @@ mod tests {
         assert_eq!(value["snapshot"]["artifacts"][0]["lastModifiedMs"], 0);
         assert_eq!(value["changes"][0]["kind"], "sizeIncreased");
         assert_eq!(value["changes"][0]["deltaBytes"], 5);
+    }
+
+    #[test]
+    fn artifact_snapshot_history_wire_format_exposes_retention_metadata() {
+        let result = ArtifactSnapshotResult {
+            status: ArtifactSnapshotStatus::BaselineCreated,
+            snapshot: ArtifactSnapshot {
+                workspace_id: "/workspace".to_owned(),
+                timestamp: ArtifactSnapshot::from_analysis(
+                    Path::new("/workspace"),
+                    &AnalysisResult::default(),
+                )
+                .timestamp,
+                artifacts: Vec::new(),
+            },
+            previous_snapshot: None,
+            changes: Vec::new(),
+        };
+
+        let value = serde_json::to_value(artifact_snapshot_history_to_dto(vec![result])).unwrap();
+
+        assert_eq!(value["entries"].as_array().unwrap().len(), 1);
+        assert_eq!(value["retainedSnapshotCount"], 1);
+        assert_eq!(
+            value["retentionLimit"],
+            MAX_ARTIFACT_SNAPSHOTS_PER_WORKSPACE
+        );
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/contract.rs
+++ b/apps/tauri/src-tauri/src/contract.rs
@@ -1110,6 +1110,10 @@ mod tests {
             value["retentionLimit"],
             MAX_ARTIFACT_SNAPSHOTS_PER_WORKSPACE
         );
+        assert_eq!(
+            serde_json::to_value(ArtifactSnapshotStatus::ComparisonUnavailable).unwrap(),
+            "comparisonUnavailable"
+        );
     }
 
     #[test]

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -16,12 +16,12 @@ use std::{
 };
 
 use contract::{
-    artifact_path, artifact_snapshot_to_dto, cleanup_failure_reason, project_identity_to_dto,
-    storage_summary_to_dto, volume_storage_to_dto, AnalysisResponse, ArtifactAnalysisDto,
-    ArtifactDto, CleanupCandidateDto, CleanupFailureDto, CleanupHistoryEntryDto,
-    CleanupPlanResponse, CleanupResultResponse, ExecuteCleanupRequest, LifecycleScriptDto,
-    RunOptions, ScanResponse, SecurityScanResponse, StorageSummaryDto, VolumeStorageDto,
-    WorkspaceAnalysisResponse,
+    artifact_path, artifact_snapshot_history_to_dto, artifact_snapshot_to_dto,
+    cleanup_failure_reason, project_identity_to_dto, storage_summary_to_dto, volume_storage_to_dto,
+    AnalysisResponse, ArtifactAnalysisDto, ArtifactDto, CleanupCandidateDto, CleanupFailureDto,
+    CleanupHistoryEntryDto, CleanupPlanResponse, CleanupResultResponse, ExecuteCleanupRequest,
+    LifecycleScriptDto, RunOptions, ScanResponse, SecurityScanResponse, StorageSummaryDto,
+    VolumeStorageDto, WorkspaceAnalysisResponse,
 };
 use dustfril_core::{
     api,
@@ -555,6 +555,22 @@ async fn load_cleanup_history() -> Result<Vec<CleanupHistoryEntryDto>, String> {
     .map_err(|error| error.to_string())?
 }
 
+/// Loads retained artifact snapshot comparisons without starting a new scan.
+#[tauri::command]
+async fn load_artifact_snapshot_history(
+    root: String,
+) -> Result<contract::ArtifactSnapshotHistoryDto, String> {
+    let root = resolve_root(Some(root))?;
+
+    tokio::task::spawn_blocking(move || {
+        api::artifact_snapshot::load_artifact_snapshot_history(&root)
+            .map(artifact_snapshot_history_to_dto)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
 #[tauri::command]
 async fn audit(options: RunOptions) -> Result<Vec<LifecycleScriptDto>, String> {
     let root = resolve_root(options.root)?;
@@ -616,6 +632,7 @@ pub fn run() {
             load_activity_history,
             clear_activity_history,
             load_cleanup_history,
+            load_artifact_snapshot_history,
             audit,
             security_scan
         ])

--- a/apps/tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.test.tsx
@@ -3,17 +3,25 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from './AppShell';
 import {
   analyzeWorkspace,
+  chooseWorkspaceFolder,
   clearActivityHistory,
   executeCleanup,
+  loadArtifactSnapshotHistory,
   loadActivityHistory,
   refreshStorageVolume,
 } from '../../lib/tauri';
+import type { ArtifactSnapshotHistory } from '../../types/workflow';
 
 vi.mock('../../lib/tauri', () => ({
   analyzeWorkspace: vi.fn(),
   chooseWorkspaceFolder: vi.fn(),
   defaultRoot: vi.fn().mockResolvedValue('/workspace'),
   executeCleanup: vi.fn(),
+  loadArtifactSnapshotHistory: vi.fn().mockResolvedValue({
+    entries: [],
+    retainedSnapshotCount: 0,
+    retentionLimit: 32,
+  }),
   refreshStorageVolume: vi.fn(),
   loadActivityHistory: vi.fn().mockResolvedValue([]),
   clearActivityHistory: vi.fn().mockResolvedValue(undefined),
@@ -64,7 +72,7 @@ describe('AppShell Overview navigation', () => {
     ['Java', false],
     ['Cache', true],
     ['Dependencies', true],
-    ['Artifact History', true],
+    ['Artifact History', false],
     ['Activity', false],
     ['Supply Chain', true],
     ['GitHub Actions', true],
@@ -80,6 +88,17 @@ describe('AppShell Overview navigation', () => {
       expect(screen.getByRole('heading', { name: `${title} is planned` })).toBeInTheDocument();
     }
     expect(analyzeWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('loads artifact history through a read-only query without starting a scan', async () => {
+    render(<AppShell />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Analyze Workspace' })).toBeEnabled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Artifact History' }));
+
+    await waitFor(() => expect(loadArtifactSnapshotHistory).toHaveBeenCalledWith('/workspace'));
+    expect(analyzeWorkspace).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Artifact History' })).toBeInTheDocument();
   });
 
   it('opens the exact Overview artifact in Workspace without selecting it', async () => {
@@ -294,5 +313,44 @@ describe('AppShell Overview navigation', () => {
     await waitFor(() => expect(refreshStorageVolume).toHaveBeenCalledWith('/workspace'));
     fireEvent.click(screen.getByRole('button', { name: 'Overview' }));
     expect(screen.getByText('300 GB used of 512 GB')).toBeInTheDocument();
+  });
+
+  it('ignores a stale artifact history response after the workspace changes', async () => {
+    let resolveOriginal: ((history: ArtifactSnapshotHistory) => void) | undefined;
+    vi.mocked(loadArtifactSnapshotHistory).mockImplementation((selectedRoot) => {
+      if (selectedRoot === '/workspace') {
+        return new Promise((resolve) => {
+          resolveOriginal = resolve;
+        });
+      }
+
+      return Promise.resolve({ entries: [], retainedSnapshotCount: 0, retentionLimit: 32 });
+    });
+    vi.mocked(chooseWorkspaceFolder).mockResolvedValue('/other');
+
+    render(<AppShell />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Analyze Workspace' })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: 'Artifact History' }));
+    await waitFor(() => expect(loadArtifactSnapshotHistory).toHaveBeenCalledWith('/workspace'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'workspace' }));
+    await waitFor(() => expect(screen.getByText('/other', { selector: 'p.heading-path' })).toBeInTheDocument());
+    await waitFor(() => expect(loadArtifactSnapshotHistory).toHaveBeenCalledWith('/other'));
+
+    resolveOriginal?.({
+      entries: [
+        {
+          status: 'baselineCreated',
+          snapshot: { workspaceId: '/workspace', timestamp: '2026-09-01T00:00:00Z', artifacts: [] },
+          previousSnapshot: null,
+          changes: [],
+        },
+      ],
+      retainedSnapshotCount: 1,
+      retentionLimit: 32,
+    });
+
+    await waitFor(() => expect(screen.getByText(/No scan has been run for this workspace yet/)).toBeInTheDocument());
+    expect(screen.queryByText('Baseline created')).not.toBeInTheDocument();
   });
 });

--- a/apps/tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.tsx
@@ -8,6 +8,7 @@ import { HistoryView } from './views/HistoryView';
 import { ModulePlaceholderView } from './views/ModulePlaceholderView';
 import { OverviewView } from './views/OverviewView';
 import { WorkspaceView } from './views/WorkspaceView';
+import { ArtifactHistoryView } from './views/ArtifactHistoryView';
 
 export function AppShell() {
   const app = useAppState();
@@ -16,6 +17,7 @@ export function AppShell() {
   const showingWorkspace = app.activeCategory === 'workspace' || showingCleanup;
   const showingActivity =
     app.activeCategory === 'history' || app.activeCategory === 'workspace-activity';
+  const showingArtifactHistory = app.activeCategory === 'workspace-artifact-history';
 
   return (
     <main className="app-shell">
@@ -85,7 +87,22 @@ export function AppShell() {
             />
           ) : null}
 
-          {app.activeCategory !== 'overview' && !showingWorkspace && !showingActivity && activeConfig ? (
+          {showingArtifactHistory ? (
+            <ArtifactHistoryView
+              root={app.root}
+              history={app.artifactHistory}
+              status={app.artifactHistoryStatus}
+              error={app.artifactHistoryError}
+              scanEntry={app.latestScanEntry}
+              persistenceWarning={app.artifactHistoryPersistenceWarning}
+            />
+          ) : null}
+
+          {app.activeCategory !== 'overview' &&
+          !showingWorkspace &&
+          !showingActivity &&
+          !showingArtifactHistory &&
+          activeConfig ? (
             <ModulePlaceholderView
               config={activeConfig}
               onReturnToOverview={() => app.setActiveCategory('overview')}

--- a/apps/tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useAppState.ts
@@ -6,18 +6,22 @@ import {
   clearActivityHistory,
   defaultRoot,
   executeCleanup,
+  loadArtifactSnapshotHistory,
   loadActivityHistory,
   refreshStorageVolume,
 } from '../../../lib/tauri';
 import { categoryConfigs, type SidebarCategory } from '../../../model/categories';
+import { latestScanForWorkspace } from '../../../model/artifactHistory';
 import {
   idleAsyncOperation,
   reduceAsyncOperation,
 } from '../../../model/async';
+import type { AsyncOperationStatus } from '../../../model/async';
 import type { SidebarEntry } from '../../../components/Sidebar/Sidebar';
 import type {
   ActivityRecord,
   AnalysisResponse,
+  ArtifactSnapshotHistory,
   CleanupPlanResponse,
   CleanupResultResponse,
   DeleteMode,
@@ -45,6 +49,12 @@ export function useAppState() {
   const [cleanupPlan, setCleanupPlan] = useState<CleanupPlanResponse | null>(null);
   const [storageSummary, setStorageSummary] = useState<StorageSummary | null>(null);
   const [historyEntries, setHistoryEntries] = useState<ActivityRecord[]>([]);
+  const [artifactHistory, setArtifactHistory] = useState<ArtifactSnapshotHistory | null>(null);
+  const [artifactHistoryStatus, setArtifactHistoryStatus] =
+    useState<AsyncOperationStatus>('idle');
+  const [artifactHistoryError, setArtifactHistoryError] = useState<string | null>(null);
+  const [artifactHistoryPersistenceWarning, setArtifactHistoryPersistenceWarning] =
+    useState<string | null>(null);
   const [selectedCleanupPaths, setSelectedCleanupPaths] = useState<string[]>([]);
   const [cleanupReviewPaths, setCleanupReviewPaths] = useState<string[]>([]);
   const [cleanupAgeDays, setCleanupAgeDays] = useState<number>(defaultCleanupAgeDays);
@@ -55,6 +65,8 @@ export function useAppState() {
   );
   const workspaceRequestRef = useRef(0);
   const actionRequestRef = useRef(0);
+  const artifactHistoryRequestRef = useRef(0);
+  const [artifactHistoryRefreshToken, setArtifactHistoryRefreshToken] = useState(0);
 
   useEffect(() => {
     defaultRoot()
@@ -65,6 +77,39 @@ export function useAppState() {
       .then(setHistoryEntries)
       .catch((invokeError) => setError(String(invokeError)));
   }, []);
+
+  useEffect(() => {
+    const requestId = ++artifactHistoryRequestRef.current;
+
+    if (activeCategory !== 'workspace-artifact-history' || !root) {
+      setArtifactHistory(null);
+      setArtifactHistoryStatus('idle');
+      setArtifactHistoryError(null);
+      return;
+    }
+
+    setArtifactHistory(null);
+    setArtifactHistoryStatus('loading');
+    setArtifactHistoryError(null);
+
+    loadArtifactSnapshotHistory(root)
+      .then((response) => {
+        if (requestId !== artifactHistoryRequestRef.current) {
+          return;
+        }
+
+        setArtifactHistory(response);
+        setArtifactHistoryStatus('success');
+      })
+      .catch((invokeError) => {
+        if (requestId !== artifactHistoryRequestRef.current) {
+          return;
+        }
+
+        setArtifactHistoryError(String(invokeError));
+        setArtifactHistoryStatus('error');
+      });
+  }, [activeCategory, artifactHistoryRefreshToken, root]);
 
   const workspaceArtifacts = analysisResult?.artifacts ?? [];
   const cleanupCandidates = cleanupPlan?.candidates ?? [];
@@ -155,6 +200,11 @@ export function useAppState() {
     setAnalysisResult(null);
     setCleanupPlan(null);
     setStorageSummary(null);
+    setArtifactHistory(null);
+    setArtifactHistoryStatus('idle');
+    setArtifactHistoryError(null);
+    setArtifactHistoryPersistenceWarning(null);
+    artifactHistoryRequestRef.current += 1;
     setSelectedCleanupPaths([]);
     setCleanupReviewPaths([]);
     setSelectedItemId(null);
@@ -220,6 +270,14 @@ export function useAppState() {
         setAnalysisResult(response.analysis);
         setCleanupPlan(response.cleanupPlan);
         setStorageSummary(response.storageSummary);
+        if (recordArtifactSnapshot) {
+          setArtifactHistoryPersistenceWarning(
+            [response.analysis.historyWarning, response.artifactSnapshotWarning]
+              .filter((warning): warning is string => Boolean(warning))
+              .join(' ') || null,
+          );
+          setArtifactHistoryRefreshToken((current) => current + 1);
+        }
         // Rebuild the default cleanup selection from the new policy. This
         // conservatively drops items that are no longer recommended and never
         // broadens the selection without a new recommendation.
@@ -459,6 +517,11 @@ export function useAppState() {
     sidebarEntries,
     filteredArtifacts,
     historyEntries,
+    artifactHistory,
+    artifactHistoryStatus,
+    artifactHistoryError,
+    artifactHistoryPersistenceWarning,
+    latestScanEntry: latestScanForWorkspace(historyEntries, root),
     confirmDialogOpen,
     confirmSamplePaths,
     workspaceOperation,

--- a/apps/tauri/src/features/app-shell/views/ArtifactHistoryView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/ArtifactHistoryView.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ArtifactHistoryView } from './ArtifactHistoryView';
+import type { ActivityRecord, ArtifactSnapshotHistory } from '../../../types/workflow';
+
+const scanEntry: ActivityRecord = {
+  id: 'scan-2',
+  timestampMs: Date.UTC(2026, 8, 3, 4, 5),
+  kind: 'Scan',
+  result: {
+    success: true,
+    details: {
+      path: '/workspace',
+      accessSummary: {
+        root: '/workspace',
+        directoriesVisited: 12,
+        filesInspected: 9,
+        metadataFilesInspected: 7,
+        artifactCandidates: 3,
+        symlinksSkipped: 2,
+        failures: 1,
+        failureSamples: [{ path: 'restricted', reason: 'permission denied' }],
+      },
+    },
+  },
+};
+
+const history: ArtifactSnapshotHistory = {
+  entries: [
+    {
+      status: 'baselineCreated',
+      snapshot: {
+        workspaceId: '/workspace',
+        timestamp: '2026-09-01T00:00:00Z',
+        artifacts: [],
+      },
+      previousSnapshot: null,
+      changes: [],
+    },
+    {
+      status: 'compared',
+      snapshot: {
+        workspaceId: '/workspace',
+        timestamp: '2026-09-03T00:00:00Z',
+        artifacts: [],
+      },
+      previousSnapshot: {
+        workspaceId: '/workspace',
+        timestamp: '2026-09-01T00:00:00Z',
+        artifacts: [],
+      },
+      changes: [
+        { path: 'target', ecosystem: 'Rust', kind: 'new', previousSizeBytes: null, currentSizeBytes: 2048, deltaBytes: 2048 },
+        { path: 'node_modules', ecosystem: 'Node', kind: 'removed', previousSizeBytes: 4096, currentSizeBytes: null, deltaBytes: -4096 },
+        { path: 'build', ecosystem: 'Java', kind: 'sizeIncreased', previousSizeBytes: 1024, currentSizeBytes: 3072, deltaBytes: 2048 },
+        { path: 'other/target', ecosystem: 'Rust', kind: 'sizeDecreased', previousSizeBytes: 3072, currentSizeBytes: 1024, deltaBytes: -2048 },
+        { path: 'other/node_modules', ecosystem: 'Node', kind: 'unchanged', previousSizeBytes: 512, currentSizeBytes: 512, deltaBytes: 0 },
+      ],
+    },
+  ],
+  retainedSnapshotCount: 2,
+  retentionLimit: 32,
+};
+
+const props = {
+  root: '/workspace',
+  status: 'success' as const,
+  error: null,
+  persistenceWarning: null,
+};
+
+describe('ArtifactHistoryView', () => {
+  it('distinguishes a workspace with no scan history', () => {
+    render(<ArtifactHistoryView {...props} history={{ entries: [], retainedSnapshotCount: 0, retentionLimit: 32 }} scanEntry={null} />);
+
+    expect(screen.getByText(/No scan has been run for this workspace yet/)).toBeInTheDocument();
+    expect(screen.getByText(/no generated-artifact baseline to compare/)).toBeInTheDocument();
+  });
+
+  it('renders the bounded summary, baseline, all Core change states, and exact signed deltas', () => {
+    render(<ArtifactHistoryView {...props} history={history} scanEntry={scanEntry} />);
+
+    expect(screen.getByText('Scan access summary')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('Representative failure samples')).toBeInTheDocument();
+    expect(screen.getByText('Baseline created')).toBeInTheDocument();
+    expect(screen.getByText('New')).toBeInTheDocument();
+    expect(screen.getByText('Removed')).toBeInTheDocument();
+    expect(screen.getByText('Size increased')).toBeInTheDocument();
+    expect(screen.getByText('Size decreased')).toBeInTheDocument();
+    expect(screen.getByText('Unchanged')).toBeInTheDocument();
+    expect(screen.getAllByText('+2,048 bytes')).not.toHaveLength(0);
+    expect(screen.getByText('-4,096 bytes')).toBeInTheDocument();
+    expect(screen.getByText('0 bytes')).toBeInTheDocument();
+    expect(screen.getByText(/at most 32 snapshots/)).toBeInTheDocument();
+  });
+
+  it('keeps persistence warnings visible while displaying retained history', () => {
+    render(
+      <ArtifactHistoryView
+        {...props}
+        history={history}
+        scanEntry={scanEntry}
+        persistenceWarning="Failed to record artifact snapshot"
+      />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Failed to record artifact snapshot');
+    expect(screen.getByText('Generated artifact snapshots')).toBeInTheDocument();
+  });
+
+  it('shows malformed or unsupported persisted state as an error', () => {
+    render(
+      <ArtifactHistoryView
+        root="/workspace"
+        history={null}
+        status="error"
+        error="unsupported artifact snapshot state version: 2"
+        scanEntry={null}
+        persistenceWarning={null}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Artifact history unavailable' })).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('unsupported artifact snapshot state version: 2');
+  });
+});

--- a/apps/tauri/src/features/app-shell/views/ArtifactHistoryView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/ArtifactHistoryView.test.tsx
@@ -109,6 +109,42 @@ describe('ArtifactHistoryView', () => {
     expect(screen.getByText('Generated artifact snapshots')).toBeInTheDocument();
   });
 
+  it('explains when the oldest retained entry has no available predecessor', () => {
+    render(
+      <ArtifactHistoryView
+        {...props}
+        history={{
+          entries: [
+            {
+              status: 'comparisonUnavailable',
+              snapshot: {
+                workspaceId: '/workspace',
+                timestamp: '2026-09-01T00:00:00Z',
+                artifacts: [],
+              },
+              previousSnapshot: null,
+              changes: [],
+            },
+          ],
+          retainedSnapshotCount: 32,
+          retentionLimit: 32,
+        }}
+        scanEntry={scanEntry}
+      />,
+    );
+
+    expect(screen.getByText('Comparison unavailable')).toBeInTheDocument();
+    expect(screen.getByText(/retention limit was reached/)).toBeInTheDocument();
+  });
+
+  it('does not call a missing activity record proof that no scan ever ran', () => {
+    render(<ArtifactHistoryView {...props} history={history} scanEntry={null} />);
+
+    expect(screen.getByText(/No retained scan activity is available/)).toBeInTheDocument();
+    expect(screen.queryByText(/No scan has been run for this workspace yet/)).not.toBeInTheDocument();
+    expect(screen.getByText('Compared')).toBeInTheDocument();
+  });
+
   it('shows malformed or unsupported persisted state as an error', () => {
     render(
       <ArtifactHistoryView

--- a/apps/tauri/src/features/app-shell/views/ArtifactHistoryView.tsx
+++ b/apps/tauri/src/features/app-shell/views/ArtifactHistoryView.tsx
@@ -1,0 +1,272 @@
+import { AsyncStatePanel } from '../../../components/AsyncStatePanel/AsyncStatePanel';
+import { EmptyState } from '../../../components/EmptyState/EmptyState';
+import { FolderIcon } from '../../../components/icons';
+import { formatBytes, formatCount, formatDate, formatSignedBytes } from '../../../lib/format';
+import {
+  changeKindLabel,
+  scanExecutionLabel,
+  snapshotStatusLabel,
+} from '../../../model/artifactHistory';
+import type {
+  ActivityRecord,
+  ArtifactSnapshotHistory,
+  ArtifactSnapshotResult,
+  ScanAccessSummary,
+} from '../../../types/workflow';
+import type { AsyncOperationStatus } from '../../../model/async';
+
+type ArtifactHistoryViewProps = {
+  root: string;
+  history: ArtifactSnapshotHistory | null;
+  status: AsyncOperationStatus;
+  error: string | null;
+  scanEntry: ActivityRecord | null;
+  persistenceWarning: string | null;
+};
+
+export function ArtifactHistoryView(props: ArtifactHistoryViewProps) {
+  return (
+    <div className="artifact-history-view">
+      <header className="artifact-history-heading">
+        <div>
+          <p className="eyebrow">Workspace</p>
+          <h1>Artifact History</h1>
+          <p className="heading-path" title={props.root}>
+            {props.root || 'No workspace selected'}
+          </p>
+        </div>
+      </header>
+
+      {props.persistenceWarning ? (
+        <div className="artifact-history-notice" role="status">
+          {props.persistenceWarning}
+        </div>
+      ) : null}
+
+      {props.status === 'loading' ? (
+        <AsyncStatePanel
+          status="loading"
+          title="Loading artifact history"
+          description="Reading retained scan summaries and generated-artifact snapshots."
+        />
+      ) : null}
+
+      {props.status === 'error' ? (
+        <AsyncStatePanel
+          status="error"
+          title="Artifact history unavailable"
+          description="DustFril could not read the retained artifact snapshot state."
+          error={props.error ?? undefined}
+        />
+      ) : null}
+
+      {props.status === 'idle' && !props.root ? (
+        <AsyncStatePanel
+          status="empty"
+          title="No workspace selected"
+          description="Choose a workspace to view its scan summary and artifact snapshots."
+        />
+      ) : null}
+
+      {props.status === 'success' && props.history ? (
+        <div className="artifact-history-content">
+          <ScanSummary entry={props.scanEntry} />
+          <SnapshotHistory history={props.history} scanEntry={props.scanEntry} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ScanSummary({ entry }: { entry: ActivityRecord | null }) {
+  return (
+    <section className="artifact-history-card" aria-labelledby="scan-summary-heading">
+      <div className="artifact-history-card-heading">
+        <div>
+          <p className="eyebrow">Bounded scan data</p>
+          <h2 id="scan-summary-heading">Scan access summary</h2>
+        </div>
+        {entry ? (
+          <span className={`history-status history-status-${entry.result.success ? 'success' : 'failed'}`}>
+            {scanExecutionLabel(entry)}
+          </span>
+        ) : null}
+      </div>
+
+      {!entry ? (
+        <EmptyState
+          compact
+          icon={<FolderIcon />}
+          message="No scan has been run for this workspace yet. Artifact History is read-only until an explicit scan is completed."
+        />
+      ) : entry.result.details.accessSummary ? (
+        <AccessSummaryDetails entry={entry} summary={entry.result.details.accessSummary} />
+      ) : (
+        <div className="artifact-history-inline-state" role="status">
+          <strong>Scan summary unavailable</strong>
+          <span>
+            This scan record does not contain bounded access metrics. Its operation reference is{' '}
+            <code>{entry.id}</code>.
+          </span>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function AccessSummaryDetails({
+  entry,
+  summary,
+}: {
+  entry: ActivityRecord;
+  summary: ScanAccessSummary;
+}) {
+  return (
+    <>
+      <dl className="artifact-history-metrics">
+        <Metric label="Scan time" value={formatDate(entry.timestampMs)} />
+        <Metric label="Operation" value={entry.id} />
+        <Metric label="Directories visited" value={formatCount(summary.directoriesVisited)} />
+        <Metric label="Files inspected" value={formatCount(summary.filesInspected)} />
+        <Metric label="Metadata files" value={formatCount(summary.metadataFilesInspected)} />
+        <Metric label="Artifact candidates" value={formatCount(summary.artifactCandidates)} />
+        <Metric label="Symlinks skipped" value={formatCount(summary.symlinksSkipped)} />
+        <Metric label="Failures" value={formatCount(summary.failures)} />
+      </dl>
+      {summary.failureSamples.length ? (
+        <div className="artifact-history-samples">
+          <p className="eyebrow">Representative failure samples</p>
+          <ul>
+            {summary.failureSamples.map((failure, index) => (
+              <li key={`${failure.path}-${index}`}>
+                <code>{failure.path}</code>
+                <span>{failure.reason}</span>
+              </li>
+            ))}
+          </ul>
+          <small>Total failures remain authoritative; displayed paths are bounded representative samples.</small>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function SnapshotHistory({
+  history,
+  scanEntry,
+}: {
+  history: ArtifactSnapshotHistory;
+  scanEntry: ActivityRecord | null;
+}) {
+  const entries = [...history.entries].reverse();
+
+  return (
+    <section className="artifact-history-card" aria-labelledby="snapshot-history-heading">
+      <div className="artifact-history-card-heading">
+        <div>
+          <p className="eyebrow">Core-provided comparisons</p>
+          <h2 id="snapshot-history-heading">Generated artifact snapshots</h2>
+        </div>
+        <span className="artifact-history-retention">
+          {formatCount(history.retainedSnapshotCount)} of {formatCount(history.retentionLimit)} retained
+        </span>
+      </div>
+
+      <p className="artifact-history-retention-note">
+        DustFril retains at most {formatCount(history.retentionLimit)} snapshots per workspace. This view
+        shows the bounded history available from Core; opening it does not create a snapshot.
+      </p>
+
+      {!history.entries.length ? (
+        <EmptyState
+          compact
+          icon={<FolderIcon />}
+          message={
+            scanEntry
+              ? 'No artifact snapshot is available for the latest scan. A snapshot persistence warning may explain why.'
+              : 'No scan has been run yet, so there is no generated-artifact baseline to compare.'
+          }
+        />
+      ) : (
+        <div className="artifact-snapshot-list">
+          {entries.map((entry) => (
+            <SnapshotCard key={entry.snapshot.timestamp} entry={entry} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SnapshotCard({ entry }: { entry: ArtifactSnapshotResult }) {
+  const isBaseline = entry.status === 'baselineCreated';
+
+  return (
+    <article className="artifact-snapshot-card">
+      <header className="artifact-snapshot-header">
+        <div>
+          <h3>{snapshotStatusLabel(entry.status)}</h3>
+          <p>{formatDate(new Date(entry.snapshot.timestamp).getTime())}</p>
+        </div>
+        <span className="artifact-snapshot-count">
+          {formatCount(entry.snapshot.artifacts.length)} artifact{entry.snapshot.artifacts.length === 1 ? '' : 's'}
+        </span>
+      </header>
+
+      {isBaseline ? (
+        <p className="artifact-history-card-description">
+          First retained baseline. There is no earlier snapshot for a size comparison.
+        </p>
+      ) : entry.changes.length ? (
+        <ChangeTable entry={entry} />
+      ) : (
+        <p className="artifact-history-card-description">
+          No generated-artifact changes were reported for this snapshot.
+        </p>
+      )}
+    </article>
+  );
+}
+
+function ChangeTable({ entry }: { entry: ArtifactSnapshotResult }) {
+  return (
+    <div className="artifact-change-table" role="table" aria-label="Artifact snapshot changes">
+      <div className="artifact-change-row artifact-change-row-header" role="row">
+        <span role="columnheader">Artifact</span>
+        <span role="columnheader">State</span>
+        <span role="columnheader">Previous</span>
+        <span role="columnheader">Current</span>
+        <span role="columnheader">Delta</span>
+      </div>
+      {entry.changes.map((change) => (
+        <div className="artifact-change-row" role="row" key={`${change.ecosystem}:${change.path}`}>
+          <span role="cell">
+            <strong>{change.path}</strong>
+            <small>{change.ecosystem}</small>
+          </span>
+          <span role="cell" className={`artifact-change-kind artifact-change-kind-${change.kind}`}>
+            {changeKindLabel(change.kind)}
+          </span>
+          <span role="cell">{formatOptionalBytes(change.previousSizeBytes)}</span>
+          <span role="cell">{formatOptionalBytes(change.currentSizeBytes)}</span>
+          <span role="cell" className="artifact-change-delta">
+            {formatSignedBytes(change.deltaBytes)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt>{label}</dt>
+      <dd title={value}>{value}</dd>
+    </div>
+  );
+}
+
+function formatOptionalBytes(bytes: number | null) {
+  return bytes === null ? '—' : formatBytes(bytes);
+}

--- a/apps/tauri/src/features/app-shell/views/ArtifactHistoryView.tsx
+++ b/apps/tauri/src/features/app-shell/views/ArtifactHistoryView.tsx
@@ -70,7 +70,7 @@ export function ArtifactHistoryView(props: ArtifactHistoryViewProps) {
 
       {props.status === 'success' && props.history ? (
         <div className="artifact-history-content">
-          <ScanSummary entry={props.scanEntry} />
+          <ScanSummary entry={props.scanEntry} hasSnapshotHistory={props.history.entries.length > 0} />
           <SnapshotHistory history={props.history} scanEntry={props.scanEntry} />
         </div>
       ) : null}
@@ -78,7 +78,13 @@ export function ArtifactHistoryView(props: ArtifactHistoryViewProps) {
   );
 }
 
-function ScanSummary({ entry }: { entry: ActivityRecord | null }) {
+function ScanSummary({
+  entry,
+  hasSnapshotHistory,
+}: {
+  entry: ActivityRecord | null;
+  hasSnapshotHistory: boolean;
+}) {
   return (
     <section className="artifact-history-card" aria-labelledby="scan-summary-heading">
       <div className="artifact-history-card-heading">
@@ -97,7 +103,11 @@ function ScanSummary({ entry }: { entry: ActivityRecord | null }) {
         <EmptyState
           compact
           icon={<FolderIcon />}
-          message="No scan has been run for this workspace yet. Artifact History is read-only until an explicit scan is completed."
+          message={
+            hasSnapshotHistory
+              ? 'No retained scan activity is available for this workspace. The artifact snapshots below remain available from Core.'
+              : 'No scan has been run for this workspace yet. Artifact History is read-only until an explicit scan is completed.'
+          }
         />
       ) : entry.result.details.accessSummary ? (
         <AccessSummaryDetails entry={entry} summary={entry.result.details.accessSummary} />
@@ -200,6 +210,7 @@ function SnapshotHistory({
 
 function SnapshotCard({ entry }: { entry: ArtifactSnapshotResult }) {
   const isBaseline = entry.status === 'baselineCreated';
+  const isComparisonUnavailable = entry.status === 'comparisonUnavailable';
 
   return (
     <article className="artifact-snapshot-card">
@@ -216,6 +227,11 @@ function SnapshotCard({ entry }: { entry: ArtifactSnapshotResult }) {
       {isBaseline ? (
         <p className="artifact-history-card-description">
           First retained baseline. There is no earlier snapshot for a size comparison.
+        </p>
+      ) : isComparisonUnavailable ? (
+        <p className="artifact-history-card-description">
+          The earlier snapshot for this retained entry is no longer available because the history
+          retention limit was reached. No comparison is inferred.
         </p>
       ) : entry.changes.length ? (
         <ChangeTable entry={entry} />

--- a/apps/tauri/src/lib/format.test.ts
+++ b/apps/tauri/src/lib/format.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { formatSignedBytes } from './format';
+
+describe('formatSignedBytes', () => {
+  it('formats positive, negative, and zero raw byte deltas', () => {
+    expect(formatSignedBytes(2048)).toBe('+2,048 bytes');
+    expect(formatSignedBytes(-4096)).toBe('-4,096 bytes');
+    expect(formatSignedBytes(0)).toBe('0 bytes');
+  });
+});

--- a/apps/tauri/src/lib/format.ts
+++ b/apps/tauri/src/lib/format.ts
@@ -14,6 +14,14 @@ export function formatBytes(bytes: number) {
   return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
 }
 
+export function formatSignedBytes(bytes: number) {
+  if (bytes === 0) {
+    return '0 bytes';
+  }
+
+  return `${bytes > 0 ? '+' : '-'}${numberFormatter.format(Math.abs(bytes))} bytes`;
+}
+
 export function formatAge(days: number | null) {
   if (days === null) {
     return 'Unknown';

--- a/apps/tauri/src/lib/tauri.ts
+++ b/apps/tauri/src/lib/tauri.ts
@@ -3,6 +3,7 @@ import { open } from '@tauri-apps/plugin-dialog';
 import type {
   AnalysisResponse,
   ArtifactSelection,
+  ArtifactSnapshotHistory,
   ActivityRecord,
   CleanupPlanResponse,
   CleanupResultResponse,
@@ -28,6 +29,7 @@ const commands = {
   loadActivityHistory: 'load_activity_history',
   clearActivityHistory: 'clear_activity_history',
   loadCleanupHistory: 'load_cleanup_history',
+  loadArtifactSnapshotHistory: 'load_artifact_snapshot_history',
 } as const;
 
 export function defaultRoot() {
@@ -91,4 +93,8 @@ export function loadActivityHistory() {
 
 export function clearActivityHistory() {
   return invoke<void>(commands.clearActivityHistory);
+}
+
+export function loadArtifactSnapshotHistory(root: string) {
+  return invoke<ArtifactSnapshotHistory>(commands.loadArtifactSnapshotHistory, { root });
 }

--- a/apps/tauri/src/model/artifactHistory.test.ts
+++ b/apps/tauri/src/model/artifactHistory.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { latestScanForWorkspace, scanExecutionLabel } from './artifactHistory';
+import type { ActivityRecord } from '../types/workflow';
+
+function scan(id: string, timestampMs: number, path: string): ActivityRecord {
+  return {
+    id,
+    timestampMs,
+    kind: 'Scan',
+    result: { success: true, details: { path } },
+  };
+}
+
+describe('artifact history model', () => {
+  it('selects the newest scan for the selected workspace only', () => {
+    const entries = [
+      scan('other', 30, '/other'),
+      scan('old', 10, '/workspace/'),
+      scan('new', 20, '/workspace'),
+    ];
+
+    expect(latestScanForWorkspace(entries, '/workspace')?.id).toBe('new');
+  });
+
+  it('distinguishes completed scans with bounded access warnings', () => {
+    const entry = scan('warning', 10, '/workspace');
+    entry.result.details.accessSummary = {
+      root: '/workspace',
+      directoriesVisited: 1,
+      filesInspected: 0,
+      metadataFilesInspected: 0,
+      artifactCandidates: 0,
+      symlinksSkipped: 0,
+      failures: 2,
+      failureSamples: [],
+    };
+
+    expect(scanExecutionLabel(entry)).toBe('Completed with warnings');
+    entry.result.success = false;
+    expect(scanExecutionLabel(entry)).toBe('Failed');
+  });
+});

--- a/apps/tauri/src/model/artifactHistory.ts
+++ b/apps/tauri/src/model/artifactHistory.ts
@@ -1,4 +1,8 @@
-import type { ActivityRecord, ArtifactChangeKind } from '../types/workflow';
+import type {
+  ActivityRecord,
+  ArtifactChangeKind,
+  ArtifactSnapshotStatus,
+} from '../types/workflow';
 
 export function latestScanForWorkspace(entries: ActivityRecord[], root: string) {
   const normalizedRoot = normalizePath(root);
@@ -43,8 +47,15 @@ export function changeKindLabel(kind: ArtifactChangeKind) {
   }
 }
 
-export function snapshotStatusLabel(status: 'baselineCreated' | 'compared') {
-  return status === 'baselineCreated' ? 'Baseline created' : 'Compared';
+export function snapshotStatusLabel(status: ArtifactSnapshotStatus) {
+  switch (status) {
+    case 'baselineCreated':
+      return 'Baseline created';
+    case 'compared':
+      return 'Compared';
+    case 'comparisonUnavailable':
+      return 'Comparison unavailable';
+  }
 }
 
 function normalizePath(path: string) {

--- a/apps/tauri/src/model/artifactHistory.ts
+++ b/apps/tauri/src/model/artifactHistory.ts
@@ -1,0 +1,53 @@
+import type { ActivityRecord, ArtifactChangeKind } from '../types/workflow';
+
+export function latestScanForWorkspace(entries: ActivityRecord[], root: string) {
+  const normalizedRoot = normalizePath(root);
+
+  return (
+    entries
+      .filter((entry) => {
+        if (entry.kind !== 'Scan') {
+          return false;
+        }
+
+        const details = entry.result.details;
+        const recordedRoot = details.path ?? details.accessSummary?.root;
+        return recordedRoot ? normalizePath(recordedRoot) === normalizedRoot : false;
+      })
+      .sort((left, right) => right.timestampMs - left.timestampMs)[0] ?? null
+  );
+}
+
+export function scanExecutionLabel(entry: ActivityRecord) {
+  if (!entry.result.success) {
+    return 'Failed';
+  }
+
+  return entry.result.details.accessSummary?.failures
+    ? 'Completed with warnings'
+    : 'Completed';
+}
+
+export function changeKindLabel(kind: ArtifactChangeKind) {
+  switch (kind) {
+    case 'new':
+      return 'New';
+    case 'removed':
+      return 'Removed';
+    case 'sizeIncreased':
+      return 'Size increased';
+    case 'sizeDecreased':
+      return 'Size decreased';
+    case 'unchanged':
+      return 'Unchanged';
+  }
+}
+
+export function snapshotStatusLabel(status: 'baselineCreated' | 'compared') {
+  return status === 'baselineCreated' ? 'Baseline created' : 'Compared';
+}
+
+function normalizePath(path: string) {
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
+  return normalized || '/';
+}

--- a/apps/tauri/src/model/categories.test.ts
+++ b/apps/tauri/src/model/categories.test.ts
@@ -31,8 +31,8 @@ describe('desktop module navigation', () => {
     expect(categoryConfig('cleanup-node')?.availability).toBe('available');
     expect(categoryConfig('cleanup-java')?.availability).toBe('available');
     expect(categoryConfig('workspace-activity')?.availability).toBe('available');
+    expect(categoryConfig('workspace-artifact-history')?.availability).toBe('available');
     expect(categoryConfig('cleanup-cache')?.availability).toBe('planned');
     expect(categoryConfig('security-supply-chain')?.availability).toBe('planned');
-    expect(categoryConfig('workspace-artifact-history')?.availability).toBe('planned');
   });
 });

--- a/apps/tauri/src/model/categories.ts
+++ b/apps/tauri/src/model/categories.ts
@@ -91,9 +91,9 @@ export const categoryConfigs: CategoryConfig[] = [
   {
     key: 'workspace-artifact-history',
     title: 'Artifact History',
-    description: 'Future generated-artifact history and growth',
+    description: 'Scan access summaries and generated-artifact growth',
     section: 'workspace',
-    availability: 'planned',
+    availability: 'available',
   },
   {
     key: 'workspace-activity',

--- a/apps/tauri/src/styles/style.css
+++ b/apps/tauri/src/styles/style.css
@@ -2000,6 +2000,323 @@ button:disabled {
   opacity: 0.5;
 }
 
+.artifact-history-view {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 22px 24px 14px;
+}
+
+.artifact-history-heading {
+  display: flex;
+  min-width: 0;
+  flex: 0 0 auto;
+  padding-bottom: 15px;
+}
+
+.artifact-history-heading h1 {
+  margin: 3px 0 0;
+  color: #f7f9fc;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+}
+
+.artifact-history-content {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 12px;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.artifact-history-view > .async-state-panel {
+  flex: 0 0 auto;
+}
+
+.artifact-history-notice {
+  flex: 0 0 auto;
+  margin: 0 0 10px;
+  padding: 8px 10px;
+  border: 1px solid rgba(247, 190, 91, 0.28);
+  border-radius: 5px;
+  background: rgba(180, 117, 28, 0.1);
+  color: #f7d797;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.artifact-history-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 11px;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  background: #222427;
+}
+
+.artifact-history-card-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.artifact-history-card-heading h2 {
+  margin: 4px 0 0;
+  color: #f0f4f7;
+  font-size: 16px;
+}
+
+.artifact-history-card-heading .history-status {
+  flex: 0 0 auto;
+}
+
+.artifact-history-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.artifact-history-metrics > div {
+  min-width: 0;
+  padding: 9px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.artifact-history-metrics dt {
+  margin: 0 0 4px;
+  color: #7f8996;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.artifact-history-metrics dd {
+  margin: 0;
+  overflow: hidden;
+  color: #d7e0e7;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.artifact-history-inline-state {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 12px;
+  border-radius: 5px;
+  background: rgba(247, 190, 91, 0.08);
+  color: #f7d797;
+  font-size: 12px;
+}
+
+.artifact-history-inline-state span {
+  color: #bfc8d0;
+  line-height: 1.5;
+}
+
+.artifact-history-inline-state code,
+.artifact-history-samples code {
+  color: #e8edf2;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+}
+
+.artifact-history-samples {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 3px;
+}
+
+.artifact-history-samples ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.artifact-history-samples li {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 5px 10px;
+  padding: 7px 9px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #adb8c2;
+  font-size: 11px;
+}
+
+.artifact-history-samples li span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.artifact-history-samples small,
+.artifact-history-retention-note {
+  color: #7f8996;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.artifact-history-retention {
+  flex: 0 0 auto;
+  color: #aeb9c5;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.artifact-history-retention-note {
+  margin: -3px 0 0;
+}
+
+.artifact-snapshot-list {
+  display: grid;
+  gap: 9px;
+}
+
+.artifact-snapshot-card {
+  min-width: 0;
+  padding: 11px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.artifact-snapshot-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 9px;
+}
+
+.artifact-snapshot-header h3 {
+  margin: 0;
+  color: #e9eef2;
+  font-size: 13px;
+}
+
+.artifact-snapshot-header p {
+  margin: 4px 0 0;
+  color: #84909c;
+  font-size: 11px;
+}
+
+.artifact-snapshot-count {
+  flex: 0 0 auto;
+  color: #9faab5;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.artifact-history-card-description {
+  margin: 0;
+  color: #aeb8c3;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.artifact-change-table {
+  min-width: 660px;
+  overflow-x: auto;
+}
+
+.artifact-change-row {
+  display: grid;
+  grid-template-columns: minmax(190px, 1.8fr) minmax(115px, 1fr) 90px 90px 90px;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+  color: #c2ccd5;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.artifact-change-row-header {
+  min-height: 27px;
+  background: rgba(255, 255, 255, 0.035);
+  color: #828c99;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.artifact-change-row > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.artifact-change-row > span:first-child {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.artifact-change-row strong {
+  overflow: hidden;
+  color: #e4ebf0;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.artifact-change-row small {
+  color: #7f8996;
+  font-size: 10px;
+}
+
+.artifact-change-kind {
+  font-weight: 650;
+}
+
+.artifact-change-kind-new {
+  color: #a9e6f8;
+}
+
+.artifact-change-kind-removed {
+  color: #f0b7b7;
+}
+
+.artifact-change-kind-sizeIncreased {
+  color: #f7d797;
+}
+
+.artifact-change-kind-sizeDecreased {
+  color: #b6e7cc;
+}
+
+.artifact-change-kind-unchanged {
+  color: #aeb9c5;
+}
+
+.artifact-change-delta {
+  color: #f1f5f8;
+  font-weight: 650;
+}
+
 @media (max-width: 1100px) {
   .app-toolbar {
     grid-template-columns: auto minmax(150px, 1fr) minmax(150px, 1fr) auto;
@@ -2130,6 +2447,14 @@ button:disabled {
 
   .history-toolbar {
     padding: 6px 12px;
+  }
+
+  .artifact-history-view {
+    padding: 16px 12px 10px;
+  }
+
+  .artifact-history-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
 }

--- a/apps/tauri/src/types/workflow.ts
+++ b/apps/tauri/src/types/workflow.ts
@@ -30,7 +30,7 @@ export type ScanResponse = {
   artifactSnapshotWarning?: string;
 };
 
-export type ArtifactSnapshotStatus = 'baselineCreated' | 'compared';
+export type ArtifactSnapshotStatus = 'baselineCreated' | 'compared' | 'comparisonUnavailable';
 export type ArtifactChangeKind =
   | 'new'
   | 'removed'

--- a/apps/tauri/src/types/workflow.ts
+++ b/apps/tauri/src/types/workflow.ts
@@ -66,6 +66,12 @@ export type ArtifactSnapshotResult = {
   changes: ArtifactSizeChange[];
 };
 
+export type ArtifactSnapshotHistory = {
+  entries: ArtifactSnapshotResult[];
+  retainedSnapshotCount: number;
+  retentionLimit: number;
+};
+
 export type ArtifactAnalysis = {
   path: string;
   ecosystem: Ecosystem;

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -36,7 +36,10 @@ Only existing `target/`, `node_modules/`, and `build/` artifacts are included;
 `Cargo.lock` and ordinary source files are excluded. The first snapshot creates
 a baseline without changes. Later snapshots compare only structured analysis
 metadata and return deterministic new/removed/increased/decreased/unchanged
-states with exact signed byte deltas. The store atomically replaces its file,
+states with exact signed byte deltas. If retention has evicted the predecessor
+of the oldest retained snapshot, read-only history reports that comparison as
+unavailable rather than relabeling it as a new baseline. The store atomically
+replaces its file,
 preserves multiple workspaces, retains at most 32 snapshots per workspace, and
 returns malformed or unsupported state errors explicitly. A persistence error
 does not mutate the caller's completed analysis result. Symlink and canonical

--- a/crates/core/src/api/artifact_snapshot.rs
+++ b/crates/core/src/api/artifact_snapshot.rs
@@ -58,8 +58,11 @@ pub fn load_artifact_snapshot_history(
     workspace_path: &Path,
 ) -> DustResult<Vec<ArtifactSnapshotResult>> {
     let path = artifact_snapshot_path()?;
-    let snapshots = ArtifactSnapshotStore::new(path).load_workspace(workspace_path)?;
-    Ok(artifact_snapshot::artifact_snapshot_history(snapshots))
+    let retained = ArtifactSnapshotStore::new(path).load_workspace_with_metadata(workspace_path)?;
+    Ok(artifact_snapshot::artifact_snapshot_history(
+        retained.snapshots,
+        retained.history_truncated,
+    ))
 }
 
 #[cfg(test)]
@@ -110,7 +113,8 @@ mod tests {
         store.record_snapshot(first).unwrap();
         store.record_snapshot(second).unwrap();
 
-        let history = artifact_snapshot::artifact_snapshot_history(store.load_all().unwrap());
+        let history =
+            artifact_snapshot::artifact_snapshot_history(store.load_all().unwrap(), false);
 
         assert_eq!(history.len(), 2);
         assert_eq!(

--- a/crates/core/src/api/artifact_snapshot.rs
+++ b/crates/core/src/api/artifact_snapshot.rs
@@ -50,6 +50,18 @@ pub fn load_artifact_snapshots() -> DustResult<Vec<ArtifactSnapshot>> {
     ArtifactSnapshotStore::new(path).load_all()
 }
 
+/// Loads the retained snapshot comparisons for one canonical workspace.
+///
+/// This is a read-only query. It never scans the workspace, calculates
+/// artifact sizes, or writes snapshot state.
+pub fn load_artifact_snapshot_history(
+    workspace_path: &Path,
+) -> DustResult<Vec<ArtifactSnapshotResult>> {
+    let path = artifact_snapshot_path()?;
+    let snapshots = ArtifactSnapshotStore::new(path).load_workspace(workspace_path)?;
+    Ok(artifact_snapshot::artifact_snapshot_history(snapshots))
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -78,5 +90,37 @@ mod tests {
 
         assert_eq!(snapshot.artifacts[0].path, PathBuf::from("target"));
         assert_eq!(snapshot.artifacts[0].size_bytes, 42);
+    }
+
+    #[test]
+    fn snapshot_history_query_is_read_only_and_core_computed() {
+        let workspace = TempDir::new().unwrap();
+        let store = ArtifactSnapshotStore::new(workspace.path().join("snapshots.json"));
+        let first = ArtifactSnapshot::from_analysis_at(
+            workspace.path().display().to_string(),
+            workspace.path(),
+            &AnalysisResult::default(),
+            chrono::DateTime::UNIX_EPOCH,
+        );
+        let second = ArtifactSnapshot {
+            timestamp: chrono::DateTime::UNIX_EPOCH + chrono::Duration::seconds(1),
+            ..first.clone()
+        };
+
+        store.record_snapshot(first).unwrap();
+        store.record_snapshot(second).unwrap();
+
+        let history = artifact_snapshot::artifact_snapshot_history(store.load_all().unwrap());
+
+        assert_eq!(history.len(), 2);
+        assert_eq!(
+            history[0].status,
+            crate::models::ArtifactSnapshotStatus::BaselineCreated
+        );
+        assert_eq!(
+            history[1].status,
+            crate::models::ArtifactSnapshotStatus::Compared
+        );
+        assert!(history[1].changes.is_empty());
     }
 }

--- a/crates/core/src/artifact_snapshot.rs
+++ b/crates/core/src/artifact_snapshot.rs
@@ -28,6 +28,12 @@ static SNAPSHOT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 struct ArtifactSnapshotState {
     version: u32,
     workspaces: BTreeMap<String, Vec<ArtifactSnapshot>>,
+    /// Whether the oldest retained snapshot may have an evicted predecessor.
+    /// `None` keeps older state files backward-compatible; a full legacy
+    /// workspace is treated conservatively because its retention boundary is
+    /// otherwise unknowable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retention_metadata: Option<BTreeMap<String, bool>>,
 }
 
 impl Default for ArtifactSnapshotState {
@@ -35,8 +41,14 @@ impl Default for ArtifactSnapshotState {
         Self {
             version: ARTIFACT_SNAPSHOT_STATE_VERSION,
             workspaces: BTreeMap::new(),
+            retention_metadata: None,
         }
     }
+}
+
+pub(crate) struct RetainedArtifactSnapshots {
+    pub(crate) snapshots: Vec<ArtifactSnapshot>,
+    pub(crate) history_truncated: bool,
 }
 
 /// Access to the versioned local generated-artifact snapshot collection.
@@ -67,17 +79,36 @@ impl ArtifactSnapshotStore {
 
     /// Loads retained snapshots for one canonical workspace.
     pub fn load_workspace(&self, workspace_path: &Path) -> DustResult<Vec<ArtifactSnapshot>> {
+        self.load_workspace_with_metadata(workspace_path)
+            .map(|history| history.snapshots)
+    }
+
+    /// Loads retained snapshots and whether retention may have removed an
+    /// older predecessor from the beginning of the returned history.
+    pub(crate) fn load_workspace_with_metadata(
+        &self,
+        workspace_path: &Path,
+    ) -> DustResult<RetainedArtifactSnapshots> {
         let workspace_id = workspace_id(workspace_path)?;
         let _guard = snapshot_lock()
             .lock()
             .unwrap_or_else(|error| error.into_inner());
         let state = load_state(&self.path)?;
-
-        Ok(state
+        let snapshots = state
             .workspaces
             .get(&workspace_id)
             .cloned()
-            .unwrap_or_default())
+            .unwrap_or_default();
+        let history_truncated = state
+            .retention_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(&workspace_id).copied())
+            .unwrap_or(snapshots.len() >= MAX_ARTIFACT_SNAPSHOTS_PER_WORKSPACE);
+
+        Ok(RetainedArtifactSnapshots {
+            snapshots,
+            history_truncated,
+        })
     }
 
     /// Creates and persists one snapshot from an existing analysis result.
@@ -149,6 +180,16 @@ impl ArtifactSnapshotStore {
             .unwrap_or_default();
 
         let mut next_state = state;
+        let existing_snapshot_count = next_state
+            .workspaces
+            .get(&snapshot.workspace_id)
+            .map_or(0, Vec::len);
+        let history_truncated = next_state
+            .retention_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(&snapshot.workspace_id).copied())
+            .unwrap_or(false)
+            || existing_snapshot_count >= MAX_ARTIFACT_SNAPSHOTS_PER_WORKSPACE;
         let snapshots = next_state
             .workspaces
             .entry(snapshot.workspace_id.clone())
@@ -158,6 +199,10 @@ impl ArtifactSnapshotStore {
             let first_retained = snapshots.len() - MAX_ARTIFACT_SNAPSHOTS_PER_WORKSPACE;
             snapshots.drain(..first_retained);
         }
+        next_state
+            .retention_metadata
+            .get_or_insert_with(BTreeMap::new)
+            .insert(snapshot.workspace_id.clone(), history_truncated);
 
         save_state(&self.path, &next_state)?;
 
@@ -175,7 +220,10 @@ impl ArtifactSnapshotStore {
 /// Keeping this comparison next to snapshot persistence means read-only
 /// consumers can render the exact same New/Removed/Resized/Unchanged states as
 /// an explicit snapshot operation without reimplementing comparison logic.
-pub fn artifact_snapshot_history(snapshots: Vec<ArtifactSnapshot>) -> Vec<ArtifactSnapshotResult> {
+pub fn artifact_snapshot_history(
+    snapshots: Vec<ArtifactSnapshot>,
+    history_truncated: bool,
+) -> Vec<ArtifactSnapshotResult> {
     let mut previous_snapshot = None;
 
     snapshots
@@ -184,6 +232,8 @@ pub fn artifact_snapshot_history(snapshots: Vec<ArtifactSnapshot>) -> Vec<Artifa
             let result = ArtifactSnapshotResult {
                 status: if previous_snapshot.is_some() {
                     ArtifactSnapshotStatus::Compared
+                } else if history_truncated {
+                    ArtifactSnapshotStatus::ComparisonUnavailable
                 } else {
                     ArtifactSnapshotStatus::BaselineCreated
                 },
@@ -737,5 +787,41 @@ mod tests {
         let snapshots = store.load_all().unwrap();
         assert_eq!(snapshots.len(), MAX_ARTIFACT_SNAPSHOTS_PER_WORKSPACE);
         assert_eq!(snapshots[0].artifacts[0].size_bytes, 3);
+
+        let retained = store
+            .load_workspace_with_metadata(workspace.path())
+            .unwrap();
+        assert!(retained.history_truncated);
+        let history = artifact_snapshot_history(retained.snapshots, retained.history_truncated);
+        assert_eq!(
+            history[0].status,
+            ArtifactSnapshotStatus::ComparisonUnavailable
+        );
+        assert!(history[0].previous_snapshot.is_none());
+        assert!(history[0].changes.is_empty());
+    }
+
+    #[test]
+    fn exact_retention_limit_keeps_a_known_baseline() {
+        let workspace = TempDir::new().unwrap();
+        let store = ArtifactSnapshotStore::new(workspace.path().join("snapshots.json"));
+
+        for timestamp in 0..MAX_ARTIFACT_SNAPSHOTS_PER_WORKSPACE as i64 {
+            store
+                .record_snapshot(snapshot(
+                    workspace.path(),
+                    "target",
+                    timestamp as u64,
+                    timestamp,
+                ))
+                .unwrap();
+        }
+
+        let retained = store
+            .load_workspace_with_metadata(workspace.path())
+            .unwrap();
+        assert!(!retained.history_truncated);
+        let history = artifact_snapshot_history(retained.snapshots, retained.history_truncated);
+        assert_eq!(history[0].status, ArtifactSnapshotStatus::BaselineCreated);
     }
 }

--- a/crates/core/src/artifact_snapshot.rs
+++ b/crates/core/src/artifact_snapshot.rs
@@ -170,6 +170,36 @@ impl ArtifactSnapshotStore {
     }
 }
 
+/// Builds the Core-owned comparison results for retained snapshots.
+///
+/// Keeping this comparison next to snapshot persistence means read-only
+/// consumers can render the exact same New/Removed/Resized/Unchanged states as
+/// an explicit snapshot operation without reimplementing comparison logic.
+pub fn artifact_snapshot_history(snapshots: Vec<ArtifactSnapshot>) -> Vec<ArtifactSnapshotResult> {
+    let mut previous_snapshot = None;
+
+    snapshots
+        .into_iter()
+        .map(|snapshot| {
+            let result = ArtifactSnapshotResult {
+                status: if previous_snapshot.is_some() {
+                    ArtifactSnapshotStatus::Compared
+                } else {
+                    ArtifactSnapshotStatus::BaselineCreated
+                },
+                changes: previous_snapshot
+                    .as_ref()
+                    .map(|previous| compare_artifact_snapshots(previous, &snapshot))
+                    .unwrap_or_default(),
+                previous_snapshot: previous_snapshot.clone(),
+                snapshot: snapshot.clone(),
+            };
+            previous_snapshot = Some(snapshot);
+            result
+        })
+        .collect()
+}
+
 fn merge_unselected_artifacts(
     previous: Option<&ArtifactSnapshot>,
     mut current: ArtifactSnapshot,

--- a/crates/core/src/models/artifact_snapshot.rs
+++ b/crates/core/src/models/artifact_snapshot.rs
@@ -19,11 +19,12 @@ pub const MAX_ARTIFACT_SNAPSHOTS_PER_WORKSPACE: usize = 32;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ArtifactSnapshotResult {
-    /// Whether this operation established a baseline or compared two snapshots.
+    /// Whether this result established a baseline, compared snapshots, or
+    /// cannot compare because retention evicted the predecessor.
     pub status: ArtifactSnapshotStatus,
     /// The snapshot produced by the explicit operation.
     pub snapshot: ArtifactSnapshot,
-    /// The previous snapshot for this workspace, if one existed.
+    /// The previous retained snapshot for this workspace, if one is available.
     pub previous_snapshot: Option<ArtifactSnapshot>,
     /// Deterministically ordered changes between the previous and current state.
     pub changes: Vec<ArtifactSizeChange>,
@@ -36,7 +37,7 @@ impl ArtifactSnapshotResult {
     }
 }
 
-/// Whether an explicit snapshot created a baseline or produced a comparison.
+/// Whether a snapshot is a baseline, a comparison, or has an evicted predecessor.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum ArtifactSnapshotStatus {
@@ -44,6 +45,8 @@ pub enum ArtifactSnapshotStatus {
     BaselineCreated,
     /// The current snapshot was compared with the previous snapshot.
     Compared,
+    /// The previous snapshot may exist but is no longer retained.
+    ComparisonUnavailable,
 }
 
 impl fmt::Display for ArtifactSnapshotStatus {
@@ -51,6 +54,7 @@ impl fmt::Display for ArtifactSnapshotStatus {
         match self {
             Self::BaselineCreated => f.write_str("Baseline created"),
             Self::Compared => f.write_str("Compared"),
+            Self::ComparisonUnavailable => f.write_str("Comparison unavailable"),
         }
     }
 }


### PR DESCRIPTION
Refs #143\n\n## Summary\n- Add a read-only Core/Tauri query for retained artifact snapshot comparisons and retention metadata.\n- Add the Workspace > Artifact History screen with bounded scan access metrics, failure samples, baseline/comparison states, exact byte deltas, persistence errors, and retention messaging.\n- Preserve retention boundaries: an evicted predecessor is reported as comparisonUnavailable instead of being relabeled as a baseline.\n- Distinguish missing retained Activity records from a workspace with no scan evidence.\n- Protect history loading from stale workspace responses and keep filtered/Core comparison semantics intact.\n- Add frontend, Core, and Tauri contract regression tests plus documentation.\n\n## Validation\n- cargo fmt --all -- --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test -p dustfril-core artifact_snapshot (19 passed)\n- cargo test -p dustfril-tauri (20 passed)\n- npm test (58 passed)\n- npm run build\n- cargo test --workspace (303 passed; one pre-existing macOS codesign fixture mismatch: expected Software Signing, observed macOS Software Signing)\n- cargo llvm-cov --workspace --all-features --summary-only (303 passed; same pre-existing macOS codesign fixture mismatch)\n